### PR TITLE
fix(client): a builder's writes belong to the builder's own connection

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -2740,6 +2740,28 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
   // Single boundary cast: `state.sql` is `any` (allows mock/tx injection) and
   // getOrCreateBunSql() returns Bun's `SQL`; both satisfy DriverConnection. With
   // `_sql` typed, the downstream `.unsafe(...)` calls no longer need casts (#1044).
+  //
+  // EVERY statement this builder executes must go through `_sql`, never the
+  // module-global `bunSql`. They are the same object only for a plain builder;
+  // the moment one is created with its own connection — `db.transaction()`,
+  // `savepoint()`, `beginDistributed()`, `reserve()`, or an explicit
+  // `createQueryBuilder({ sql })` — they are two different connections, and the
+  // global is a DIFFERENT pooled session from the one the builder's own reads
+  // and writes use.
+  //
+  // That is not a cosmetic distinction. A write issued on the global while the
+  // caller is inside `db.transaction()` autocommits on its own session, so it
+  // outlives a ROLLBACK: the transaction fails, the caller sees the error, and
+  // the row is still there. A read issued on the global cannot see the
+  // transaction's uncommitted rows, so read-then-decide logic acts on stale
+  // data. With `pool: { max: 1 }` it does not even get that far — the call
+  // blocks forever waiting for the single connection its own transaction is
+  // holding. All three are silent; none produces a driver error.
+  //
+  // The exceptions are the pool-lifecycle methods (`reserve`, `close`), which
+  // act on the pool itself rather than on a session, and the two-phase
+  // `commitDistributed`/`rollbackDistributed`, which by design run outside the
+  // transaction that prepared them.
   const _sql: DriverConnection = (state?.sql ?? getOrCreateBunSql()) as unknown as DriverConnection
   const meta = state?.meta
   const schema = state?.schema
@@ -6973,7 +6995,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         let hash = 7
         for (let i = 0; i < s.length; i++) hash = (hash * 31 + s.charCodeAt(i)) | 0
         const k = typeof key === 'number' ? key : Math.abs(hash)
-        const q = bunSql`SELECT pg_advisory_lock(${k})`
+        const q = _sql`SELECT pg_advisory_lock(${k})`
         await runWithHooks<any[]>(q, 'raw')
         return
       }
@@ -6981,7 +7003,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // MySQL has `GET_LOCK(name, timeout)`. Wait indefinitely
         // (timeout=-1) to match Postgres `pg_advisory_lock` semantics.
         const lockName = `bqb:${String(key)}`
-        const q = bunSql`SELECT GET_LOCK(${lockName}, -1) AS ok`
+        const q = _sql`SELECT GET_LOCK(${lockName}, -1) AS ok`
         await runWithHooks<any[]>(q, 'raw')
         return
       }
@@ -6997,7 +7019,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         let hash = 7
         for (let i = 0; i < s.length; i++) hash = (hash * 31 + s.charCodeAt(i)) | 0
         const k = typeof key === 'number' ? key : Math.abs(hash)
-        const q = bunSql`SELECT pg_try_advisory_lock(${k}) as ok`
+        const q = _sql`SELECT pg_try_advisory_lock(${k}) as ok`
         const rows = await runWithHooks<any[]>(q, 'raw')
         return Boolean(rows?.[0]?.ok)
       }
@@ -7005,7 +7027,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // MySQL `GET_LOCK(name, 0)` returns 1 immediately if free, 0
         // if held by another connection.
         const lockName = `bqb:${String(key)}`
-        const q = bunSql`SELECT GET_LOCK(${lockName}, 0) AS ok`
+        const q = _sql`SELECT GET_LOCK(${lockName}, 0) AS ok`
         const rows = await runWithHooks<any[]>(q, 'raw')
         return Number(rows?.[0]?.ok) === 1
       }
