### PR TITLE
fix(types): config options should not require what the library already defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ const q = db
 const rows = await q.execute()
 ```
 
+### Configuration
+
+Drop a `query-builder.config.ts` in your project root. Every field is optional at
+every depth — supply only what you want to change, and the library defaults the rest:
+
+```ts
+import { defineConfig } from 'bun-query-builder'
+
+export default defineConfig({
+  dialect: 'postgres',
+  database: { database: 'my_app' },
+})
+```
+
+```ts
+// Load it once at app boot, or configure from code with setConfig().
+import { getConfig } from 'bun-query-builder'
+
+await getConfig()
+```
+
 ### Aggregations
 
 ```ts

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -7,7 +7,7 @@ This page summarizes method signatures and brief descriptions. See feature pages
 ## Imports
 
 ```ts
-import type { CursorPaginationResult, DatabaseSchema, PaginationResult, QueryBuilderConfig, SchemaMeta, SortDirection, TransactionOptions, WhereExpression, WhereOperator } from 'bun-query-builder'
+import type { CursorPaginationResult, DatabaseSchema, PaginationResult, QueryBuilderOptions, SchemaMeta, SortDirection, TransactionOptions, WhereExpression, WhereOperator } from 'bun-query-builder'
 import {
   // Schema and Model Definition
   buildDatabaseSchema,
@@ -41,10 +41,26 @@ const db = createQueryBuilder<typeof schema>({ schema, meta })
 
 ## Configuration
 
-- config: Global runtime config (merged via bunfig). Shape: `QueryBuilderConfig`
-- defaultConfig: Library defaults
+- `defineConfig(options)`: identity helper for a typed `query-builder.config.ts`
+- `setConfig(options)`: deep-merges `QueryBuilderOptions` into the live config
+- `getConfig()`: loads `query-builder.config.ts` and `QUERY_BUILDER_*` env vars once, merges them in, returns the resolved config
+- `config`: the live process-wide config, typed `QueryBuilderConfig` — every field is present, so `config.pagination.defaultPerPage` needs no guard
+- `defaultConfig`: the library defaults, same resolved shape
 
-Key sections: `dialect`, `timestamps`, `pagination`, `aliasing`, `relations`, `transactionDefaults`, `sql`, `features`, `debug`.
+Two types, two jobs. **Write** `QueryBuilderOptions`: every field optional at every
+depth, so you supply only what you want to change. **Read** `QueryBuilderConfig`:
+your options merged over the defaults, every field present. Annotating your own
+config with the resolved type is what made every field added here a compile error
+downstream ([#1062](https://github.com/stacksjs/bun-query-builder/issues/1062)).
+
+Key sections: `dialect`, `database`, `snapshotDir`, `migrationDir`, `timestamps`, `pagination`, `aliasing`, `relations`, `transactionDefaults`, `sql`, `features`, `softDeletes`, `hooks`, `debug`.
+
+Naming one leaf keeps the rest of its section:
+
+```ts
+setConfig({ transactionDefaults: { retries: 5 } })
+// retries is 5; sqlStates and backoff keep their defaults
+```
 
 ## Schema & Models
 
@@ -276,7 +292,9 @@ await db
 
 - WhereOperator: '=', '!=', '<', '>', '<=', '>=', 'like', 'in', 'not in', 'is', 'is not'
 - WhereExpression<TColumns>: object | tuple | raw
-- QueryBuilderConfig: see Configuration section
+- QueryBuilderOptions: user-supplied configuration — every field optional, recursively. What you write in `query-builder.config.ts` or pass to `setConfig()`
+- QueryBuilderConfig: defaults merged with your configuration — every field present. What `config`, `defaultConfig` and `getConfig()` give you
+- DeepPartial&lt;T&gt;: the utility behind `QueryBuilderOptions`
 - DatabaseSchema<ModelRecord>
 
 ---

--- a/docs/advanced/dialects.md
+++ b/docs/advanced/dialects.md
@@ -472,7 +472,9 @@ function trackConfigurationChange(key: string, oldValue: any, newValue: any) {
 
 ### How do per-instance overrides work
 
-Call `db.configure(partialConfig)` to shallow-merge selected properties for that builder instance.
+Call `db.configure(options)` to deep-merge selected properties — naming one leaf of a
+section keeps that section's other defaults. Note there is no per-instance config yet:
+this writes the same process-wide config `setConfig()` does.
 
 ### Can I change config at runtime
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,92 +1,81 @@
 # Configuration
 
-The bun-query-builder configuration system allows you to customize behavior across dialects, performance settings, and development preferences. All defaults can be overridden via the global `config` object.
+The bun-query-builder configuration system allows you to customize behavior across dialects, performance settings, and development preferences.
+
+**Nothing is ever required.** Every field is optional, at every depth — whatever you
+leave out keeps the library default, so fields added in future releases never become
+your problem.
 
 ## Quick Start
+
+### A config file
+
+`query-builder.config.ts` in your project root, picked up by `getConfig()`:
+
+```ts
+import { defineConfig } from 'bun-query-builder'
+
+export default defineConfig({
+  dialect: 'postgres',
+  database: { database: 'my_app' },
+})
+```
+
+```ts
+// Then, once at app boot:
+import { getConfig } from 'bun-query-builder'
+
+await getConfig() // applies the config file + QUERY_BUILDER_* env vars
+```
+
+Loading is explicit and async on purpose: the builder otherwise runs off the
+synchronous config singleton, so an early query can never race a background load.
+
+### From application code
+
+`setConfig()` deep-merges, and outranks the config file:
+
+```ts
+import { setConfig } from 'bun-query-builder'
+
+setConfig({ dialect: 'sqlite', pagination: { defaultPerPage: 50 } })
+
+// Naming one leaf keeps the rest of its section — retries becomes 5,
+// while sqlStates and backoff keep their defaults.
+setConfig({ transactionDefaults: { retries: 5 } })
+```
+
+Precedence is `defaults < config file < setConfig()`.
+
+### Mutating the live config
 
 ```ts
 import { config } from 'bun-query-builder'
 
-// Basic PostgreSQL configuration
 config.dialect = 'postgres'
 config.sql.randomFunction = 'RANDOM()'
-config.sql.sharedLockSyntax = 'FOR SHARE'
-config.sql.jsonContainsMode = 'operator'
 config.aliasing.relationColumnAliasFormat = 'table_column'
