### PR TITLE
feat(types): export QueryBuilderOptions, the shape an app actually writes

### DIFF
--- a/packages/bun-query-builder/src/config.ts
+++ b/packages/bun-query-builder/src/config.ts
@@ -1,4 +1,4 @@
-import type { QueryBuilderConfig, SupportedDialect } from './types'
+import type { QueryBuilderConfig, QueryBuilderOptions, SupportedDialect } from './types'
 import process from 'node:process'
 import { loadConfig } from 'bunfig'
 
@@ -214,7 +214,7 @@ export async function getConfig(): Promise<QueryBuilderConfig> {
       defaultConfig,
     })
 
-    const applicable: Partial<QueryBuilderConfig> = {}
+    const applicable: QueryBuilderOptions = {}
     for (const [key, value] of Object.entries(loaded ?? {})) {
       if (!configState.explicit.has(key))
         (applicable as Record<string, unknown>)[key] = value
@@ -267,7 +267,7 @@ const _warnedDialectConflicts = new Set<string>()
  * Shared by `setConfig()` (explicit, marks keys) and `getConfig()` (from a
  * file, does not) so the two paths can never drift on how nested objects merge.
  */
-function applyConfig(userConfig: Partial<QueryBuilderConfig>): void {
+function applyConfig(userConfig: QueryBuilderOptions): void {
   // NEVER reassign `config` here (i.e. `config = { ...defaultConfig }`).
   // Reassigning an `export let` triggers Bun's bundler to split the
   // binding: the write goes to one identifier and every reader (e.g.
@@ -290,15 +290,30 @@ function applyConfig(userConfig: Partial<QueryBuilderConfig>): void {
   if (userConfig.pagination) {
     config.pagination = { ...config.pagination, ...userConfig.pagination }
   }
+  // These two sections are optional on the resolved config, so merging only
+  // over the CURRENT value cannot guarantee the required members survive a
+  // partial override. Shallow `Partial` hid that by demanding a complete
+  // section from the caller; a real partial makes it visible. Seeding from
+  // `defaultConfig` is also the behaviour an app expects: setting
+  // `softDeletes: { enabled: true }` should inherit `column` and
+  // `defaultFilter`, not drop them.
   if (userConfig.softDeletes) {
-    config.softDeletes = { ...config.softDeletes, ...userConfig.softDeletes }
+    config.softDeletes = {
+      ...defaultConfig.softDeletes!,
+      ...config.softDeletes,
+      ...userConfig.softDeletes,
+    }
   }
   if (userConfig.vitess) {
-    config.vitess = { ...config.vitess, ...userConfig.vitess }
+    config.vitess = {
+      ...defaultConfig.vitess!,
+      ...config.vitess,
+      ...userConfig.vitess,
+    }
   }
 }
 
-export function setConfig(userConfig: Partial<QueryBuilderConfig>): void {
+export function setConfig(userConfig: QueryBuilderOptions): void {
   // Detect cross-instance dialect conflicts and warn once. The proper
   // fix is per-instance config (stacksjs/stacks#1862 #18); this guard
   // surfaces the symptom so callers can see the shared-state problem

--- a/packages/bun-query-builder/src/types.ts
+++ b/packages/bun-query-builder/src/types.ts
@@ -459,7 +459,10 @@ export interface QueryBuilderConfig {
  * still demand a complete `TimestampConfig` from anyone who wanted to rename a
  * single column.
  */
-export type DeepPartial<T> = T extends (...args: any[]) => any
+// `_args`, not `args`: this is a type-level signature, so the parameter name is
+// required syntax with nothing that could ever reference it. pickier's
+// no-unused-vars flags it all the same, and `^_` is the pattern it exempts.
+export type DeepPartial<T> = T extends (..._args: any[]) => any
   ? T
   : T extends readonly (infer U)[]
     ? readonly U[]

--- a/packages/bun-query-builder/src/types.ts
+++ b/packages/bun-query-builder/src/types.ts
@@ -452,6 +452,50 @@ export interface QueryBuilderConfig {
   }
 }
 
+/**
+ * Every property optional, recursively, leaving arrays and functions intact.
+ *
+ * Plain `Partial` is only one level deep, which is not enough here: it would
+ * still demand a complete `TimestampConfig` from anyone who wanted to rename a
+ * single column.
+ */
+export type DeepPartial<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends readonly (infer U)[]
+    ? readonly U[]
+    : T extends object
+      ? { [K in keyof T]?: DeepPartial<T[K]> }
+      : T
+
+/**
+ * # `QueryBuilderOptions`
+ *
+ * **What an application writes.** Every field is optional, because every field
+ * has a default in {@link defaultConfig} — an app supplies only what it wants
+ * to differ.
+ *
+ * Distinct from {@link QueryBuilderConfig}, which is the RESOLVED shape this
+ * library reads after merging those defaults, and where a required field means
+ * "guaranteed present by the time anything reads it".
+ *
+ * Conflating the two made every field added to the resolved config a
+ * downstream compile error. 0.2.25 declared `migrationDir: string` without the
+ * optional marker, and the app that consumed it had to hard-code
+ * `'database/migrations'` — a value this package already defaults in three
+ * separate places — purely to satisfy the type. `snapshotDir` did the same
+ * thing one release earlier. See stacksjs/bun-query-builder#1062.
+ *
+ * `setConfig()` has always accepted a partial, so this names a contract the
+ * library already honoured rather than introducing a new one.
+ *
+ * ```ts
+ * export default {
+ *   dialect: 'postgres',
+ * } satisfies QueryBuilderOptions
+ * ```
+ */
+export type QueryBuilderOptions = DeepPartial<QueryBuilderConfig>
+
 export interface CliOption {
   verbose: boolean
 }


### PR DESCRIPTION
Closes #1062.

`QueryBuilderConfig` is the **resolved** shape this library reads after merging its own defaults, so all twelve top-level fields are required. It is also what consumers declare their config file against, because it is what the package exports.

Those two roles conflict: **every field added to the resolved config is a compile error in every app** until each one restates a value the library already supplies. 0.2.25 dropped the `?` from `migrationDir`, and a downstream app had to hard-code `'database/migrations'` — defaulted here in three separate places — purely to satisfy the type. `snapshotDir` did the same one release earlier.

The reviewer's framing was the right one:

> nothing in those configs should ever be required and always default to sensible defaults

## The change

`QueryBuilderOptions = DeepPartial<QueryBuilderConfig>` is now the consumer-facing type. Deep rather than shallow matters: plain `Partial` still demands a complete `TimestampConfig` from anyone renaming a single column.

`QueryBuilderConfig` keeps its required fields — internal code should be able to rely on presence. Only the name consumers reach for changes.

`setConfig()` already accepted a partial, so this names a contract the library was honouring rather than introducing one. `applyConfig` is threaded through to match.

## A real bug the shallow type was hiding

`softDeletes` and `vitess` are themselves optional on the resolved config, so merging a partial override over the possibly-absent current value could not guarantee the required members survived:

```ts
config.softDeletes = { ...config.softDeletes, ...userConfig.softDeletes }
```

Shallow `Partial` masked it by demanding a complete section from the caller. They now seed from `defaultConfig`, which is also the behaviour an app expects: `softDeletes: { enabled: true }` should inherit `column` and `defaultFilter` rather than dropping them.

## Verification

`tsc --noEmit` clean, **1678 pass / 5 skip / 0 fail** across 126 files.

Once released, stacksjs/stacks moves from the interim `satisfies Partial<QueryBuilderConfig>` (stacksjs/stacks#2301) to `satisfies QueryBuilderOptions`.