@@ -7023,7 +7045,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       return (_sql as any).unsafe(query, params)
     },
     file(path: string, params?: any[]) {
-      return (bunSql as any).file(path, params)
+      return (_sql as any).file(path, params)
     },
     async reserve() {
       const reserved = await (bunSql as any).reserve()
@@ -7058,7 +7080,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
     },
     async ping() {
       try {
-        const q = bunSql`SELECT 1`
+        const q = _sql`SELECT 1`
         await runWithHooks<any[]>(q, 'select')
         return true
       }
@@ -7242,28 +7264,28 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       const sqlText = isMysqlLike(config.dialect)
         ? `INSERT IGNORE INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`
         : `INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql} ON CONFLICT DO NOTHING`
-      return (bunSql.unsafe(sqlText, params) as any).execute()
+      return (_sql.unsafe(sqlText, params) as any).execute()
     },
     async insertGetId(table, values, idColumn = 'id' as any) {
       const { colsSql, valuesSql, params } = buildInsertClause([values as Record<string, any>])
       const tbl = quoteInsertIdent(String(table))
       if (isMysqlLike(config.dialect)) {
         // MySQL has no RETURNING — insert then read LAST_INSERT_ID().
-        await (bunSql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
-        const [row] = await (bunSql.unsafe(`SELECT LAST_INSERT_ID() as id`) as any).execute()
+        await (_sql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
+        const [row] = await (_sql.unsafe(`SELECT LAST_INSERT_ID() as id`) as any).execute()
         return row?.id
       }
       if (config.dialect === 'sqlite') {
         // The bun:sqlite wrapper returns { changes, lastInsertRowid } rather
         // than RETURNING rows, so read the rowid directly.
-        const res = await (bunSql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
+        const res = await (_sql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
         if (res?.lastInsertRowid != null)
           return res.lastInsertRowid
-        const [row] = await (bunSql.unsafe(`SELECT last_insert_rowid() as id`) as any).execute()
+        const [row] = await (_sql.unsafe(`SELECT last_insert_rowid() as id`) as any).execute()
         return row?.id
       }
       // Postgres supports RETURNING.
-      const [row] = await (bunSql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql} RETURNING ${quoteInsertIdent(String(idColumn))} as id`, params) as any).execute()
+      const [row] = await (_sql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql} RETURNING ${quoteInsertIdent(String(idColumn))} as id`, params) as any).execute()
       return row?.id
     },
     async updateOrInsert(table, match, values) {
@@ -7272,18 +7294,18 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       let idx = 1
       const whereSql = matchKeys.map(k => `${quoteInsertIdent(k)} = ${getPlaceholder(idx++)}`).join(' AND ')
       const whereParams = matchKeys.map(k => (match as any)[k])
-      const existsRows = await (bunSql.unsafe(`SELECT 1 FROM ${tbl} WHERE ${whereSql} LIMIT 1`, whereParams) as any).execute()
+      const existsRows = await (_sql.unsafe(`SELECT 1 FROM ${tbl} WHERE ${whereSql} LIMIT 1`, whereParams) as any).execute()
       if ((existsRows as any[]).length) {
         const setKeys = Object.keys(values)
         let i = 1
         const setSql = setKeys.map(k => `${quoteInsertIdent(k)} = ${getPlaceholder(i++)}`).join(', ')
         const whereSql2 = matchKeys.map(k => `${quoteInsertIdent(k)} = ${getPlaceholder(i++)}`).join(' AND ')
         const params = [...setKeys.map(k => (values as any)[k]), ...matchKeys.map(k => (match as any)[k])]
-        await (bunSql.unsafe(`UPDATE ${tbl} SET ${setSql} WHERE ${whereSql2}`, params) as any).execute()
+        await (_sql.unsafe(`UPDATE ${tbl} SET ${setSql} WHERE ${whereSql2}`, params) as any).execute()
         return true
       }
       const { colsSql, valuesSql, params } = buildInsertClause([{ ...match, ...values } as Record<string, any>])
-      await (bunSql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
+      await (_sql.unsafe(`INSERT INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
       return true
     },
     async upsert(table, rows, conflictColumns, mergeColumns) {
@@ -7301,16 +7323,16 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       // "do nothing" form (an empty SET is a syntax error). See #1035, #1052.
       if (isMysqlLike(config.dialect)) {
         if (setCols.length === 0)
-          return (bunSql.unsafe(`INSERT IGNORE INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
+          return (_sql.unsafe(`INSERT IGNORE INTO ${tbl} (${colsSql}) VALUES ${valuesSql}`, params) as any).execute()
         const updateList = setCols.map(c => `${quoteInsertIdent(c)} = VALUES(${quoteInsertIdent(c)})`).join(', ')
-        return (bunSql.unsafe(`${insert} ON DUPLICATE KEY UPDATE ${updateList}`, params) as any).execute()
+        return (_sql.unsafe(`${insert} ON DUPLICATE KEY UPDATE ${updateList}`, params) as any).execute()
       }
 
       const targets = targetCols.map(quoteInsertIdent).join(', ')
       if (setCols.length === 0)
-        return (bunSql.unsafe(`${insert} ON CONFLICT (${targets}) DO NOTHING`, params) as any).execute()
+        return (_sql.unsafe(`${insert} ON CONFLICT (${targets}) DO NOTHING`, params) as any).execute()
       const updateList = setCols.map(c => `${quoteInsertIdent(c)} = EXCLUDED.${quoteInsertIdent(c)}`).join(', ')
-      return (bunSql.unsafe(`${insert} ON CONFLICT (${targets}) DO UPDATE SET ${updateList}`, params) as any).execute()
+      return (_sql.unsafe(`${insert} ON CONFLICT (${targets}) DO UPDATE SET ${updateList}`, params) as any).execute()
     },
     async save(table, values) {
       const pk = meta?.primaryKeys[String(table)] ?? 'id'
@@ -7361,7 +7383,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       const start = Date.now()
       try {
         config.hooks?.onQueryStart?.({ sql: query, kind: 'raw' })
-        const res = await (bunSql as any).unsafe(query)
+        const res = await (_sql as any).unsafe(query)
         config.hooks?.onQueryEnd?.({ sql: query, durationMs: Date.now() - start, kind: 'raw' })
         return res
       }
@@ -7383,10 +7405,8 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
 
       if (config.dialect === 'postgres') {
         // For PostgreSQL, use RETURNING to get the ID, then fetch the full row
-        const q = bunSql`INSERT INTO ${bunSql(String(table))} ${bunSql(values as any)} RETURNING ${bunSql(String(pk))} as id`
+        const q = _sql`INSERT INTO ${_sql(String(table))} ${_sql(values as any)} RETURNING ${_sql(String(pk))} as id`
         const [result] = await q.execute()
-
-        console.log('resultId', result)
 
         if (!result?.id) {
           console.error(`create() failed to get insert ID for table ${String(table)}`)
@@ -7600,28 +7620,28 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       return await (this as any).create(table, { ...(match as any), ...(values as any) })
     },
     async count(table, column) {
-      const col = column ? bunSql(String(column)) : bunSql`*`
-      const q = bunSql`SELECT COUNT(${col}) as c FROM ${bunSql(String(table))}`
+      const col = column ? _sql(String(column)) : _sql`*`
+      const q = _sql`SELECT COUNT(${col}) as c FROM ${_sql(String(table))}`
       const [row] = await (q as any).execute()
       return Number((row?.c ?? 0) as any)
     },
     async sum(table, column) {
-      const q = bunSql`SELECT SUM(${bunSql(String(column))}) as s FROM ${bunSql(String(table))}`
+      const q = _sql`SELECT SUM(${_sql(String(column))}) as s FROM ${_sql(String(table))}`
       const [row] = await (q as any).execute()
       return Number((row?.s ?? 0) as any)
     },
     async avg(table, column) {
-      const q = bunSql`SELECT AVG(${bunSql(String(column))}) as a FROM ${bunSql(String(table))}`
+      const q = _sql`SELECT AVG(${_sql(String(column))}) as a FROM ${_sql(String(table))}`
       const [row] = await (q as any).execute()
       return Number((row?.a ?? 0) as any)
     },
     async min(table, column) {
-      const q = bunSql`SELECT MIN(${bunSql(String(column))}) as m FROM ${bunSql(String(table))}`
+      const q = _sql`SELECT MIN(${_sql(String(column))}) as m FROM ${_sql(String(table))}`
       const [row] = await (q as any).execute()
       return (row?.m as any)
     },
     async max(table, column) {
-      const q = bunSql`SELECT MAX(${bunSql(String(column))}) as m FROM ${bunSql(String(table))}`
+      const q = _sql`SELECT MAX(${_sql(String(column))}) as m FROM ${_sql(String(table))}`
       const [row] = await (q as any).execute()
       return (row?.m as any)
     },

--- a/packages/bun-query-builder/test/client.transaction-connection.test.ts
+++ b/packages/bun-query-builder/test/client.transaction-connection.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Every statement a builder issues must go through the builder's OWN
+ * connection (`_sql`), never the module-global `bunSql`.
+ *
+ * They are the same object for a plain builder, so this is invisible until a
+ * builder is created with a connection of its own — which is exactly what
+ * `db.transaction()` does for its callback. Then the global is a DIFFERENT
+ * pooled session, and ~29 helper methods were using it:
+ *
+ *  - A write inside `db.transaction()` autocommitted on that other session and
+ *    SURVIVED THE ROLLBACK. The transaction failed, the caller saw the error,
+ *    and the row was still in the table. Silent, with no driver error.
+ *  - A read inside the transaction could not see the transaction's own
+ *    uncommitted rows, so `tx.count()` returned 0 for a row `tx` had just
+ *    inserted and read-then-decide logic acted on stale data.
+ *
+ * SQLite cannot catch either one: `bunSql` and the transaction share a single
+ * `bun:sqlite` handle, so the distinction the bug turns on does not exist. It
+ * needs a real pooled driver, so this file is gated on a live Postgres and runs
+ * in a subprocess (an earlier `configureOrm()` elsewhere in the suite pins the
+ * global executor at sqlite and would mask the network path).
+ *
+ * `unsafe()` was fixed for this once already (client.ts, the comment about raw
+ * SQL escaping the transaction); these are the rest of the same family.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { SQL } from 'bun'
+import { describe, expect, it } from 'bun:test'
+
+const PG_URL = `postgres://${process.env.USER}@localhost:5432/postgres`
+
+let pgAvailable = false
+try {
+  const probe = new SQL(PG_URL)
+  await probe.unsafe('SELECT 1')
+  await probe.end()
+  pgAvailable = true
+}
+catch {
+  pgAvailable = false
+}
+
+describe.skipIf(!pgAvailable)('builder-local connection routing', () => {
+  it('keeps transactional writes inside the transaction, and reads inside it current', () => {
+    const srcEntry = resolve(import.meta.dir, '../src/index.ts')
+    const dir = mkdtempSync(join(tmpdir(), 'qb-txconn-'))
+    const scriptPath = join(dir, 'probe.ts')
+
+    writeFileSync(scriptPath, `
+import { SQL } from 'bun'
+import { setConfig, createQueryBuilder, buildDatabaseSchema } from ${JSON.stringify(srcEntry)}
+
+const URL = ${JSON.stringify(PG_URL)}
+const raw = new SQL(URL)
+await raw.unsafe('DROP TABLE IF EXISTS _qb_txconn')
+await raw.unsafe('CREATE TABLE _qb_txconn (id serial primary key, name text)')
+
+setConfig({ dialect: 'postgres', database: { url: URL } })
+const schema = buildDatabaseSchema({
+  Widget: { name: 'Widget', table: '_qb_txconn', primaryKey: 'id', attributes: { id: { validation: { rule: {} } }, name: { validation: { rule: {} } } } },
+})
+const db = createQueryBuilder({ schema })
+
+// A write in a transaction that throws must not outlive the ROLLBACK.
+try {
+  await db.transaction(async (tx) => {
+    await tx.insertGetId('_qb_txconn', { name: 'rolled-back' })
+    throw new Error('deliberate failure')
+  })
+}
+catch {}
+const survivors = await raw.unsafe('SELECT name FROM _qb_txconn')
+
+// A read in a transaction must see that transaction's own uncommitted write.
+let seenInside = -1
+await db.transaction(async (tx) => {
+  await tx.insertGetId('_qb_txconn', { name: 'committed' })
+  seenInside = Number(await tx.count('_qb_txconn'))
+})
+const committed = await raw.unsafe('SELECT name FROM _qb_txconn')
+
+await raw.unsafe('DROP TABLE IF EXISTS _qb_txconn')
+await raw.end()
+
+console.log(JSON.stringify({
+  survivedRollback: survivors.length,
+  seenInside,
+  committed: committed.length,
+}))
+`)
+
+    const proc = Bun.spawnSync({ cmd: ['bun', scriptPath], cwd: dir, stdout: 'pipe', stderr: 'pipe' })
+    const stdout = new TextDecoder().decode(proc.stdout).trim()
+    const stderr = new TextDecoder().decode(proc.stderr).trim()
+    rmSync(dir, { recursive: true, force: true })
+
+    if (proc.exitCode !== 0)
+      throw new Error(`probe exited ${proc.exitCode}: ${stderr || stdout}`)
+
+    const result = JSON.parse(stdout.split('\n').filter(Boolean).at(-1) ?? '{}')
+
+    // Was 1 — the write autocommitted on the global connection and outlived the rollback.
+    expect(result.survivedRollback).toBe(0)
+    // Was 0 — the count ran on the global connection and could not see the tx's row.
+    expect(result.seenInside).toBe(1)
+    expect(result.committed).toBe(1)
+  })
+})


### PR DESCRIPTION
Fixes a silent data-loss bug. Also fixes the last live cause of #1001.

## Writes were surviving `ROLLBACK`

`createQueryBuilder` captures the connection it was given as `_sql` (`client.ts:2743`), but ~29 of its methods reached for the module-global `bunSql` instead. Those are the same object for a plain builder — which is why this went unnoticed — but `db.transaction()` hands its callback a builder with a connection of its own, and then the global is a *different pooled session*.

Reproduced against live Postgres, before the fix:

```
transaction threw as expected: deliberate failure -> ROLLBACK
rows surviving the ROLLBACK -> [{"name":"should-be-rolled-back"}]
*** DATA LEAK: write survived ROLLBACK ***
```

The write autocommitted on the other session, so it outlived the rollback. The transaction failed, the caller caught the error, and the row is still in the table — no driver error anywhere. `insertGetId`, `upsert`, `insertOrIgnore`, `updateOrInsert` and `create` were all affected.

The read side is the same bug pointed the other way: `tx.count()` ran on the global, which cannot see the transaction's uncommitted rows, so it returned **0** for a row `tx` had just inserted. `sum`/`avg`/`min`/`max` and the advisory-lock helpers were equally adrift — and a lock taken on a session that isn't the transaction's locks nothing. With `pool: { max: 1 }` these don't return at all: the call waits on the single connection its own transaction is holding.

After the fix, same script:

```
(1) rows surviving ROLLBACK: 0 OK
(2) tx.count() sees its own uncommitted row: 1 OK
(3) committed rows persist: 1 OK
```

## Why this is a re-fix, not a new idea

`unsafe()` was already corrected for exactly this, and the comment above it spells out the rule — raw SQL routed through the pool "lets it escape the transaction (and makes row locks such as `FOR UPDATE` ineffective)". This PR is the rest of that family. The rule now lives on the `_sql` declaration itself, so the next method added inherits it instead of rediscovering it.

## Scope

Swapped to `_sql`: the advisory locks, `ping`, `file`, `rawQuery`, `insertGetId` (all four dialect paths), `updateOrInsert`, `upsert`/`insertOrIgnore`, and `count`/`sum`/`avg`/`min`/`max`.

Left on the global **deliberately**: `reserve()` and `close()`, which act on the pool rather than a session, and `commitDistributed`/`rollbackDistributed`, which by design run outside the transaction that prepared them.

Also drops a stray `console.log('resultId', result)` that was shipping in the Postgres `insertGetId` path.

## On #1001

`ping()` was the user-visible face of this: it health-checked the global rather than the connection the builder actually queries, so it could report a healthy builder as down — the reporter's "Database not ready after waiting" — or report ready at boot while the first real query fails (the ordinary `export const db = createQueryBuilder(...)` then `await getConfig()` boot order).

Worth noting the reporter's *original* failure had a different cause that was fixed ~30 releases ago; their exact flow returns `true` on current main. This was the last remaining live path producing that same error on a healthy database.

## Tests

The regression test is Postgres-gated and subprocess-isolated. **SQLite cannot catch any of this** — `bunSql` and the transaction share a single `bun:sqlite` handle, so the distinction the bug turns on doesn't exist there. Verified the test genuinely discriminates: against the unfixed `client.ts` it fails with `Expected: 0, Received: 1` (the leaked row).

Full suite **1699 pass / 4 skip / 0 fail**, typecheck 0, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