-config.transactionDefaults.retries = 2
 ```
 
-## Configuration Interface
+Note that assigning a whole section (`config.sql = { … }`) replaces it rather than
+merging — prefer `setConfig()` unless you mean to drop the other keys.
 
-```ts
-export interface QueryBuilderConfig {
-  // General settings
-  verbose: boolean
-  dialect: 'postgres' | 'mysql' | 'sqlite'
+## The two config types
 
-  // Timestamp handling
-  timestamps: {
-    createdAt: string
-    updatedAt: string
-    defaultOrderColumn: string
-  }
+| Type | Role |
+| --- | --- |
+| `QueryBuilderOptions` | What you **write**. Every field optional, recursively. Use it for `query-builder.config.ts`, `setConfig()` and `db.configure()`. |
+| `QueryBuilderConfig` | What you **read**. Your options merged over the defaults, every field present — the type of `config`, `defaultConfig` and `getConfig()`'s result. |
 
-  // Pagination defaults
-  pagination: {
-    defaultPerPage: number
-    cursorColumn: string
-  }
+Annotate your own configuration with `QueryBuilderOptions` (or skip the decision
+entirely and use `defineConfig`). Declaring it against the resolved
+`QueryBuilderConfig` is what made every field added to this package a compile error
+in downstream apps — see
+[#1062](https://github.com/stacksjs/bun-query-builder/issues/1062).
 
-  // Column aliasing for relations
-  aliasing: {
-    relationColumnAliasFormat: 'table_column' | 'table.dot.column' | 'camelCase'
-  }
-
-  // Relationship configuration
-  relations: {
-    foreignKeyFormat: 'singularParent_id' | 'parentId'
-    singularizeStrategy?: 'stripTrailingS' | 'none'
-  }
-
-  // Transaction behavior
-  transactionDefaults: {
-    retries: number
-    isolation?: 'read committed' | 'repeatable read' | 'serializable'
-    sqlStates: string[]
-    backoff: {
-      baseMs: number
-      factor: number
-      maxMs: number
-      jitter: boolean
-    }
-  }
-
-  // SQL dialect-specific settings
-  sql: {
-    randomFunction?: 'RANDOM()' | 'RAND()'
-    sharedLockSyntax?: 'FOR SHARE' | 'LOCK IN SHARE MODE'
-    jsonContainsMode?: 'operator' | 'function'
-  }
-
-  // Feature toggles
-  features: {
-    distinctOn: boolean
-  }
-
-  // Development and debugging
-  debug?: {
-    captureText: boolean
-  }
-
-  // Query lifecycle hooks
-  hooks?: {
-    onQueryStart?: (context: QueryContext) => void
-    onQueryEnd?: (context: QueryContext & { durationMs: number, rowCount: number }) => void
-    onQueryError?: (context: QueryContext & { error: Error }) => void
-    startSpan?: (name: string) => { end: () => void }
-  }
-}
-```
+The authoritative field list ships in the package's type declarations, so your editor
+completes it inline; this page deliberately no longer duplicates the interface, since
+a second hand-maintained copy of the config shape drifts exactly the way the types did.
 
 ## Environment-Specific Configurations
 

--- a/packages/bun-query-builder/README.md
+++ b/packages/bun-query-builder/README.md
@@ -45,6 +45,30 @@ await QueryBuilder
   .execute()
 ```
 
+## Configuration
+
+Drop a `query-builder.config.ts` in your project root. Every field is optional at
+every depth — supply only what you want to change, and the library defaults the rest:
+
+```typescript
+import { defineConfig } from 'bun-query-builder'
+
+export default defineConfig({
+  dialect: 'postgres',
+  database: { database: 'my_app' },
+})
+```
+
+```typescript
+// Load it once at app boot, or configure from code with setConfig().
+import { getConfig } from 'bun-query-builder'
+
+await getConfig()
+```
+
+Type your own configuration against `QueryBuilderOptions` (what you write, everything
+optional), not `QueryBuilderConfig` (what the library reads back, everything present).
+
 ## Features
 
 - **Typed from Models** - Infer tables, columns, and primary keys from your model files

--- a/packages/bun-query-builder/build.ts
+++ b/packages/bun-query-builder/build.ts
@@ -4,6 +4,12 @@ import { join, resolve } from 'node:path'
 import process from 'node:process'
 import { dts } from 'bun-plugin-dtsx'
 
+// `ts/no-top-level-await` guards the SHIPPED entry, because a top-level await
+// anywhere in the bundle makes `bun build --compile` refuse every consumer that
+// requires it — which is the exact failure `assertCompilable()` below exists to
+// catch. This file is not shipped: it is a script Bun runs directly, where a
+// top-level await is the only way to await at all.
+// eslint-disable-next-line ts/no-top-level-await
 const result = await Bun.build({
   entrypoints: ['src/index.ts', 'src/browser.ts', 'src/dynamodb/index.ts', 'bin/cli.ts'],
   outdir: './dist',
@@ -70,4 +76,5 @@ async function assertCompilable(entry: string): Promise<void> {
   process.exit(1)
 }
 
+// eslint-disable-next-line ts/no-top-level-await -- build script, not shipped; see the note above
 await assertCompilable('./dist/src/index.js')

--- a/packages/bun-query-builder/src/__tests__/config-options-compile.ts
+++ b/packages/bun-query-builder/src/__tests__/config-options-compile.ts
@@ -1,0 +1,153 @@
+/**
+ * Compile-time verification of `QueryBuilderOptions` — the type consumers
+ * annotate their configuration with.
+ *
+ * This file is NOT executed; it's checked by `bun --bun tsc --noEmit`. Lines
+ * marked @ts-expect-error MUST fail to compile, every other line MUST compile.
+ * (`test/` is excluded from the typecheck, so config type coverage has to live
+ * here under `src/` to be enforced at all.)
+ *
+ * The point of the file is stacksjs/bun-query-builder#1062: adding a field to
+ * the resolved `QueryBuilderConfig` was a compile error in every downstream
+ * app, because the resolved type was also the only one exported for consumers
+ * to declare against. Section 1 is the regression pin — a config naming ONE
+ * key must compile, at any depth. Sections 2-4 pin the parts a naive
+ * `DeepPartial` silently breaks; section 5 pins that being optional did not
+ * cost us any real type safety.
+ */
+
+import type { QueryBuilderConfig, QueryBuilderOptions } from '../types'
+import { defineConfig, setConfig } from '../config'
+
+// ---------------------------------------------------------------------------
+// 1. Nothing is required, at any depth
+// ---------------------------------------------------------------------------
+
+// The empty config: the library supplies everything.
+export const empty: QueryBuilderOptions = {}
+
+// One top-level key. `migrationDir` is the field whose arrival broke #1062.
+export const oneKey: QueryBuilderOptions = { dialect: 'sqlite' }
+export const migrationOnly: QueryBuilderOptions = { migrationDir: 'db/migrations' }
+
+// One leaf of a REQUIRED nested section. Plain `Partial` stops here: it would
+// demand a complete `TimestampConfig`/`TransactionDefaultsConfig`.
+export const oneLeaf: QueryBuilderOptions = { timestamps: { createdAt: 'inserted_at' } }
+export const oneRetry: QueryBuilderOptions = { transactionDefaults: { retries: 5 } }
+
+// One leaf of an OPTIONAL nested section. These four are the sharpest pin in
+// the file: a naive `{ [K in keyof T]?: T[K] extends object ? … : T[K] }`
+// leaves optional members unpartialized — `T[K]` is `X | undefined`, which is
+// not a naked type parameter and so does not distribute, fails `extends object`
+// and passes through whole — and every one of these still errors.
+export const softOnly: QueryBuilderOptions = { softDeletes: { enabled: true } }
+export const emptyVitess: QueryBuilderOptions = { vitess: {} }
+export const emptyDebug: QueryBuilderOptions = { debug: {} }
+export const browserLeaf: QueryBuilderOptions = { browser: { timeout: 1000 } }
+
+// Two levels down.
+export const deepLeaf: QueryBuilderOptions = { transactionDefaults: { backoff: { jitter: false } } }
+export const poolLeaf: QueryBuilderOptions = { database: { pool: { max: 20 } } }
+
+// The call sites take it too.
+setConfig({ pagination: { defaultPerPage: 50 } })
+export const defined = defineConfig({ dialect: 'postgres', database: { database: 'my_app' } })
+
+// ---------------------------------------------------------------------------
+// 2. Functions stay callable
+// ---------------------------------------------------------------------------
+
+// A mapped type only copies PROPERTIES, and a call signature is not one.
+// Without the function guard clause `keyof (() => void)` is `never`, these
+// hooks collapse to an empty object type, and the calls below stop compiling.
+export const hooked: QueryBuilderOptions = {
+  hooks: {
+    onQueryStart: (event) => { void event.sql },
+    onQueryEnd: (event) => { void event.durationMs },
+  },
+}
+hooked.hooks?.onQueryStart?.({ sql: 'select 1' })
+
+// Generic signatures survive too — `transformResponse` is `<T>(r: any) => T`,
+// and a mapped type would erase the type parameter along with the signature.
+type TransformResponse = NonNullable<NonNullable<QueryBuilderOptions['browser']>['transformResponse']>
+export const transform: TransformResponse = (response: any) => response
+export const transformed: number[] = transform<number[]>({})
+
+// ---------------------------------------------------------------------------
+// 3. Arrays stay arrays
+// ---------------------------------------------------------------------------
+
+// Recursing into `string[]` yields `(string | undefined)[]`, which no longer
+// assigns back out to an array of `string` — so the read-backs are the pin.
+// Arrays are replaced wholesale by the merge, so a partial array was never
+// meaningful.
+export const states: QueryBuilderOptions = { transactionDefaults: { sqlStates: ['40001'] } }
+export const statesOut: readonly string[] = states.transactionDefaults!.sqlStates!
+export const pragmas: QueryBuilderOptions = { sqlite: { pragmas: ['PRAGMA foreign_keys = ON'] } }
+export const pragmasOut: readonly string[] = pragmas.sqlite!.pragmas!
+
+// Array leaves are `readonly`, so the idiomatic `as const` config file assigns.
+// A mutable `string[]` still assigns too — `readonly E[]` is the wider type.
+export const asConst: QueryBuilderOptions = {
+  dialect: 'sqlite',
+  transactionDefaults: { sqlStates: ['40001', '40P01'] },
+} as const
+
+const sharedStates: readonly string[] = ['40001']
+export const hoisted: QueryBuilderOptions = { transactionDefaults: { sqlStates: sharedStates } }
+
+const mutableStates: string[] = ['40001']
+export const fromMutable: QueryBuilderOptions = { transactionDefaults: { sqlStates: mutableStates } }
+
+// ---------------------------------------------------------------------------
+// 4. Record bags stay intact
+// ---------------------------------------------------------------------------
+
+const headers: Record<string, string> = { authorization: 'Bearer x' }
+export const withHeaders: QueryBuilderOptions = { browser: { baseUrl: '/api', headers } }
+// The read-back is the pin, exactly as for arrays: recursing into the bag would
+// rewrite it as `{ [x: string]: string | undefined }`, which does not assign
+// back out to `Record<string, string>`. Assigning INTO the bag is safe either
+// way, so testing only that direction would leave the guard unpinned.
+export const headersOut: Record<string, string> = withHeaders.browser!.headers!
+
+// ---------------------------------------------------------------------------
+// 5. Optional is not the same as unchecked
+// ---------------------------------------------------------------------------
+
+// @ts-expect-error - 'oracle' is not a SupportedDialect
+export const badDialect: QueryBuilderOptions = { dialect: 'oracle' }
+
+// @ts-expect-error - createdAt is a column name, not a number
+export const badLeafType: QueryBuilderOptions = { timestamps: { createdAt: 42 } }
+
+// @ts-expect-error - typo in a nested key is still an excess property
+export const typo: QueryBuilderOptions = { timestamps: { craetedAt: 'created_at' } }
+
+// @ts-expect-error - defaultPerPage is a number
+export const badPagination: QueryBuilderOptions = { pagination: { defaultPerPage: 'lots' } }
+
+// @ts-expect-error - foreignKeyFormat is a closed union
+export const badRelations: QueryBuilderOptions = { relations: { foreignKeyFormat: 'nope' } }
+
+// @ts-expect-error - a hook must be callable, not a number
+export const badHook: QueryBuilderOptions = { hooks: { onQueryStart: 42 } }
+
+// @ts-expect-error - headers values are strings
+export const badHeaders: QueryBuilderOptions = { browser: { headers: { a: 1 } } }
+
+// ---------------------------------------------------------------------------
+// 6. The options type is a strict WIDENING of what setConfig used to take
+// ---------------------------------------------------------------------------
+
+// Every caller who was passing a `QueryBuilderConfig` or a
+// `Partial<QueryBuilderConfig>` keeps compiling — that is what makes widening
+// `setConfig()` a non-breaking change.
+export const fromResolved: QueryBuilderOptions = {} as QueryBuilderConfig
+export const fromPartial: QueryBuilderOptions = {} as Partial<QueryBuilderConfig>
+
+// ...and not the reverse, which is what preserves the internal guarantee that
+// every field of the resolved config is present.
+// @ts-expect-error - QueryBuilderOptions cannot stand in for the resolved config
+export const backToResolved: QueryBuilderConfig = {} as QueryBuilderOptions

--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -4,7 +4,8 @@
 import type { SchemaMeta } from './meta'
 import type { ResolvedPivot } from './pivot'
 import type { DatabaseSchema } from './schema'
-import { config, getPlaceholder, getPlaceholders, isMysqlLike } from './config'
+import type { QueryBuilderOptions } from './types'
+import { config, getPlaceholder, getPlaceholders, isMysqlLike, setConfig } from './config'
 import type { DriverConnection } from './db'
 import { bunSql, getOrCreateBunSql, resetConnection } from './db'
 import { resolvePivot } from './pivot'
@@ -5968,10 +5969,16 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
   }
 
   return {
-    // Create a builder with per-instance option overrides
-    configure(opts: Partial<typeof config>) {
-      // This keeps types simple; for now, users can set global config via import
-      Object.assign(config, opts)
+    // Create a builder with per-instance option overrides.
+    //
+    // There is no per-instance config yet: this writes the same process-wide
+    // singleton `setConfig()` does (see the warning on `setConfig`), so it goes
+    // through the same merge rather than a bare `Object.assign`. That assign
+    // was the last write path that could replace a whole nested section —
+    // `db.configure({ debug: { captureText: false } })` used to drop every
+    // other key of `debug`.
+    configure(opts: QueryBuilderOptions) {
+      setConfig(opts)
       return this as any
     },
     /** Escape/validate identifier names (best-effort) */

--- a/packages/bun-query-builder/src/config.ts
+++ b/packages/bun-query-builder/src/config.ts
@@ -1,4 +1,4 @@
-import type { QueryBuilderConfig, SupportedDialect } from './types'
+import type { QueryBuilderConfig, QueryBuilderOptions, SupportedDialect } from './types'
 import process from 'node:process'
 import { loadConfig } from 'bunfig'
 
@@ -78,6 +78,113 @@ export const defaultConfig: QueryBuilderConfig = {
   },
 }
 
+/**
+ * Keys a merge must never write.
+ *
+ * `Object.assign` and plain property assignment both go through [[Set]], so
+ * writing a key literally named `__proto__` changes the target's prototype
+ * instead of adding a property — and `config` lives on a `Symbol.for` key
+ * shared by every copy of this module AND every version of this package in the
+ * process (see the singleton comment below), so one polluted merge poisons all
+ * of them. The realistic vector is not a `.ts` config file, which already
+ * executes arbitrary code, but bunfig's `package.json` config section, where
+ * `JSON.parse` turns `"__proto__"` into an ordinary own data property that
+ * then flows through `getConfig()` into here.
+ */
+const FORBIDDEN_MERGE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * Whether a value is a plain object the merge may recurse into.
+ *
+ * Deliberately narrow. `typeof null === 'object'` is the classic deep-merge
+ * crash, and a class instance, `Date`, `Map` or `Set` would be silently
+ * dismantled into a bag of its own enumerable properties. Anything that is not
+ * `{}`-literal-shaped is a LEAF and gets assigned wholesale.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+/**
+ * Recursively merge `source` over `target`, returning a NEW object. Neither
+ * argument is mutated.
+ *
+ * The semantics below are load-bearing — each is pinned by a test or by a
+ * documented promise, so do not "simplify" them:
+ *
+ *  - ARRAYS REPLACE. They do not concatenate or union. `SqliteConfig.pragmas`
+ *    says so in its own doc comment, and `sqlite-bootstrap-pragmas.test.ts`
+ *    asserts it by checking that `foreign_keys` is still 0 after an override
+ *    that omits it — concatenation would flip that to 1.
+ *    `transactionDefaults.sqlStates` is the same shape: a user narrowing
+ *    retries to `['40002']` must stop retrying on `40001`, not keep it.
+ *
+ *  - FUNCTIONS REPLACE. `isPlainObject` rejects them, so `QueryHooks` members
+ *    and `BrowserConfig.getToken` / `transformResponse` stay opaque leaves. We
+ *    never recurse into a function's own enumerable properties.
+ *
+ *  - AN EXPLICIT `undefined` ASSIGNS; AN ABSENT KEY DOES NOT. The rule is
+ *    PRESENCE, not value — `Object.keys(source)` contains a key written as
+ *    `undefined` and does not contain one that was never written. Not a style
+ *    choice: `resolve-dialect.test.ts` calls `setConfig({ dialect: undefined })`
+ *    and expects `resolveDialect()` to fall back to `'postgres'`, and
+ *    `sqlite-bootstrap-pragmas.test.ts` uses `sqlite: undefined` as the restore
+ *    that un-does a pragma override for the rest of a shared-process run.
+ *    Skipping `undefined` breaks both, and now that `hooks` deep-merges, an
+ *    explicit `undefined` is also the only way to REMOVE a hook.
+ *
+ *  - `null` ASSIGNS and is never recursed into. No field in
+ *    `QueryBuilderConfig` is nullable, so a `null` arriving here is a caller
+ *    mistake; assigning it surfaces that at the read site instead of hiding it.
+ *
+ * Arrays are copied by REFERENCE, being leaves — `config.transactionDefaults
+ * .sqlStates` is the same array as `defaultConfig`'s until something replaces
+ * it. Nothing in `src/` mutates a config array in place (the only read is an
+ * `.includes`), and cloning on every merge is not worth paying for that.
+ *
+ * `seen` is the chain of source objects currently being merged, so a source
+ * that points back at one of its own ancestors is treated as a leaf instead of
+ * recursed into. An embedding framework's config slice — the case this type
+ * exists to serve — routinely carries a parent back-pointer, and it typechecks
+ * fine because an optional field of an interface can be that interface. Without
+ * the guard that input spins for seconds, allocates gigabytes and dies with a
+ * stack overflow. It is a DEPTH chain, pushed and popped around the recursion,
+ * not a global set: the same object legitimately appearing under two different
+ * keys must merge both times, and a global set would silently drop the second.
+ */
+function mergeObject(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  seen: Set<object> = new Set(),
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...target }
+  seen.add(source)
+
+  for (const key of Object.keys(source)) {
+    if (FORBIDDEN_MERGE_KEYS.has(key))
+      continue
+
+    const next = source[key]
+    if (isPlainObject(next) && !seen.has(next)) {
+      const prev = out[key]
+      // When `prev` is not itself a mergeable object there is nothing to merge
+      // into, but we still recurse rather than storing the caller's literal by
+      // reference — otherwise a caller who mutates their own object later would
+      // be reaching into the live config.
+      out[key] = mergeObject(isPlainObject(prev) ? prev : {}, next, seen)
+    }
+    else {
+      out[key] = next
+    }
+  }
+
+  seen.delete(source)
+  return out
+}
+
 // The single, process-wide config object — stored on a `globalThis` symbol so
 // that EVERY copy of this module shares one object, even if Bun's bundler
 // inlines `config.ts` more than once. Previously this was an `export let` that
@@ -94,9 +201,15 @@ export const defaultConfig: QueryBuilderConfig = {
 //    is also shared across package versions in one process — that's the intended
 //    hardening; pin a versioned key if you ever need per-version isolation.
 //  - Synchronous + no top-level await here, so `bun --compile` is unaffected.
+//  - Seeded through `mergeObject`, not `{ ...defaultConfig }`. A shallow spread
+//    left `config.debug === defaultConfig.debug`, so the direct writes this
+//    package makes to the live config — `config.debug.captureText = true` in
+//    `actions/sql.ts` and `computeSqlText()` — were reaching into the exported
+//    DEFAULTS and permanently changing them. `mergeObject` clones every plain
+//    object node, which closes that.
 const CONFIG_SINGLETON_KEY = Symbol.for('bun-query-builder.config')
 export const config: QueryBuilderConfig
-  = ((globalThis as any)[CONFIG_SINGLETON_KEY] ??= { ...defaultConfig })
+  = ((globalThis as any)[CONFIG_SINGLETON_KEY] ??= mergeObject({}, defaultConfig as unknown as Record<string, unknown>) as unknown as QueryBuilderConfig)
 
 /**
  * Config-precedence bookkeeping, on `globalThis` for the same reason `config`
@@ -110,6 +223,18 @@ export const config: QueryBuilderConfig
  *  - `explicit`: top-level keys passed to `setConfig()`.
  *  - `fileLoaded`: whether the config file has been read, so it is applied
  *    once per process rather than once per inlined copy.
+ *
+ * The veto is deliberately WHOLE-SECTION, not per-leaf, even though
+ * `QueryBuilderOptions` now makes `setConfig({ database: { host } })` the
+ * normal idiom. Per-leaf looks more precise and is wrong: the fields of a
+ * section are not always independent settings. `database.url` and the discrete
+ * `database.host`/`port`/`username`/`password` are two mutually exclusive
+ * SPELLINGS of one setting — `createConnectionString()` returns `url` verbatim
+ * and never reads the others — so letting a config file's `url` survive
+ * because the embedder "only named host" hands the app a connection to a
+ * different database than the one it asked for, silently. Vetoing the section
+ * an embedder has spoken for keeps the two spellings from being mixed across
+ * sources.
  */
 const CONFIG_STATE_KEY = Symbol.for('bun-query-builder.config-state')
 interface ConfigState { explicit: Set<string>, fileLoaded: boolean }
@@ -199,6 +324,8 @@ export function getPlaceholders(count: number, startIndex = 1): string {
  *
  * So the loaded object is applied with those keys filtered out — an explicit API
  * call is a stronger signal than a file that may not know the embedder exists.
+ * The filter is per top-level section; see `configState` for why per-leaf is
+ * the wrong granularity.
  *
  * Note the load MUST pass `defaultConfig`: bunfig derives the environment
  * variable names it recognises (`QUERY_BUILDER_*`) from the shape of the
@@ -214,7 +341,7 @@ export async function getConfig(): Promise<QueryBuilderConfig> {
       defaultConfig,
     })
 
-    const applicable: Partial<QueryBuilderConfig> = {}
+    const applicable: QueryBuilderOptions = {}
     for (const [key, value] of Object.entries(loaded ?? {})) {
       if (!configState.explicit.has(key))
         (applicable as Record<string, unknown>)[key] = value
@@ -264,41 +391,58 @@ const _warnedDialectConflicts = new Set<string>()
 /**
  * Merge a partial config into the process-wide singleton.
  *
- * Shared by `setConfig()` (explicit, marks keys) and `getConfig()` (from a
- * file, does not) so the two paths can never drift on how nested objects merge.
+ * Shared by `setConfig()` (explicit, records precedence) and `getConfig()`
+ * (from a file, does not) so the two paths can never drift on how nested
+ * objects merge.
+ *
+ * This used to be `Object.assign(config, userConfig)` plus five hand-written
+ * nested spreads — `database`, `timestamps`, `pagination`, `softDeletes`,
+ * `vitess`. The other nine object-valued sections (`aliasing`, `relations`,
+ * `transactionDefaults`, `sql`, `sqlite`, `features`, `debug`, `hooks`,
+ * `browser`) were REPLACED wholesale, as were `database.pool` and
+ * `transactionDefaults.backoff` one level further down. That was survivable
+ * only because the parameter was `Partial<QueryBuilderConfig>`, which forced a
+ * caller who wanted to change one nested field to hand over a complete
+ * sub-object: the accident of an over-strict type was standing in for a merge
+ * that did not exist. Now that the parameter is `QueryBuilderOptions` and
+ * `setConfig({ transactionDefaults: { retries: 5 } })` is the intended idiom,
+ * the merge has to be real — otherwise the type fix would have traded a
+ * compile error for `config.transactionDefaults.backoff` being `undefined` at
+ * runtime, which is strictly worse.
+ *
+ * Two mutation rules, both required:
+ *
+ *  1. THE TOP-LEVEL `config` OBJECT IDENTITY NEVER CHANGES. Never reassign
+ *     `config`, never rebuild it. Bun's bundler splits a reassigned binding so
+ *     that writers and readers land on different identifiers — Stacks +
+ *     bun-query-builder hit exactly that, where `setConfig({dialect:'sqlite'})`
+ *     looked like a no-op because consumers still saw the `postgres` default.
+ *     `dist.config-singleton.test.ts` asserts the identity survives bundling.
+ *     So the merged result is copied back onto `config` key by key.
+ *
+ *  2. NESTED NODES ARE REPLACED WITH FRESH OBJECTS, NOT MUTATED IN PLACE
+ *     (`mergeObject` returns new objects at every level). Seven test files
+ *     capture a nested node by reference and hand it back later to restore it
+ *     — `database-name.test.ts` holds `config.database` and passes it to a
+ *     later `setConfig` — and that idiom only works if the merge replaced the
+ *     node rather than mutating the object they are still holding. In-place
+ *     mutation would make every one of those restores a silent no-op.
  */
-function applyConfig(userConfig: Partial<QueryBuilderConfig>): void {
-  // NEVER reassign `config` here (i.e. `config = { ...defaultConfig }`).
-  // Reassigning an `export let` triggers Bun's bundler to split the
-  // binding: the write goes to one identifier and every reader (e.g.
-  // `getBunSql`, `getPlaceholder`) keeps reading the original. Stacks +
-  // bun-query-builder hit this exact bug — `setConfig({dialect:'sqlite'})`
-  // looked like a no-op because consumers still saw the `postgres`
-  // default. If `config` is somehow undefined at call time, that's a
-  // bundler-init failure we can't paper over here without recreating the
-  // split, so let it surface instead. The module-top `config` singleton
-  // is the single source of truth.
-  Object.assign(config, userConfig)
+function applyConfig(userConfig: QueryBuilderOptions): void {
+  const merged = mergeObject(
+    config as unknown as Record<string, unknown>,
+    userConfig as Record<string, unknown>,
+  )
 
-  // Handle nested objects like database, timestamps, etc.
-  if (userConfig.database) {
-    config.database = { ...config.database, ...userConfig.database }
-  }
-  if (userConfig.timestamps) {
-    config.timestamps = { ...config.timestamps, ...userConfig.timestamps }
-  }
-  if (userConfig.pagination) {
-    config.pagination = { ...config.pagination, ...userConfig.pagination }
-  }
-  if (userConfig.softDeletes) {
-    config.softDeletes = { ...config.softDeletes, ...userConfig.softDeletes }
-  }
-  if (userConfig.vitess) {
-    config.vitess = { ...config.vitess, ...userConfig.vitess }
+  const target = config as unknown as Record<string, unknown>
+  for (const key of Object.keys(merged)) {
+    if (FORBIDDEN_MERGE_KEYS.has(key))
+      continue
+    target[key] = merged[key]
   }
 }
 
-export function setConfig(userConfig: Partial<QueryBuilderConfig>): void {
+export function setConfig(userConfig: QueryBuilderOptions): void {
   // Detect cross-instance dialect conflicts and warn once. The proper
   // fix is per-instance config (stacksjs/stacks#1862 #18); this guard
   // surfaces the symptom so callers can see the shared-state problem
@@ -308,10 +452,14 @@ export function setConfig(userConfig: Partial<QueryBuilderConfig>): void {
     const key = `${_lastConfiguredDialect}->${userConfig.dialect}`
     if (!_warnedDialectConflicts.has(key)) {
       _warnedDialectConflicts.add(key)
+      // Phrased without naming the entry point: `db.configure()` routes through
+      // here too, and telling that caller to go find a `setConfig` call they
+      // never wrote sends them hunting for a site that does not exist.
       console.warn(
-        `[query-builder] setConfig({ dialect: '${userConfig.dialect}' }) overrides a previous `
-        + `setConfig({ dialect: '${_lastConfiguredDialect}' }). `
-        + `Config is process-wide; in-flight queries from the previous configuration may break. `
+        `[query-builder] Configuring dialect '${userConfig.dialect}' overrides the previously `
+        + `configured dialect '${_lastConfiguredDialect}'. `
+        + `Config is process-wide (setConfig, db.configure and query-builder.config.ts all write it); `
+        + `in-flight queries from the previous configuration may break. `
         + `Run conflicting connections in separate processes — see stacksjs/stacks#1862 #18.`,
       )
     }
@@ -324,4 +472,34 @@ export function setConfig(userConfig: Partial<QueryBuilderConfig>): void {
     configState.explicit.add(key)
 
   applyConfig(userConfig)
+}
+
+/**
+ * Identity helper for a typed `query-builder.config.ts`.
+ *
+ * It exists so that writing a config file requires no decision about which
+ * type to annotate with — which is what stacksjs/bun-query-builder#1062 was
+ * actually about. The only config type this package exported was
+ * `QueryBuilderConfig`, the RESOLVED shape with every field required, and the
+ * docs told people to import it, so downstream apps annotated their config
+ * file with a type demanding `migrationDir`, `snapshotDir`, `features`,
+ * `aliasing` and nine other sections they had no opinion about. Every field
+ * added here afterwards was a downstream build break.
+ *
+ * `defineConfig` takes `QueryBuilderOptions`, so nothing is ever required, and
+ * returns its argument unchanged — there is no runtime behavior here, only the
+ * type and the editor completion that comes with it.
+ *
+ * ```ts
+ * // query-builder.config.ts
+ * import { defineConfig } from 'bun-query-builder'
+ *
+ * export default defineConfig({
+ *   dialect: 'postgres',
+ *   database: { database: 'my_app' },
+ * })
+ * ```
+ */
+export function defineConfig(userConfig: QueryBuilderOptions): QueryBuilderOptions {
+  return userConfig
 }

--- a/packages/bun-query-builder/src/types.ts
+++ b/packages/bun-query-builder/src/types.ts
@@ -452,6 +452,95 @@ export interface QueryBuilderConfig {
   }
 }
 
+/**
+ * # `DeepPartial`
+ *
+ * Every property of `T`, recursively optional — the shape of configuration
+ * INPUT, as opposed to the resolved shape the library reads back out.
+ *
+ * `QueryBuilderConfig` describes the config AFTER `defaultConfig` has been
+ * merged in, so its fields are non-optional on purpose: `getPlaceholder()`,
+ * the dialect dispatch, `resolveDialect()` and the model layer all read
+ * `config.x.y` without guarding, and that is only sound because every key is
+ * guaranteed present. That guarantee is worth keeping.
+ *
+ * The problem was that consumers were handed the same interface to annotate
+ * their own `query-builder.config.ts` with, because it was the only one this
+ * package exported. In that role every non-optional field is a bug: adding
+ * `migrationDir: string` to the resolved config — and `snapshotDir` before it —
+ * broke `tsc --noEmit` in every downstream app until each of them restated
+ * `'database/migrations'`, a value this package already defaults in three
+ * places (`config.ts`, `workspace.ts:38`, `workspace.ts:39`). Nothing in a
+ * config file should ever be required. So consumers get `QueryBuilderOptions`
+ * and internal code keeps `QueryBuilderConfig`.
+ *
+ * The guard clauses are not decoration. A plain
+ * `{ [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }` gets
+ * each of these wrong, and the order matters:
+ *
+ *  1. FUNCTIONS FIRST. A function type extends `object`, so a naive recursion
+ *     descends into it — but a mapped type copies properties, and a call
+ *     signature is not a property. `keyof (() => void)` is `never`, so the
+ *     hook collapses to an empty object type: no longer callable, and loose
+ *     enough to accept `42`. It also erases type parameters, which would turn
+ *     `BrowserConfig.transformResponse` (`<T>(response: any) => T`) into a
+ *     shape with no signature at all. A hook or a token getter is a leaf.
+ *
+ *  2. ARRAYS SECOND, because the merge replaces them rather than merging them.
+ *     A homomorphic map over `string[]` rewrites `TransactionDefaultsConfig`'s
+ *     `sqlStates` as `(string | undefined)[]`, which no longer assigns back to
+ *     `string[]`. Same for `SqliteConfig.pragmas`, whose own doc comment
+ *     already promises that setting it REPLACES the default list. A
+ *     half-supplied array is not a thing, so arrays are leaves — and they come
+ *     back out `readonly`, so that a config file written the idiomatic
+ *     `export default { … } as const` way still assigns. Nothing in `src/`
+ *     mutates a config array, so asking callers for a mutable one bought
+ *     nothing and rejected `as const`.
+ *
+ *  3. INDEX SIGNATURES THIRD, because there is nothing to make optional.
+ *     `BrowserConfig.headers` is a `Record<string, string>` bag whose keys are
+ *     all optional already, so recursing buys nothing and costs something: it
+ *     rewrites the bag as `{ [x: string]: string | undefined }`, which then no
+ *     longer assigns back OUT to a `Record<string, string>`, and which reads
+ *     worse on hover. (At runtime a bag is indistinguishable from a config
+ *     section, so `setConfig` does merge bags key by key — two calls each
+ *     naming one header leave you with both.)
+ *
+ * String-literal unions (`SupportedDialect`, `relationColumnAliasFormat`, …)
+ * and primitives need no clause — they are not objects, so the final check
+ * passes them through and a typo in `dialect` is still an error.
+ *
+ * There is no `Date`, `RegExp`, `Map` or `Set` anywhere in
+ * `QueryBuilderConfig`. If one is ever added, give it a clause here too: a
+ * mapped type shreds its methods exactly like a function's.
+ */
+export type DeepPartial<T> = T extends (...args: any[]) => any // eslint-disable-line pickier/no-unused-vars -- `args` names a parameter in a function TYPE, not a binding
+  ? T
+  : T extends readonly (infer E)[]
+    ? readonly E[]
+    : string extends keyof T
+      ? T
+      : number extends keyof T
+        ? T
+        : T extends object
+          ? { [K in keyof T]?: DeepPartial<T[K]> }
+          : T
+
+/**
+ * # `QueryBuilderOptions`
+ *
+ * The shape a consumer writes: a `query-builder.config.ts`, an argument to
+ * `setConfig()` or `db.configure()`, an embedding framework's own config
+ * slice. Everything is optional at every depth — `defaultConfig` supplies the
+ * rest, and `setConfig()` deep-merges what you do supply, so naming one leaf
+ * of a section keeps the section's other defaults.
+ *
+ * Type your configuration against THIS, not `QueryBuilderConfig`. That one is
+ * the resolved result the library reads; every field added to it would
+ * otherwise become a compile error in your app.
+ */
+export type QueryBuilderOptions = DeepPartial<QueryBuilderConfig>
+
 export interface CliOption {
   verbose: boolean
 }

--- a/packages/bun-query-builder/test/config-merge.test.ts
+++ b/packages/bun-query-builder/test/config-merge.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, config, createQueryBuilder, defaultConfig, setConfig } from '../src'
+
+/**
+ * `setConfig()` deep-merges.
+ *
+ * Regression cover for stacksjs/bun-query-builder#1062. That issue was about
+ * types — `QueryBuilderConfig` forced apps to restate defaults the library
+ * already supplies — but the fix could not be type-only. `applyConfig()` did
+ * `Object.assign` plus five hand-written nested spreads, so only `database`,
+ * `timestamps`, `pagination`, `softDeletes` and `vitess` merged, and only one
+ * level deep. Everything else was replaced wholesale. That was survivable
+ * exactly because the over-strict type forced callers to hand over complete
+ * sub-objects: the bad type was standing in for the missing merge.
+ *
+ * Widening the parameter to `QueryBuilderOptions` without fixing the merge
+ * would have turned a compile error into a silent `undefined` at runtime —
+ * `setConfig({ transactionDefaults: { retries: 5 } })` typechecking and then
+ * dropping `sqlStates` and `backoff`. These tests are what stops that
+ * regression from shipping.
+ *
+ * `config` is a process-wide singleton shared with ~27 other test files, so
+ * every case snapshots and restores it.
+ */
+
+/** Deep-copy plain objects, leave every other value (arrays, functions) alone. */
+function clone<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    return value
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(value as Record<string, unknown>))
+    out[key] = clone((value as Record<string, unknown>)[key])
+  return out as T
+}
+
+let saved: Record<string, unknown>
+
+beforeEach(() => {
+  saved = clone(config as unknown as Record<string, unknown>)
+})
+
+afterEach(() => {
+  for (const key of Object.keys(config))
+    delete (config as Record<string, unknown>)[key]
+  Object.assign(config, saved)
+})
+
+describe('setConfig deep merge', () => {
+  it('merges a nested section instead of replacing it', () => {
+    setConfig({ transactionDefaults: { retries: 5 } })
+
+    expect(config.transactionDefaults.retries).toBe(5)
+    // The two that used to vanish. `sqlStates` undefined means every retry
+    // decision throws; `backoff` undefined means the retry delay math does.
+    expect(config.transactionDefaults.sqlStates).toEqual(['40001', '40P01'])
+    expect(config.transactionDefaults.backoff.baseMs).toBe(50)
+  })
+
+  it('merges two levels deep', () => {
+    setConfig({ transactionDefaults: { backoff: { jitter: false } } })
+
+    expect(config.transactionDefaults.backoff.jitter).toBe(false)
+    expect(config.transactionDefaults.backoff.baseMs).toBe(50)
+    expect(config.transactionDefaults.backoff.factor).toBe(2)
+    expect(config.transactionDefaults.retries).toBe(2)
+  })
+
+  it('merges database.pool across successive calls', () => {
+    const database = config.database.database
+
+    setConfig({ database: { pool: { max: 20 } } })
+    setConfig({ database: { pool: { idleTimeoutMs: 1000 } } })
+
+    // Broken even before the type change: `database` merged, but `database.pool`
+    // one level further down did not, so each call dropped the other's field.
+    expect(config.database.pool?.max).toBe(20)
+    expect(config.database.pool?.idleTimeoutMs).toBe(1000)
+    expect(config.database.database).toBe(database)
+  })
+
+  it('merges sibling sections independently', () => {
+    setConfig({ sql: { randomFunction: 'RAND()' } })
+
+    expect(config.sql.randomFunction).toBe('RAND()')
+    expect(config.sql.sharedLockSyntax).toBe('FOR SHARE')
+    expect(config.sql.jsonContainsMode).toBe('operator')
+  })
+
+  it('replaces arrays wholesale rather than concatenating them', () => {
+    setConfig({ transactionDefaults: { sqlStates: ['40002'] } })
+
+    // A user narrowing the retriable set must stop retrying on 40001.
+    expect(config.transactionDefaults.sqlStates).toEqual(['40002'])
+  })
+
+  it('replaces functions wholesale and never recurses into them', () => {
+    const first = (): void => {}
+    const second = (): void => {}
+
+    setConfig({ hooks: { onQueryStart: first } })
+    setConfig({ hooks: { onQueryStart: second } })
+
+    expect(config.hooks?.onQueryStart).toBe(second)
+    expect(typeof config.hooks?.onQueryStart).toBe('function')
+  })
+
+  it('accumulates sibling hooks instead of wiping them', () => {
+    const start = (): void => {}
+    const end = (): void => {}
+
+    setConfig({ hooks: { onQueryStart: start } })
+    setConfig({ hooks: { onQueryEnd: end } })
+
+    expect(config.hooks?.onQueryStart).toBe(start)
+    expect(config.hooks?.onQueryEnd).toBe(end)
+  })
+
+  it('assigns an explicit undefined but leaves absent keys alone', () => {
+    // Presence, not value: this is how `resolve-dialect.test.ts` clears the
+    // dialect and how `sqlite-bootstrap-pragmas.test.ts` un-does an override.
+    setConfig({ dialect: undefined })
+    expect(config.dialect).toBeUndefined()
+
+    setConfig({ dialect: 'sqlite' })
+    setConfig({ verbose: false })
+    expect(config.dialect).toBe('sqlite')
+    expect(config.snapshotDir).toBe('.qb')
+  })
+
+  it('assigns null without recursing into it', () => {
+    expect(() => setConfig({ sqlite: null as any })).not.toThrow()
+    expect(config.sqlite).toBeNull()
+  })
+
+  it('treats a self-referential config as a leaf instead of recursing forever', () => {
+    // An embedding framework's config slice routinely carries a parent
+    // back-pointer, and it typechecks — an optional field of an interface can
+    // be that interface. Without a cycle guard this spins for seconds,
+    // allocates gigabytes and dies with a stack overflow.
+    const cyclic: any = { database: { host: 'cyclic-host' } }
+    cyclic.database.root = cyclic
+
+    const started = Bun.nanoseconds()
+    expect(() => setConfig(cyclic)).not.toThrow()
+    const elapsedMs = (Bun.nanoseconds() - started) / 1e6
+
+    expect(elapsedMs).toBeLessThan(500)
+    expect(config.database.host).toBe('cyclic-host')
+  })
+
+  it('merges the same object appearing under two keys, both times', () => {
+    // The cycle guard is a DEPTH chain, popped on the way out — a global seen-set
+    // would treat the second occurrence as already-visited and silently drop it.
+    const shared = { captureText: false }
+    setConfig({ debug: shared, hooks: shared as any })
+
+    expect(config.debug?.captureText).toBe(false)
+    expect((config.hooks as any).captureText).toBe(false)
+  })
+})
+
+describe('setConfig mutation discipline', () => {
+  it('preserves the top-level config object identity', () => {
+    // Reassigning `config` splits the binding under Bun's bundler and every
+    // reader keeps seeing the old object — see the comment on `applyConfig`.
+    const ref = config
+
+    setConfig({ verbose: false })
+    setConfig({ transactionDefaults: { retries: 4 } })
+    setConfig({ database: { host: 'elsewhere' } })
+
+    expect(config).toBe(ref)
+  })
+
+  it('replaces nested nodes rather than mutating them in place', () => {
+    // Seven test files capture a nested node and hand it back later to restore
+    // it. That only works if the merge left the object they are holding alone.
+    const previous = config.database
+    const host = previous.host
+
+    setConfig({ database: { host: 'other' } })
+
+    expect(config.database).not.toBe(previous)
+    expect(previous.host).toBe(host)
+    expect(config.database.host).toBe('other')
+  })
+
+  it('does not mutate defaultConfig', () => {
+    // `config` used to be a SHALLOW spread of `defaultConfig`, so the two
+    // shared every nested node and a write to one changed the other.
+    expect(config.sql).not.toBe(defaultConfig.sql)
+
+    setConfig({ sql: { randomFunction: 'RAND()' } })
+
+    expect(defaultConfig.sql.randomFunction).toBe('RANDOM()')
+  })
+
+  it('ignores __proto__ arriving through a merge', () => {
+    // The vector is bunfig's package.json config section, where JSON.parse
+    // turns "__proto__" into an ordinary own property.
+    setConfig(JSON.parse('{"__proto__":{"polluted":true}}'))
+    expect(({} as any).polluted).toBeUndefined()
+    expect((config as any).polluted).toBeUndefined()
+
+    setConfig(JSON.parse('{"database":{"__proto__":{"alsoPolluted":true}}}'))
+    expect(({} as any).alsoPolluted).toBeUndefined()
+    expect((config.database as any).alsoPolluted).toBeUndefined()
+  })
+})
+
+describe('db.configure', () => {
+  it('deep-merges like setConfig instead of replacing a section', () => {
+    const schema = buildDatabaseSchema({
+      User: { name: 'User', table: 'users', primaryKey: 'id', attributes: { id: { validation: { rule: {} } } } },
+    } as any)
+    const db = createQueryBuilder<typeof schema>({ schema })
+
+    setConfig({ debug: { captureText: true } })
+    db.configure({ debug: { captureText: false } })
+
+    expect(config.debug?.captureText).toBe(false)
+  })
+})

--- a/packages/bun-query-builder/test/config-precedence.test.ts
+++ b/packages/bun-query-builder/test/config-precedence.test.ts
@@ -25,6 +25,9 @@ interface ProbeResult {
   snapshotDir?: string
   dialect?: string
   verbose?: boolean
+  dbHost?: string
+  dbPort?: number
+  dbUrl?: string
 }
 
 /**
@@ -46,6 +49,9 @@ function probe(configFile: string, setup: string): ProbeResult {
         snapshotDir: config.snapshotDir,
         dialect: config.dialect,
         verbose: config.verbose,
+        dbHost: config.database?.host,
+        dbPort: config.database?.port,
+        dbUrl: config.database?.url,
       }))
     `
 
@@ -115,5 +121,56 @@ describe('config precedence', () => {
     )
 
     expect(result.snapshotDir).toBe('.qb')
+  })
+
+  /**
+   * The veto is per SECTION, not per leaf — naming one field of `database`
+   * discards the file's whole `database` section.
+   *
+   * That looks coarse, and a per-leaf veto was tried. It is wrong, because the
+   * fields of a section are not always independent settings: `database.url` and
+   * the discrete `host`/`port`/`username`/`password` are two mutually exclusive
+   * SPELLINGS of one setting, and `createConnectionString()` returns `url`
+   * verbatim without reading any of the others. Under a per-leaf veto, an
+   * embedder passing discrete credentials never names `url`, so a stale `url`
+   * in the config file survives the merge and silently wins — the app connects
+   * to a different database than the one its own code asked for.
+   *
+   * So an embedder who speaks for a section owns that whole section.
+   */
+  it('discards the whole section from the file when setConfig named any of it', () => {
+    const result = probe(
+      `export default { database: { port: 6543 } }`,
+      `setConfig({ database: { host: 'from-embedder' } })`,
+    )
+
+    expect(result.dbHost).toBe('from-embedder')
+    expect(result.dbPort).toBe(5432)
+  })
+
+  it('keeps a config-file section that setConfig never mentioned', () => {
+    const result = probe(
+      `export default { database: { host: 'from-file', port: 6543 } }`,
+      `setConfig({ snapshotDir: 'from-embedder' })`,
+    )
+
+    expect(result.dbHost).toBe('from-file')
+    expect(result.dbPort).toBe(6543)
+    expect(result.snapshotDir).toBe('from-embedder')
+  })
+
+  /**
+   * The wrong-database scenario itself, pinned directly: a config file left
+   * over with a `url`, and application code configuring discrete credentials.
+   */
+  it('does not let a stale url in the config file override configured credentials', () => {
+    const result = probe(
+      `export default { database: { url: 'postgres://user:pw@stale-host:5432/stale_db' } }`,
+      `setConfig({ database: { host: 'real-host', port: 6543, database: 'real_db' } })`,
+    )
+
+    expect(result.dbUrl).toBeUndefined()
+    expect(result.dbHost).toBe('real-host')
+    expect(result.dbPort).toBe(6543)
   })
 })


### PR DESCRIPTION
Closes #1062.

## The problem

`QueryBuilderConfig` describes the config **after** defaults are merged in, so all twelve top-level fields are required. It was also the only config type this package exported, so it doubled as the type apps annotate their own `query-builder.config.ts` with — and in that role every required field is a bug. Adding `migrationDir: string` turned `tsc --noEmit` red in stacksjs/stacks, and the downstream fix was hard-coding `'database/migrations'`, a value this package already defaults in three places. `snapshotDir` did the same a release earlier.

## The fix

Export the input shape separately:

```ts
export type QueryBuilderOptions = DeepPartial<QueryBuilderConfig>
export function defineConfig(userConfig: QueryBuilderOptions): QueryBuilderOptions
```

`QueryBuilderConfig` stays the resolved type internal code relies on, so `config.pagination.defaultPerPage` still needs no guard. `defineConfig()` means a config file needs no annotation decision at all.

```ts
// query-builder.config.ts — nothing restated
import { defineConfig } from 'bun-query-builder'

export default defineConfig({
  dialect: 'postgres',
  database: { database: 'my_app' },
})
```

### `DeepPartial` is not the one-liner in the issue

The issue proposes `{ [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] }`. I verified that version **does not fix the reported bug**:

- For an **optional** member, `T[K]` is `X | undefined`. That is not a naked type parameter, so it does not distribute, fails `extends object`, and passes through still-required — `{ softDeletes: { enabled: true } }` keeps demanding `column`.
- A homomorphic map rewrites `sqlStates: string[]` as `(string | undefined)[]`, which no longer assigns back to `string[]`.
- `keyof (() => void)` is `never`, so hooks collapse to a non-callable empty object loose enough to accept `42` — a call signature is not a property.

Hence the ordered guards: functions → arrays → index signatures. Array leaves come back `readonly` so the idiomatic `export default { … } as const` config file assigns.

## The type change could not ship alone

`applyConfig` was `Object.assign` plus five hand-written nested spreads, so nine sections — plus `database.pool` and `transactionDefaults.backoff` one level down — were replaced wholesale. The over-strict type had been standing in for a merge that did not exist: it forced callers to hand over complete sub-objects. Widening it without a real merge would have traded a compile error for `transactionDefaults.backoff` being `undefined` at runtime, which is strictly worse.

The merge is now recursive, with semantics pinned by tests: arrays and functions replace, an explicit `undefined` assigns while an absent key does not, the top-level `config` identity is preserved (Bun's bundler splits reassigned bindings), and nested nodes are replaced rather than mutated (seven test files capture a nested node and hand it back to restore it). `db.configure()` routes through it instead of bypassing it.

## Two regressions caught in review and removed

An adversarial review raised 19 findings; 13 were refuted, 6 confirmed. Two were serious:

- **The config-file veto stays per SECTION.** I had made it per-leaf, which reads as more precise and is wrong: `database.url` and the discrete host/port/username/password are mutually exclusive spellings of one setting, and `createConnectionString()` returns `url` verbatim without reading the others. An app setting discrete credentials never names `url`, so a stale `url` in a config file would survive and silently win — **connecting to a different database than the code asked for.** Reverted, and pinned with a test.
- **The merge now carries a cycle guard.** A framework config slice with a parent back-pointer typechecks fine and used to spin ~5.5s, allocate ~2GB and die with a stack overflow. It is a depth chain popped on exit, not a global seen-set, so the same object legitimately appearing under two keys still merges both times.

Also fixed from review: `as const` configs assign, the header-bag guard is pinned in the read-back direction that actually breaks, and the dialect-conflict warning no longer names a `setConfig` call a `db.configure` caller never made.

## Tests

- `src/__tests__/config-options-compile.ts` — compile-time, under `src/` because `test/` is excluded from tsc, so type assertions there would be dead weight.
- `test/config-merge.test.ts` + `test/config-precedence.test.ts` — runtime.

Checked these are real regression cover by running them against the old implementation: **6 of 14 merge tests and both original precedence tests fail there.**

## Verification

- `bun --bun tsc --noEmit` → 0
- `bun test` → **1698 pass, 4 skip, 0 fail** (baseline 1679, +19 new)
- `bunx --bun pickier .` → 0 errors, both at the repo root and inside the package
- `dist` builds, loads, and re-exports the new names

A simulated downstream app compiles `QueryBuilderOptions` with zero restated defaults, while `QueryBuilderConfig` still correctly reports *"missing verbose, snapshotDir, migrationDir, timestamps, and 6 more"*.

## Notes for review

- The second commit (`chore(build)`) is unrelated: two pre-existing `ts/no-top-level-await` errors in `build.ts` that only surface when pickier runs from inside the package. Suppressed with an explanation rather than restructuring the build, since Bun runs that script directly.
- Left alone deliberately: the ~22 `config.x = { … }` doc examples (they still work), and ~179 pre-existing markdown lint **warnings** in files this PR does not touch.
- Suggested release: patch, per the `9e99f6a fix(types): allow SQLite-only database config` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
