### PR TITLE
docs: the write-path pages documented an API that does not exist

### DIFF
--- a/docs/advanced/distributed.md
+++ b/docs/advanced/distributed.md
@@ -100,7 +100,7 @@ async function processOrder(orderData: {
       const order = await tx.insertInto('orders').values({
         customer_id: orderData.customerId,
         status: 'processing',
-        total: orderData.items.reduce((sum, item) => sum + (item.price _ item.quantity), 0),
+        total: orderData.items.reduce((sum, item) => sum + (item.price * item.quantity), 0),
         created_at: new Date()
       }).returning('id').execute()
 
@@ -123,7 +123,7 @@ async function processOrder(orderData: {
     // Stage 2: Process payment
     const paymentResult = await processPayment({
       token: orderData.paymentToken,
-      amount: orderData.items.reduce((sum, item) => sum + (item.price _ item.quantity), 0),
+      amount: orderData.items.reduce((sum, item) => sum + (item.price * item.quantity), 0),
       orderId
     })
 
@@ -506,7 +506,7 @@ async function monitoredOnboarding(userData: any) {
 // Cleanup job for stale transactions
 class TransactionCleanupJob {
   async cleanupStaleTransactions() {
-    const staleThreshold = Date.now() - (24 _ 60 _ 60 _ 1000) // 24 hours
+    const staleThreshold = Date.now() - (24 * 60 * 60 * 1000) // 24 hours
 
     const staleTransactions = await db
       .selectFrom('distributed_transactions')
@@ -551,7 +551,7 @@ class TransactionCleanupJob {
 setInterval(async () => {
   const cleanup = new TransactionCleanupJob()
   await cleanup.cleanupStaleTransactions()
-}, 60 _ 60 * 1000) // Every hour
+}, 60 * 60 * 1000) // Every hour
 ```
 
 ## FAQ

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -64,7 +64,7 @@ const meta = buildSchemaMeta(models)
 | `whereIn(col, vals)` | WHERE IN | `.whereIn('id', [1, 2, 3])` |
 | `whereNotIn(col, vals)` | WHERE NOT IN | `.whereNotIn('status', ['banned'])` |
 | `whereBetween(col, a, b)` | WHERE BETWEEN | `.whereBetween('age', 18, 65)` |
-| `whereNull(col)` | WHERE IS NULL | `.whereNull('deleted*at')` |
+| `whereNull(col)` | WHERE IS NULL | `.whereNull('deleted_at')` |
 | `whereNotNull(col)` | WHERE IS NOT NULL | `.whereNotNull('email')` |
 | `whereColumn(a, op, b)` | Compare columns | `.whereColumn('a', '=', 'b')` |
 | `whereRaw(sql)` | Raw WHERE clause | `.whereRaw('LOWER(name) = ?', ['john'])` |
@@ -73,7 +73,7 @@ const meta = buildSchemaMeta(models)
 
 | Method | Description | Example |
 |--------|-------------|---------|
-| `join(table, a, op, b)` | INNER JOIN | `.join('posts', 'users.id', '=', 'posts.user*id')` |
+| `join(table, a, op, b)` | INNER JOIN | `.join('posts', 'users.id', '=', 'posts.user_id')` |
 | `leftJoin(...)` | LEFT JOIN | `.leftJoin('posts', ...)` |
 | `rightJoin(...)` | RIGHT JOIN | `.rightJoin('posts', ...)` |
 | `crossJoin(table)` | CROSS JOIN | `.crossJoin('categories')` |
@@ -83,8 +83,8 @@ const meta = buildSchemaMeta(models)
 | Method | Description | Example |
 |--------|-------------|---------|
 | `orderBy(col, dir)` | ORDER BY | `.orderBy('name', 'asc')` |
-| `orderByDesc(col)` | ORDER BY DESC | `.orderByDesc('created*at')` |
-| `latest()` | Order by created*at DESC | `.latest()` |
+| `orderByDesc(col)` | ORDER BY DESC | `.orderByDesc('created_at')` |
+| `latest()` | Order by created_at DESC | `.latest()` |
 | `oldest()` | Order by created_at ASC | `.oldest()` |
 | `inRandomOrder()` | Random order | `.inRandomOrder()` |
 | `limit(n)` | LIMIT | `.limit(10)` |
@@ -127,7 +127,7 @@ const meta = buildSchemaMeta(models)
 
 | Method | Description | Example |
 |--------|-------------|---------|
-| `update(table)` | Start UPDATE | `db.update('users')` |
+| `update(table)` | Start UPDATE | `db.updateTable('users')` |
 | `set(data)` | Set values | `.set({ active: false })` |
 | `increment(col, n)` | Increment | `.increment('views', 1)` |
 | `decrement(col, n)` | Decrement | `.decrement('stock', 1)` |
@@ -196,7 +196,7 @@ Execute queries in a transaction.
 ```typescript
 await db.transaction(async (trx) => {
   await trx.insertInto('users').values({...}).execute()
-  await trx.update('accounts').set({...}).execute()
+  await trx.updateTable('accounts').set({...}).execute()
 })
 ```
 

--- a/docs/delete.md
+++ b/docs/delete.md
@@ -2,6 +2,67 @@
 title: Delete Queries
 description: Delete records from your database with type-safe queries.
 ---
+
+# Delete Queries
+
+Delete records with type-safe queries, soft deletes, and cascade support.
+
+## Basic Delete
+
+```typescript
+import { createQueryBuilder } from 'bun-query-builder'
+
+const db = createQueryBuilder<typeof schema>({ schema, meta })
+
+// Delete by ID
+await db.remove('users', 1)
+
+// Delete with where clause
+await db
+  .deleteFrom('users')
+  .where({ active: false })
+  .execute()
+```
+
+## Delete with Conditions
+
+```typescript
+// Delete records matching conditions
+await db
+  .deleteFrom('posts')
+  .where('created_at', '<', '2023-01-01')
+  .execute()
+
+// Delete with multiple conditions
+await db
+  .deleteFrom('sessions')
+  .where('expired', '=', true)
+  .andWhere('last_activity', '<', '2024-01-01')
+  .execute()
+```
+
+## Delete Many
+
+```typescript
+// Delete multiple records by IDs
+await db.deleteMany('users', [1, 2, 3, 4, 5])
+
+// Delete many with conditions
+await db
+  .deleteFrom('logs')
+  .where('level', '=', 'debug')
+  .where('created_at', '<', '2024-01-01')
+  .execute()
+```
+
+## Soft Deletes
+
+If your model supports soft deletes, records are marked as deleted instead of being removed:
+
+```typescript
+// Model with soft deletes enabled
+const models = {
+  User: {
     name: 'User',
     table: 'users',
     softDeletes: true,  // Enable soft deletes
@@ -10,7 +71,7 @@ description: Delete records from your database with type-safe queries.
 }
 
 // Soft delete a record
-await db.delete('users', 1)
+await db.remove('users', 1)
 // Sets deleted_at = NOW() instead of removing the record
 
 // Query excluding soft deleted records (default behavior)
@@ -34,13 +95,15 @@ const deletedUsers = await db
 
 ```typescript
 
-// Restore a soft deleted record
-await db.restore('users', 1)
+// Restoring is a model-layer operation: load the trashed row, then restore it.
+const user = await User.withTrashed().find(1)
+await user.restore()
 // Sets deleted_at = NULL
 
-// Restore with conditions
+// From the query builder, clear the soft-delete column directly
 await db
-  .restoreFrom('users')
+  .updateTable('users')
+  .set({ deleted_at: null })
   .where({ email: 'restored@example.com' })
   .execute()
 
@@ -50,8 +113,9 @@ await db
 
 ```typescript
 
-// Permanently delete a soft deleted record
-await db.forceDelete('users', 1)
+// Permanently delete a soft deleted record — `remove()` issues a real DELETE,
+// so it removes the row whether or not it was already soft-deleted.
+await db.remove('users', 1)
 
 // Force delete with conditions
 await db
@@ -106,11 +170,15 @@ Remove all records from a table:
 
 ```typescript
 
-// Truncate entire table
-await db.truncate('logs')
+// Truncate entire table — a model-layer static
+await Log.truncate()
+
+// From the query builder, issue the statement directly.
+// TRUNCATE is not supported by SQLite; use DELETE there.
+await db.unsafe('TRUNCATE TABLE logs')
 
 // With cascade (if foreign keys exist)
-await db.truncate('users', { cascade: true })
+await db.unsafe('TRUNCATE TABLE users CASCADE')
 
 ```
 
@@ -126,7 +194,7 @@ await db.transaction(async (trx) => {
     .execute()
 
   // Then delete the user
-  await trx.delete('users', userId)
+  await trx.remove('users', userId)
 
   // All or nothing - if any delete fails, all are rolled back
 })
@@ -149,7 +217,7 @@ async function deleteUserWithRelations(userId: number) {
     await trx.deleteFrom('posts').where({ user_id: userId }).execute()
 
     // Delete user
-    await trx.delete('users', userId)
+    await trx.remove('users', userId)
   })
 }
 
@@ -225,15 +293,15 @@ async function cleanupData() {
     .where('created_at', '<', '2023-01-01')
     .execute()
 
-  // Restore a user
-  await db.restore('users', 1)
+  // Restore a user (clear the soft-delete column)
+  await db.updateTable('users').set({ deleted_at: null }).where({ id: 1 }).execute()
 
   // Query with trashed
   const allUsers = await db.selectFrom('users').withTrashed().get()
   const deletedOnly = await db.selectFrom('users').onlyTrashed().get()
 
-  // Force delete
-  await db.forceDelete('users', [2, 3, 4])
+  // Permanently delete — a real DELETE, regardless of soft-delete state
+  await db.deleteMany('users', [2, 3, 4])
 
   console.log('Cleanup completed')
 }

--- a/docs/features/builder.md
+++ b/docs/features/builder.md
@@ -707,7 +707,7 @@ await db
 // Delete with complex conditions
 await db
   .deleteFrom('sessions')
-  .where(['created_at', '<', new Date(Date.now() - 24 _ 60 _ 60 _ 1000)]) // older than 24h
+  .where(['created_at', '<', new Date(Date.now() - 24 * 60 * 60 * 1000)]) // older than 24h
   .andWhere(['user_id', 'is not', null])
   .execute()
 
@@ -765,7 +765,7 @@ See the Pagination page for details. Highlights:
 await db.selectFrom('users').paginate(25, 1)
 await db.selectFrom('users').simplePaginate(25)
 await db.selectFrom('users').cursorPaginate(100, undefined, 'id', 'asc')
-await db.selectFrom('users').chunkById(1000, 'id', async (batch) => { /_ ... */ })
+await db.selectFrom('users').chunkById(1000, 'id', async (batch) => { /* ... */ })
 ```
 
 ## CTEs and Recursive Queries
@@ -1139,7 +1139,7 @@ const projectsWithCollaborators = await db
 ```ts
 // Cleanup old sessions
 async function cleanupOldSessions() {
-  const cutoffDate = new Date(Date.now() - 30 _ 24 _ 60 _ 60 _ 1000) // 30 days ago
+  const cutoffDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) // 30 days ago
 
   const deletedCount = await db
     .deleteFrom('user_sessions')
@@ -1159,7 +1159,7 @@ async function archiveCompletedProjects() {
       .selectFrom('projects')
       .select('projects', 'id', 'name')
       .where(['status', '=', 'completed'])
-      .where(['completed_at', '<', new Date(Date.now() - 6 _ 30 _ 24 _ 60 _ 60 _ 1000)])
+      .where(['completed_at', '<', new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000)])
       .execute()
 
     if (projectsToArchive.length === 0)

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -725,8 +725,8 @@ query-builder file ./migrations/seed.sql
 query-builder file ./scripts/cleanup.sql --params "[30]"  # 30 days retention
 
 # Execute parameterized queries (use with caution)
-query-builder unsafe "SELECT _ FROM users WHERE team = $1" --params "[\"Engineering\"]"
-query-builder unsafe "SELECT _ FROM projects WHERE owner = $1 AND status = $2" --params "[\"Chris\",\"active\"]"
+query-builder unsafe "SELECT * FROM users WHERE team = $1" --params "[\"Engineering\"]"
+query-builder unsafe "SELECT * FROM projects WHERE owner = $1 AND status = $2" --params "[\"Chris\",\"active\"]"
 ```
 
 ### Performance Analysis
@@ -738,12 +738,12 @@ query-builder benchmark --iterations 5000
 query-builder benchmark --operations select,insert,count
 
 # Analyze query performance
-query-builder explain "SELECT _ FROM users WHERE active = true"
+query-builder explain "SELECT * FROM users WHERE active = true"
 query-builder explain "SELECT u._, p.name as project_name FROM users u JOIN projects p ON p.user_id = u.id WHERE u.role = 'admin'"
 
 # Compare different query strategies
-query-builder explain "SELECT _ FROM users WHERE name LIKE '%Chris%'"
-query-builder explain "SELECT _ FROM users WHERE name ILIKE 'chris%'"  # PostgreSQL
+query-builder explain "SELECT * FROM users WHERE name LIKE '%Chris%'"
+query-builder explain "SELECT * FROM users WHERE name ILIKE 'chris%'"  # PostgreSQL
 ```
 
 ## Best Practices
@@ -778,7 +778,7 @@ query-builder introspect ./app/Models --json | jq '.tables | keys'
 query-builder sql ./app/Models users --where '{"team":"Chris Team"}' --limit 5
 
 # Good: Check performance impact
-query-builder explain "SELECT _ FROM users u JOIN projects p ON p.user_id = u.id WHERE u.active = true"
+query-builder explain "SELECT * FROM users u JOIN projects p ON p.user_id = u.id WHERE u.active = true"
 query-builder benchmark --operations select,join
 
 # Good: Manage cache during development
@@ -786,7 +786,7 @@ query-builder cache:clear
 query-builder cache:stats
 
 # Avoid: Direct SQL without parameterization
-query-builder unsafe "SELECT _ FROM users WHERE name = 'Chris'" # Risky!
+query-builder unsafe "SELECT * FROM users WHERE name = 'Chris'" # Risky!
 
 # Better: Use parameters
 query-builder unsafe "SELECT * FROM users WHERE name = $1" --params '["Chris"]'
@@ -882,7 +882,7 @@ if [[ ! "$USER_ID" =~ ^[0-9]+$ ]]; then
   echo "Invalid user ID"
   exit 1
 fi
-query-builder unsafe "SELECT _ FROM users WHERE id = $1" --params "[\"$USER_ID\"]"
+query-builder unsafe "SELECT * FROM users WHERE id = $1" --params "[\"$USER_ID\"]"
 
 # Production audit logging
 echo "$(date): CLI operation by $(whoami): $_" >> /var/log/query-builder.log
@@ -904,7 +904,7 @@ query-builder ping || echo "Database unreachable - check network/credentials"
 
 # Debugging performance issues
 query-builder benchmark --iterations 100
-query-builder explain "SELECT _ FROM large_table WHERE unindexed_column = 'value'"
+query-builder explain "SELECT * FROM large_table WHERE unindexed_column = 'value'"
 
 # Debugging schema mismatches
 query-builder validate:schema ./app/Models
@@ -974,5 +974,5 @@ query-builder file ./migrations/seed.sql --params "[\"role\", \"admin\"]"
 ### Explain a complex statement
 
 ```bash
-query-builder explain "SELECT _ FROM users WHERE active = true ORDER BY created_at DESC LIMIT 10"
+query-builder explain "SELECT * FROM users WHERE active = true ORDER BY created_at DESC LIMIT 10"
 ```

--- a/docs/features/pagination.md
+++ b/docs/features/pagination.md
@@ -64,12 +64,12 @@ Implementation details:
 
 ### Composite cursors
 
-You can pass multiple columns for deterministic ordering, e.g. `['created*at', 'id']`.
+You can pass multiple columns for deterministic ordering, e.g. `['created_at', 'id']`.
 
 ```ts
 const page = await db
   .selectFrom('users')
-  .cursorPaginate(50, undefined, ['created*at', 'id'], 'asc')
+  .cursorPaginate(50, undefined, ['created_at', 'id'], 'asc')
 
 // use page.meta.nextCursor to fetch the next window
 ```
@@ -126,9 +126,9 @@ await db.selectFrom('users').eachById(500, 'id', async (row) => {
 async function getUsersPage(page: number = 1, perPage: number = 20) {
   const { data, meta } = await db
     .selectFrom('users')
-    .select('users', 'id', 'name', 'email', 'role', 'created*at')
+    .select('users', 'id', 'name', 'email', 'role', 'created_at')
     .where({ active: true })
-    .orderBy('created*at', 'desc')
+    .orderBy('created_at', 'desc')
     .paginate(perPage, page)
 
   return {
@@ -148,7 +148,7 @@ async function getUsersPage(page: number = 1, perPage: number = 20) {
 const chrisProjects = await db
   .selectFrom('projects')
   .where({ owner: 'Chris' })
-  .orderBy('updated*at', 'desc')
+  .orderBy('updated_at', 'desc')
   .paginate(10, 1)
 ```
 
@@ -159,10 +159,10 @@ const chrisProjects = await db
 async function getInfinitePosts(cursor?: string) {
   const page = await db
     .selectFrom('posts')
-    .select('posts', 'id', 'title', 'content', 'author*id', 'created*at')
+    .select('posts', 'id', 'title', 'content', 'author_id', 'created_at')
     .with('Author')
     .where({ published: true })
-    .cursorPaginate(20, cursor, 'created*at', 'desc')
+    .cursorPaginate(20, cursor, 'created_at', 'desc')
 
   return {
     posts: page.data,
@@ -200,7 +200,7 @@ async function sendNewsletterToAllUsers() {
 
   await db
     .selectFrom('users')
-    .where({ email*verified: true, newsletter*subscribed: true })
+    .where({ email_verified: true, newsletter_subscribed: true })
     .chunkById(100, 'id', async (userBatch) => {
       // Process batch of users
       for (const user of userBatch) {
@@ -220,15 +220,15 @@ async function exportUserData() {
   let exportedCount = 0
 
   // Write CSV header
-  exportFile.write('id,name,email,created*at\n')
+  exportFile.write('id,name,email,created_at\n')
 
   await db
     .selectFrom('users')
-    .select('users', 'id', 'name', 'email', 'created*at')
+    .select('users', 'id', 'name', 'email', 'created_at')
     .orderBy('id', 'asc')
     .chunk(500, async (userBatch) => {
       for (const user of userBatch) {
-        exportFile.write(`${user.id},"${user.name}","${user.email}","${user.created*at}"\n`)
+        exportFile.write(`${user.id},"${user.name}","${user.email}","${user.created_at}"\n`)
         exportedCount++
       }
 
@@ -265,16 +265,16 @@ async function searchUsersWithPagination(query: string, page: number = 1) {
 // Time-based cursor pagination for real-time feeds
 async function getRealtimeFeed(cursor?: string, userId?: number) {
   let query = db
-    .selectFrom('feed*items')
-    .select('feed*items', 'id', 'content', 'created*at', 'user*id')
+    .selectFrom('feed_items')
+    .select('feed_items', 'id', 'content', 'created_at', 'user_id')
     .with('User')
-    .orderBy('created*at', 'desc')
+    .orderBy('created_at', 'desc')
 
   if (userId) {
-    query = query.where({ user*id: userId })
+    query = query.where({ user_id: userId })
   }
 
-  const page = await query.cursorPaginate(25, cursor, 'created*at', 'desc')
+  const page = await query.cursorPaginate(25, cursor, 'created_at', 'desc')
 
   return {
     items: page.data,
@@ -308,12 +308,12 @@ const buddyFeed = await getRealtimeFeed(undefined, buddyUserId)
 const page = await db
   .selectFrom('posts')
   .where({ published: true })
-  .cursorPaginate(50, cursor, 'created*at', 'desc') // created*at should be indexed
+  .cursorPaginate(50, cursor, 'created_at', 'desc') // created_at should be indexed
 
 // Good: Composite cursor for stable ordering
 const page = await db
   .selectFrom('events')
-  .cursorPaginate(25, cursor, ['created*at', 'id'], 'desc') // Both columns indexed
+  .cursorPaginate(25, cursor, ['created_at', 'id'], 'desc') // Both columns indexed
 
 // Avoid: Large offset pagination
 const badPage = await db
@@ -334,16 +334,16 @@ async function getLatestNotifications(userId: number, cursor?: string) {
   // Cursor pagination is stable even if new notifications are added
   return await db
     .selectFrom('notifications')
-    .where({ user*id: userId, deleted*at: null })
-    .cursorPaginate(20, cursor, ['created*at', 'id'], 'desc')
+    .where({ user_id: userId, deleted_at: null })
+    .cursorPaginate(20, cursor, ['created_at', 'id'], 'desc')
 }
 
 // Composite cursor for handling duplicate timestamps
 async function getOrderHistory(customerId: number, cursor?: string) {
   return await db
     .selectFrom('orders')
-    .where({ customer*id: customerId })
-    .cursorPaginate(25, cursor, ['created*at', 'id'], 'desc')
+    .where({ customer_id: customerId })
+    .cursorPaginate(25, cursor, ['created_at', 'id'], 'desc')
 }
 ```
 
@@ -374,12 +374,12 @@ interface PaginatedResponse<T> {
 async function getUsersAPI(req: Request): Promise<PaginatedResponse<User>> {
   try {
     const page = Math.max(1, Number.parseInt(req.query.page as string) || 1)
-    const perPage = Math.min(100, Math.max(1, Number.parseInt(req.query.per*page as string) || 20))
+    const perPage = Math.min(100, Math.max(1, Number.parseInt(req.query.per_page as string) || 20))
 
     const result = await db
       .selectFrom('users')
       .where({ active: true })
-      .orderBy('created*at', 'desc')
+      .orderBy('created_at', 'desc')
       .paginate(perPage, page)
 
     return {
@@ -415,7 +415,7 @@ async function processLargeDataset(batchSize: number = 1000) {
 
   try {
     await db
-      .selectFrom('large*table')
+      .selectFrom('large_table')
       .where(['id', '>', lastProcessedId])
       .orderBy('id', 'asc')
       .chunkById(batchSize, 'id', async (batch) => {
@@ -513,7 +513,7 @@ const UsersList = () => {
 
 ### Can I use composite cursors
 
-Yes. Provide an array of columns like `['created*at', 'id']`. The cursor will carry a tuple of values in order.
+Yes. Provide an array of columns like `['created_at', 'id']`. The cursor will carry a tuple of values in order.
 
 ### How do I resume a chunked job
 
@@ -530,7 +530,7 @@ let cursor: number | undefined
 do {
   const { data, meta } = await db
     .selectFrom('events')
-    .cursorPaginate(100, cursor, 'created*at', 'desc')
+    .cursorPaginate(100, cursor, 'created_at', 'desc')
   // process new slice
   cursor = meta.nextCursor as number | undefined
 } while (cursor)
@@ -551,15 +551,15 @@ const { data, meta } = await db
 ```ts
 await db
   .selectFrom('posts')
-  .orderBy('published*at', 'desc')
+  .orderBy('published_at', 'desc')
   .paginate(10, 1)
 ```
 
 ### Chunk with transformation
 
 ```ts
-await db.selectFrom('audit*logs').chunk(5000, async (rows) => {
-  const normalized = rows.map(r => ({ ...r, ts: new Date(r.created*at) }))
+await db.selectFrom('audit_logs').chunk(5000, async (rows) => {
+  const normalized = rows.map(r => ({ ...r, ts: new Date(r.created_at) }))
   await writeLogs(normalized)
 })
 ```
@@ -577,5 +577,5 @@ await db.selectFrom('images').eachById(200, 'id', async (row) => {
 Ensure the cursor column has an index; otherwise, performance degrades.
 
 ```sql
-CREATE INDEX IF NOT EXISTS idx*users*id ON users(id);
+CREATE INDEX IF NOT EXISTS idx_users_id ON users(id);
 ```

--- a/docs/features/relations.md
+++ b/docs/features/relations.md
@@ -357,7 +357,7 @@ const buddyManagers = await db
 const averyActiveTeam = await db
   .selectFrom('users')
   .whereHas('Team', ['lead_id', '=', (await db.selectFrom('users').where({ name: 'Avery' }).first())?.id])
-  .whereHas('Activity', ['created_at', '>', new Date(Date.now() - 7 _ 24 _ 60 _ 60 _ 1000)])
+  .whereHas('Activity', ['created_at', '>', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)])
   .execute()
 ```
 

--- a/docs/features/seeding.md
+++ b/docs/features/seeding.md
@@ -47,8 +47,8 @@ export default class UserSeeder extends Seeder {
     const users = Array.from({ length: 10 }, () => ({
       name: faker.person.fullName(),
       email: faker.internet.email(),
-      created*at: new Date(),
-      updated*at: new Date(),
+      created_at: new Date(),
+      updated_at: new Date(),
     }))
 
     await qb.table('users').insert(users).execute()
@@ -99,8 +99,8 @@ export default class ProductSeeder extends Seeder {
       description: faker.commerce.productDescription(),
       price: faker.commerce.price(10, 1000),
       stock: faker.number.int(0, 100),
-      created*at: new Date(),
-      updated*at: new Date(),
+      created_at: new Date(),
+      updated_at: new Date(),
     }))
 
     await qb.table('products').insert(products).execute()
@@ -120,8 +120,8 @@ export default class UserSeeder extends Seeder {
       name: faker.person.fullName(),
       email: faker.internet.email(),
       age: faker.number.int(18, 80),
-      created*at: new Date(),
-      updated*at: new Date(),
+      created_at: new Date(),
+      updated_at: new Date(),
     }))
 
     await qb.table('users').insert(users).execute()
@@ -148,12 +148,12 @@ export default class PostSeeder extends Seeder {
     for (const user of users) {
       for (let i = 0; i < 3; i++) {
         posts.push({
-          user*id: user.id,
+          user_id: user.id,
           title: faker.lorem.sentence(5),
           body: faker.lorem.paragraphs(3),
           published: faker.datatype.boolean(0.7), // 70% published
-          created*at: faker.date.past(),
-          updated*at: new Date(),
+          created_at: faker.date.past(),
+          updated_at: new Date(),
         })
       }
     }
@@ -181,8 +181,8 @@ export default class LargeDataSeeder extends Seeder {
       const batch = Array.from({ length: batchSize }, () => ({
         name: faker.person.fullName(),
         email: faker.internet.email(),
-        created*at: new Date(),
-        updated*at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
       }))
 
       await qb.table('users').insert(batch).execute()
@@ -211,8 +211,8 @@ export default class ConditionalSeeder extends Seeder {
     const users = Array.from({ length: 10 }, () => ({
       name: faker.person.fullName(),
       email: faker.internet.email(),
-      created*at: new Date(),
-      updated*at: new Date(),
+      created_at: new Date(),
+      updated_at: new Date(),
     }))
 
     await qb.table('users').insert(users).execute()
@@ -237,7 +237,7 @@ faker.person.jobTitle()          // "Software Engineer"
 
 ```typescript
 faker.internet.email()           // "john.doe@example.com"
-faker.internet.userName()        // "john*doe123"
+faker.internet.userName()        // "john_doe123"
 faker.internet.url()             // "https://example.com"
 faker.internet.password()        // "aB3$dF7!"
 ```
@@ -438,7 +438,7 @@ Use appropriate faker methods for each field:
   phone: faker.phone.number(),             // Valid phone number
   age: faker.number.int(18, 80),          // Reasonable age range
   country: faker.location.country(),       // Real country names
-  created*at: faker.date.past(),          // Past dates for created*at
+  created_at: faker.date.past(),          // Past dates for created_at
 }
 ```
 
@@ -505,8 +505,8 @@ function createUser(overrides = {}) {
     email: faker.internet.email(),
     age: faker.number.int(18, 80),
     role: 'user',
-    created*at: new Date(),
-    updated*at: new Date(),
+    created_at: new Date(),
+    updated_at: new Date(),
     ...overrides,
   }
 }
@@ -537,12 +537,12 @@ export default class UserRoleSeeder extends Seeder {
     const userRoles = users.flatMap(user =>
       faker.helpers.arrayElements(roles, faker.number.int(1, 3))
         .map(role => ({
-          user*id: user.id,
-          role*id: role.id,
+          user_id: user.id,
+          role_id: role.id,
         }))
     )
 
-    await qb.table('user*roles').insert(userRoles).execute()
+    await qb.table('user_roles').insert(userRoles).execute()
   }
 
   get order(): number {
@@ -556,7 +556,7 @@ export default class UserRoleSeeder extends Seeder {
 ```typescript
 export default class EnvironmentSeeder extends Seeder {
   async run(qb: any): Promise<void> {
-    const env = process.env.NODE*ENV
+    const env = process.env.NODE_ENV
 
     if (env === 'production') {
       console.log('Skipping seeding in production')

--- a/docs/features/transactions.md
+++ b/docs/features/transactions.md
@@ -160,7 +160,7 @@ await createUser({ name: 'Alice' })
 You can pass options to override defaults:
 
 ```ts
-const createWithRetry = db.transactional(async (tx) => { /_ ... _/ }, { retries: 3 })
+const createWithRetry = db.transactional(async (tx) => { /* ... */ }, { retries: 3 })
 ```
 
 ## Error Handling and Logging
@@ -168,7 +168,7 @@ const createWithRetry = db.transactional(async (tx) => { /_ ... _/ }, { retries:
 Use `onRetry` and `logger` to observe transaction lifecycle.
 
 ```ts
-await db.transaction(async (tx) => { /_ ... _/ }, {
+await db.transaction(async (tx) => { /* ... */ }, {
   logger: (e) => {
     if (e.type === 'retry')
       console.warn('retry', e.attempt)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -127,7 +127,7 @@ await db.insertMany('users', [
 ```typescript
 // Update by condition
 await db
-  .update('users')
+  .updateTable('users')
   .set({ active: false })
   .where({ id: 1 })
   .execute()

--- a/docs/guide/insert-update-delete.md
+++ b/docs/guide/insert-update-delete.md
@@ -86,7 +86,7 @@ await db
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({ active: false })
   .where({ id: 1 })
   .execute()
@@ -96,7 +96,7 @@ await db
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({
     name: 'Updated Name',
     email: 'new@example.com',
@@ -111,7 +111,7 @@ await db
 ```typescript
 // Increment a value
 await db
-  .update('products')
+  .updateTable('products')
   .set({
     views: db.raw('views + 1')
   })
@@ -120,7 +120,7 @@ await db
 
 // Decrement stock
 await db
-  .update('products')
+  .updateTable('products')
   .set({
     stock: db.raw('stock - ?', [quantity])
   })
@@ -144,13 +144,9 @@ await db.updateMany(
 
 ```typescript
 await db
-  .update('products')
+  .updateTable('products')
   .set({
-    category_id: db.subquery(
-      db.selectFrom('categories')
-        .select(['id'])
-        .where({ name: 'Electronics' })
-    )
+    category_id: db.raw('(SELECT id FROM categories WHERE name = ?)', ['Electronics']),
   })
   .where({ type: 'gadget' })
   .execute()
@@ -191,8 +187,9 @@ await db.deleteMany('users', [1, 2, 3, 4, 5])
 // Delete all records (use with caution!)
 await db.deleteFrom('temp_data').execute()
 
-// Truncate table (faster, resets auto-increment)
-await db.truncate('temp_data')
+// Truncate table (faster, resets auto-increment).
+// Not supported by SQLite — use the DELETE above there.
+await db.unsafe('TRUNCATE TABLE temp_data')
 ```
 
 ## Soft Deletes
@@ -202,7 +199,7 @@ await db.truncate('temp_data')
 ```typescript
 // Instead of deleting, set deleted_at
 await db
-  .update('users')
+  .updateTable('users')
   .set({ deleted_at: new Date() })
   .where({ id: 1 })
   .execute()
@@ -221,7 +218,7 @@ const activeUsers = await db
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({ deleted_at: null })
   .where({ id: 1 })
   .execute()
@@ -276,7 +273,7 @@ async function processOrder(orderId: number) {
   await db.transaction(async (trx) => {
     // Update order status
     await trx
-      .update('orders')
+      .updateTable('orders')
       .set({
         status: 'processing',
         processed_at: new Date()
@@ -293,7 +290,7 @@ async function processOrder(orderId: number) {
     // Decrement stock for each item
     for (const item of items) {
       await trx
-        .update('products')
+        .updateTable('products')
         .set({
           stock: db.raw('stock - ?', [item.quantity])
         })
@@ -322,7 +319,7 @@ async function deactivateInactiveUsers(daysInactive: number) {
   cutoffDate.setDate(cutoffDate.getDate() - daysInactive)
 
   const result = await db
-    .update('users')
+    .updateTable('users')
     .set({
       active: false,
       deactivated_at: new Date(),

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -17,7 +17,7 @@ await transaction(async (trx) => {
     .execute()
 
   await trx
-    .update('users')
+    .updateTable('users')
     .set({ has_account: true })
     .where({ id: 1 })
     .execute()
@@ -77,20 +77,24 @@ await transaction(fn, { isolationLevel: 'serializable' })
 
 Create savepoints within a transaction:
 
+`savepoint()` takes a callback, like `transaction()` does — there is no
+`rollbackToSavepoint()`. The savepoint is released when the callback returns and
+rolled back if it throws, so "roll back to the savepoint" means "let the
+callback throw and catch it outside".
+
 ```typescript
-await transaction(async (trx) => {
+await db.transaction(async (trx) => {
   await trx.insertInto('logs').values({ message: 'Step 1' }).execute()
 
-  // Create savepoint
-  await trx.savepoint('step2')
-
   try {
-    await trx.insertInto('logs').values({ message: 'Step 2' }).execute()
-    // Something fails
-    throw new Error('Step 2 failed')
-  } catch (e) {
-    // Rollback to savepoint (step 1 is preserved)
-    await trx.rollbackToSavepoint('step2')
+    await trx.savepoint(async (sp) => {
+      await sp.insertInto('logs').values({ message: 'Step 2' }).execute()
+      // Something fails — only the savepoint's work is undone
+      throw new Error('Step 2 failed')
+    })
+  }
+  catch {
+    // Step 1 is preserved; the transaction itself is still alive
     await trx.insertInto('logs').values({ message: 'Step 2 fallback' }).execute()
   }
 
@@ -98,25 +102,40 @@ await transaction(async (trx) => {
 })
 ```
 
-## Manual Transaction Control
+`savepoint()` must be called inside a transaction; calling it outside throws.
 
-For more control over transaction lifecycle:
+## Commit and rollback
+
+There is no manual `beginTransaction()` / `commit()` / `rollback()` API. The
+callback form owns the lifecycle: return normally and the transaction commits,
+throw and it rolls back.
 
 ```typescript
-const trx = await db.beginTransaction()
+await db.transaction(async (tx) => {
+  await tx.insertInto('users').values({ name: 'Test' }).execute()
+  await tx.updateTable('counters').set({ value: db.raw('value + 1') }).execute()
+  // committed when this callback returns
+})
+```
 
+To roll back deliberately, throw — then handle the error outside:
+
+```typescript
 try {
-  await trx.insertInto('users').values({ name: 'Test' }).execute()
-  await trx.update('counters').set({ value: db.raw('value + 1') }).execute()
-
-  // Explicitly commit
-  await trx.commit()
-} catch (error) {
-  // Explicitly rollback
-  await trx.rollback()
-  throw error
+  await db.transaction(async (tx) => {
+    await tx.insertInto('users').values({ name: 'Test' }).execute()
+    if (!ok)
+      throw new Error('rolling back')
+  })
+}
+catch (error) {
+  // the transaction has already rolled back by the time you get here
 }
 ```
+
+Use `tx`, not `db`, for every statement inside the callback. `db` holds a
+different connection, so work issued through it is not part of the transaction
+and will not be rolled back with it.
 
 ## Nested Transactions
 
@@ -133,7 +152,7 @@ await transaction(async (trx) => {
     }
   })
 
-  await trx.update('inventory').set(/_ ... _/).execute()
+  await trx.updateTable('inventory').set(/* ... */).execute()
 })
 ```
 
@@ -149,7 +168,7 @@ try {
       throw new Error('Business logic error')
     }
 
-    await trx.update('accounts').set({ balance: 500 }).execute()
+    await trx.updateTable('accounts').set({ balance: 500 }).execute()
   })
 } catch (error) {
   console.error('Transaction failed:', error.message)
@@ -166,7 +185,7 @@ await transaction(
   async (trx) => {
     // This might fail due to lock contention
     await trx
-      .update('accounts')
+      .updateTable('accounts')
       .set({ balance: db.raw('balance - ?', [100]) })
       .where({ id: 1 })
       .execute()
@@ -205,14 +224,14 @@ async function transferMoney(
     }
 
     await trx
-      .update('accounts')
+      .updateTable('accounts')
       .set({ balance: fromAccount.balance - amount })
       .where({ id: fromAccountId })
       .execute()
 
     // Add to destination account
     await trx
-      .update('accounts')
+      .updateTable('accounts')
       .set({ balance: db.raw('balance + ?', [amount]) })
       .where({ id: toAccountId })
       .execute()
@@ -277,17 +296,17 @@ async function placeOrder(userId: number, items: OrderItem[]) {
 
       // Reduce inventory
       await trx
-        .update('products')
+        .updateTable('products')
         .set({ stock: product.stock - item.quantity })
         .where({ id: item.productId })
         .execute()
 
-      total += product.price _ item.quantity
+      total += product.price * item.quantity
     }
 
     // Update order total
     await trx
-      .update('orders')
+      .updateTable('orders')
       .set({ total, status: 'confirmed' })
       .where({ id: order.id })
       .execute()
@@ -304,28 +323,32 @@ async function placeOrder(userId: number, items: OrderItem[]) {
 
 ### Batch Processing with Checkpoints
 
+Wrap each chunk in its own savepoint. A chunk that throws is undone on its own,
+and the surrounding transaction — and every chunk before it — survives.
+
 ```typescript
 async function processBatch(records: any[]) {
-  await transaction(async (trx) => {
-    for (let i = 0; i < records.length; i++) {
-      // Create checkpoint every 100 records
-      if (i > 0 && i % 100 === 0) {
-        await trx.savepoint(`batch_${i}`)
-      }
+  const failed: number[] = []
+
+  await db.transaction(async (trx) => {
+    for (let i = 0; i < records.length; i += 100) {
+      const chunk = records.slice(i, i + 100)
 
       try {
-        await processRecord(trx, records[i])
-      } catch (error) {
-        // On error, rollback to last checkpoint and skip
-        const checkpoint = Math.floor(i / 100) _ 100
-        if (checkpoint > 0) {
-          await trx.rollbackToSavepoint(`batch_${checkpoint}`)
-        }
-        console.error(`Failed at record ${i}:`, error)
-        throw error
+        await trx.savepoint(async (sp) => {
+          for (const record of chunk)
+            await processRecord(sp, record)
+        })
+      }
+      catch (error) {
+        // Only this chunk rolled back; earlier chunks are intact.
+        console.error(`Failed in chunk starting at ${i}:`, error)
+        failed.push(i)
       }
     }
   })
+
+  return failed
 }
 ```
 

--- a/docs/guide/update.md
+++ b/docs/guide/update.md
@@ -8,7 +8,7 @@ Learn how to update existing data in your database using bun-query-builder.
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({ active: false })
   .where({ id: 1 })
   .execute()
@@ -18,7 +18,7 @@ await db
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({
     name: 'John Smith',
     email: 'john.smith@example.com',
@@ -34,7 +34,7 @@ Return the updated rows:
 
 ```typescript
 const updated = await db
-  .update('users')
+  .updateTable('users')
   .set({ status: 'verified' })
   .where({ email_verified: true })
   .returning(['id', 'name', 'status'])
@@ -49,7 +49,7 @@ console.log(`Updated ${updated.length} users`)
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({ subscription: 'expired' })
   .where('subscription_ends_at', '<', new Date())
   .andWhere('subscription', '!=', 'lifetime')
@@ -60,7 +60,7 @@ await db
 
 ```typescript
 await db
-  .update('posts')
+  .updateTable('posts')
   .set({ status: 'archived' })
   .whereIn('id', [1, 2, 3, 4, 5])
   .execute()
@@ -73,14 +73,14 @@ await db
 ```typescript
 // Increment a column
 await db
-  .update('posts')
+  .updateTable('posts')
   .increment('views', 1)
   .where({ id: 1 })
   .execute()
 
 // Increment by custom amount
 await db
-  .update('users')
+  .updateTable('users')
   .increment('points', 100)
   .where({ id: userId })
   .execute()
@@ -91,14 +91,14 @@ await db
 ```typescript
 // Decrement a column
 await db
-  .update('products')
+  .updateTable('products')
   .decrement('stock', 1)
   .where({ id: productId })
   .execute()
 
 // Ensure non-negative
 await db
-  .update('products')
+  .updateTable('products')
   .decrement('stock', quantity)
   .where({ id: productId })
   .where('stock', '>=', quantity)
@@ -125,7 +125,7 @@ await db.updateMany(
 // Update multiple records with different values
 for (const update of updates) {
   await db
-    .update('products')
+    .updateTable('products')
     .set({ price: update.newPrice })
     .where({ id: update.productId })
     .execute()
@@ -135,7 +135,7 @@ for (const update of updates) {
 await db.transaction(async (trx) => {
   for (const update of updates) {
     await trx
-      .update('products')
+      .updateTable('products')
       .set({ price: update.newPrice })
       .where({ id: update.productId })
       .execute()
@@ -149,7 +149,7 @@ await db.transaction(async (trx) => {
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({
     login_count: sql`login_count + 1`,
     last_login: sql`NOW()`
@@ -163,7 +163,7 @@ await db
 ```typescript
 // Update JSON field
 await db
-  .update('users')
+  .updateTable('users')
   .set({
     preferences: sql`JSON_SET(preferences, '$.theme', 'dark')`
   })
@@ -212,7 +212,7 @@ const db = createQueryBuilder({
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({ deleted_at: new Date() })
   .where({ id: 1 })
   .execute()
@@ -222,7 +222,7 @@ await db
 
 ```typescript
 await db
-  .update('users')
+  .updateTable('users')
   .set({ deleted_at: null })
   .where({ id: 1 })
   .execute()
@@ -245,7 +245,7 @@ async function updateProfile(userId: number, updates: ProfileUpdate) {
   }
 
   const user = await db
-    .update('users')
+    .updateTable('users')
     .set(sanitized)
     .where({ id: userId })
     .returning(['id', 'name', 'bio', 'avatar_url', 'website'])
@@ -263,7 +263,7 @@ async function archiveOldPosts(daysOld: number) {
   cutoffDate.setDate(cutoffDate.getDate() - daysOld)
 
   const result = await db
-    .update('posts')
+    .updateTable('posts')
     .set({
       status: 'archived',
       archived_at: new Date()
@@ -296,7 +296,7 @@ async function processOrder(orderId: number, items: OrderItem[]) {
 
       // Decrement stock
       await trx
-        .update('products')
+        .updateTable('products')
         .decrement('stock', item.quantity)
         .where({ id: item.product_id })
         .execute()
@@ -304,7 +304,7 @@ async function processOrder(orderId: number, items: OrderItem[]) {
 
     // Update order status
     await trx
-      .update('orders')
+      .updateTable('orders')
       .set({ status: 'processing' })
       .where({ id: orderId })
       .execute()
@@ -322,7 +322,7 @@ async function updateWithVersion(
   currentVersion: number
 ) {
   const result = await db
-    .update(table)
+    .updateTable(table)
     .set({
       ...data,
       version: currentVersion + 1
@@ -348,10 +348,10 @@ async function updateWithVersion(
 
 ```typescript
 // Good: Targeted update with index
-await db.update('users').set({ active: false }).where({ id: 1 }).execute()
+await db.updateTable('users').set({ active: false }).where({ id: 1 }).execute()
 
 // Avoid: Table scan
-await db.update('users').set({ active: false }).where('name', 'LIKE', '%test%').execute()
+await db.updateTable('users').set({ active: false }).where('name', 'LIKE', '%test%').execute()
 ```
 
 ## Next Steps

--- a/docs/insert.md
+++ b/docs/insert.md
@@ -2,6 +2,70 @@
 title: Insert Queries
 description: Insert records into your database with type-safe queries.
 ---
+
+# Insert Queries
+
+Insert single or multiple records with full type safety.
+
+## Basic Insert
+
+```typescript
+import { createQueryBuilder } from 'bun-query-builder'
+
+const db = createQueryBuilder<typeof schema>({ schema, meta })
+
+// Insert a single record
+await db.create('users', {
+  name: 'John Doe',
+  email: 'john@example.com',
+  active: true,
+})
+
+// Insert returns the inserted record (with auto-generated ID)
+const newUser = await db.create('users', {
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+})
+
+console.log(newUser.id) // Auto-generated ID
+```
+
+## Insert Many Records
+
+Insert multiple records efficiently:
+
+```typescript
+// Insert many records at once
+await db.insertMany('users', [
+  { name: 'Alice', email: 'alice@example.com' },
+  { name: 'Bob', email: 'bob@example.com' },
+  { name: 'Charlie', email: 'charlie@example.com' },
+])
+```
+
+## Insert with Timestamps
+
+Timestamps are automatically added if configured:
+
+```typescript
+// If your model has timestamps enabled
+await db.create('users', {
+  name: 'John Doe',
+  email: 'john@example.com',
+})
+// created_at and updated_at are auto-populated
+```
+
+## Insert or Ignore
+
+Insert only if the record doesn't exist (based on unique constraints):
+
+```typescript
+// Insert or ignore on conflict
+await db.insertOrIgnore('users', {
+  email: 'existing@example.com',
+  name: 'New Name',
+})
 ```
 
 ## Upsert (Insert or Update)
@@ -66,7 +130,7 @@ const db = createQueryBuilder<typeof schema>({
 })
 
 // Hooks are called automatically
-await db.insert('users', {
+await db.create('users', {
   name: 'John Doe',
   email: 'john@example.com',
 })
@@ -98,7 +162,7 @@ Insert related records:
 ```typescript
 
 // First insert the user
-const user = await db.insert('users', {
+const user = await db.create('users', {
   name: 'John Doe',
   email: 'john@example.com',
 })
@@ -118,7 +182,7 @@ Wrap inserts in a transaction for atomicity:
 ```typescript
 
 await db.transaction(async (trx) => {
-  const user = await trx.insert('users', {
+  const user = await trx.create('users', {
     name: 'John Doe',
     email: 'john@example.com',
   })
@@ -178,7 +242,7 @@ const db = createQueryBuilder<typeof schema>({
 // Insert operations
 async function createUsers() {
   // Single insert
-  const admin = await db.insert('users', {
+  const admin = await db.create('users', {
     name: 'Admin User',
     email: 'admin@example.com',
     active: true,

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -2,6 +2,70 @@
 title: Joins
 description: Build type-safe JOIN queries with the query builder.
 ---
+
+# Joins
+
+Build type-safe JOIN queries to combine data from multiple tables.
+
+## Inner Join
+
+Returns only records that have matching values in both tables:
+
+```typescript
+import { createQueryBuilder } from 'bun-query-builder'
+
+const db = createQueryBuilder<typeof schema>({ schema, meta })
+
+// Basic inner join
+const results = await db
+  .selectFrom('posts')
+  .join('users', 'posts.user_id', 'users.id')
+  .get()
+
+// With column selection
+const postsWithAuthors = await db
+  .selectFrom('posts')
+  .select(['posts.title', 'posts.content', 'users.name AS author'])
+  .join('users', 'posts.user_id', 'users.id')
+  .get()
+```
+
+## Left Join
+
+Returns all records from the left table and matching records from the right table:
+
+```typescript
+// Left join - get all users with their posts (if any)
+const usersWithPosts = await db
+  .selectFrom('users')
+  .select(['users.name', 'posts.title'])
+  .leftJoin('posts', 'users.id', 'posts.user_id')
+  .get()
+
+// Users without posts will have null for posts.title
+```
+
+## Right Join
+
+Returns all records from the right table and matching records from the left table:
+
+```typescript
+// Right join
+const postsWithUsers = await db
+  .selectFrom('posts')
+  .select(['posts.title', 'users.name'])
+  .rightJoin('users', 'posts.user_id', 'users.id')
+  .get()
+```
+
+## Cross Join
+
+Returns the Cartesian product of both tables:
+
+```typescript
+// Cross join - combine every row from both tables
+const combinations = await db
+  .selectFrom('colors')
   .crossJoin('sizes')
   .get()
 

--- a/docs/raw-queries.md
+++ b/docs/raw-queries.md
@@ -2,6 +2,69 @@
 title: Raw Queries
 description: Execute raw SQL queries when you need full control.
 ---
+
+# Raw Queries
+
+Execute raw SQL queries when you need full control over the query structure.
+
+## Raw Select
+
+Execute a raw SELECT query:
+
+```typescript
+import { createQueryBuilder } from 'bun-query-builder'
+
+const db = createQueryBuilder<typeof schema>({ schema, meta })
+
+// Raw query with parameters
+const users = await db.raw(
+  'SELECT * FROM users WHERE active = ? AND age > ?',
+  [true, 18]
+)
+
+// Using named parameters
+const posts = await db.raw(
+  'SELECT * FROM posts WHERE user_id = $userId AND published = $published',
+  { userId: 1, published: true }
+)
+```
+
+## Raw Expressions in Queries
+
+Use raw expressions within the query builder:
+
+```typescript
+// Raw in select
+const results = await db
+  .selectFrom('users')
+  .selectRaw('COUNT(*) AS total, AVG(age) AS avg_age')
+  .get()
+
+// Raw in where
+const recentUsers = await db
+  .selectFrom('users')
+  .whereRaw('DATE(created_at) > DATE_SUB(NOW(), INTERVAL 30 DAY)')
+  .get()
+
+// Raw in order by
+const sorted = await db
+  .selectFrom('products')
+  .orderByRaw('price * quantity DESC')
+  .get()
+
+// Raw in group by
+const grouped = await db
+  .selectFrom('orders')
+  .select(['SUM(amount) AS total'])
+  .groupByRaw("strftime('%Y-%m', created_at)")
+  .get()
+
+// Raw in having
+const filtered = await db
+  .selectFrom('orders')
+  .select(['user_id', 'SUM(amount) AS total'])
+  .groupBy('user_id')
+  .havingRaw('SUM(amount) > 1000')
   .get()
 
 ```
@@ -16,7 +79,7 @@ For queries that cannot use parameterized values:
 const result = await db.unsafe(`
   SELECT * FROM users
   WHERE email LIKE '%@example.com'
-  ORDER BY created*at DESC
+  ORDER BY created_at DESC
   LIMIT 10
 `)
 
@@ -33,13 +96,13 @@ Execute non-query SQL statements:
 ```typescript
 
 // Create an index
-await db.execute('CREATE INDEX idx*users*email ON users(email)')
+await db.unsafe('CREATE INDEX idx_users_email ON users(email)')
 
 // Update statistics
-await db.execute('ANALYZE users')
+await db.unsafe('ANALYZE users')
 
 // Truncate table
-await db.execute('TRUNCATE TABLE logs')
+await db.unsafe('TRUNCATE TABLE logs')
 
 ```
 
@@ -110,14 +173,14 @@ Get typed results from raw queries:
 interface UserStats {
   country: string
   count: number
-  avg*age: number
+  avg_age: number
 }
 
 const stats = await db.raw<UserStats[]>(`
   SELECT
     country,
     COUNT(*) AS count,
-    AVG(age) AS avg*age
+    AVG(age) AS avg_age
   FROM users
   GROUP BY country
   ORDER BY count DESC
@@ -125,7 +188,7 @@ const stats = await db.raw<UserStats[]>(`
 
 // stats is typed as UserStats[]
 stats.forEach((s) => {
-  console.log(`${s.country}: ${s.count} users, avg age ${s.avg*age}`)
+  console.log(`${s.country}: ${s.count} users, avg age ${s.avg_age}`)
 })
 
 ```
@@ -137,7 +200,7 @@ Use prepared statements for repeated queries:
 ```typescript
 
 // Prepare a statement
-const stmt = db.prepare('SELECT * FROM users WHERE id = ?')
+const stmt = db.unsafe('SELECT * FROM users WHERE id = ?')
 
 // Execute multiple times efficiently
 const user1 = await stmt.get([1])
@@ -158,16 +221,16 @@ Execute raw queries within transactions:
 await db.transaction(async (trx) => {
   // Raw insert
   await trx.raw(
-    'INSERT INTO audit*log (action, user*id) VALUES (?, ?)',
+    'INSERT INTO audit_log (action, user_id) VALUES (?, ?)',
     ['login', userId]
   )
 
   // Regular query builder
-  await trx.update('users', userId, { last*login: new Date() })
+  await trx.updateTable('users').set({ last_login: new Date() }).where({ id: userId })
 
   // Raw update
   await trx.raw(
-    'UPDATE statistics SET login*count = login*count + 1 WHERE user*id = ?',
+    'UPDATE statistics SET login_count = login_count + 1 WHERE user_id = ?',
     [userId]
   )
 })
@@ -180,8 +243,8 @@ Analyze query execution plans:
 
 ```typescript
 
-// Get query execution plan
-const explain = await db.explain('SELECT * FROM users WHERE active = true')
+// Get query execution plan — `explain()` terminates a builder chain
+const explain = await db.selectFrom('users').where({ active: true }).explain()
 console.log(explain)
 
 // Using CLI
@@ -206,7 +269,7 @@ const models = {
       email: { validation: { rule: {} } },
       age: { validation: { rule: {} } },
       country: { validation: { rule: {} } },
-      created*at: { validation: { rule: {} } },
+      created_at: { validation: { rule: {} } },
     },
   },
 }
@@ -220,26 +283,26 @@ async function getComplexAnalytics() {
   // Complex aggregation not easily expressible with query builder
   interface MonthlyStats {
     month: string
-    new*users: number
-    returning*users: number
-    total*active: number
+    new_users: number
+    returning_users: number
+    total_active: number
   }
 
   const stats = await db.raw<MonthlyStats[]>(`
-    WITH monthly*users AS (
+    WITH monthly_users AS (
       SELECT
-        strftime('%Y-%m', created*at) AS month,
+        strftime('%Y-%m', created_at) AS month,
         id,
-        COUNT(*) OVER (PARTITION BY id) AS visit*count
+        COUNT(*) OVER (PARTITION BY id) AS visit_count
       FROM users
-      WHERE created*at >= date('now', '-12 months')
+      WHERE created_at >= date('now', '-12 months')
     )
     SELECT
       month,
-      SUM(CASE WHEN visit*count = 1 THEN 1 ELSE 0 END) AS new*users,
-      SUM(CASE WHEN visit*count > 1 THEN 1 ELSE 0 END) AS returning*users,
-      COUNT(*) AS total*active
-    FROM monthly*users
+      SUM(CASE WHEN visit_count = 1 THEN 1 ELSE 0 END) AS new_users,
+      SUM(CASE WHEN visit_count > 1 THEN 1 ELSE 0 END) AS returning_users,
+      COUNT(*) AS total_active
+    FROM monthly_users
     GROUP BY month
     ORDER BY month
   `)
@@ -250,7 +313,7 @@ async function getComplexAnalytics() {
     .selectRaw(`
       COUNT(*) AS total,
       COUNT(CASE WHEN active = 1 THEN 1 END) AS active,
-      AVG(age) AS avg*age
+      AVG(age) AS avg_age
     `)
     .first()
 
@@ -259,8 +322,8 @@ async function getComplexAnalytics() {
     `
     SELECT
       country,
-      COUNT(*) AS user*count,
-      AVG(age) AS avg*age
+      COUNT(*) AS user_count,
+      AVG(age) AS avg_age
     FROM users
     WHERE active = ?
     GROUP BY country

--- a/docs/select.md
+++ b/docs/select.md
@@ -2,6 +2,68 @@
 title: Select Queries
 description: Build type-safe SELECT queries with the query builder.
 ---
+
+# Select Queries
+
+Build type-safe SELECT queries with full column and table inference.
+
+## Basic Select
+
+```typescript
+import { createQueryBuilder, buildDatabaseSchema, buildSchemaMeta } from 'bun-query-builder'
+
+const db = createQueryBuilder<typeof schema>({ schema, meta })
+
+// Select all columns from a table
+const users = await db.selectFrom('users').get()
+
+// Select specific columns
+const names = await db
+  .selectFrom('users')
+  .select(['name', 'email'])
+  .get()
+
+// Select with alias
+const data = await db
+  .selectFrom('users')
+  .select(['name AS userName', 'email AS userEmail'])
+  .get()
+```
+
+## Where Clauses
+
+```typescript
+// Simple where
+const activeUsers = await db
+  .selectFrom('users')
+  .where({ active: true })
+  .get()
+
+// Where with operator
+const adults = await db
+  .selectFrom('users')
+  .where('age', '>=', 18)
+  .get()
+
+// Multiple conditions (AND)
+const activeAdults = await db
+  .selectFrom('users')
+  .where({ active: true })
+  .andWhere('age', '>=', 18)
+  .get()
+
+// OR conditions
+const results = await db
+  .selectFrom('users')
+  .where({ role: 'admin' })
+  .orWhere({ role: 'moderator' })
+  .get()
+```
+
+## Ordering Results
+
+```typescript
+// Order ascending (default)
 const users = await db
   .selectFrom('users')
   .orderBy('name')

--- a/docs/update.md
+++ b/docs/update.md
@@ -2,9 +2,75 @@
 title: Update Queries
 description: Update records in your database with type-safe queries.
 ---
+
+# Update Queries
+
+Update records with type-safe queries and automatic timestamp handling.
+
+## Basic Update
+
+```typescript
+import { createQueryBuilder } from 'bun-query-builder'
+
+const db = createQueryBuilder<typeof schema>({ schema, meta })
+
+// Update a single record by ID
+await db
+  .updateTable('users')
+  .set({
+    name: 'Updated Name',
+  })
+  .where({ id: 1 })
+  .execute()
+
+// Update with where clause
+await db
+  .updateTable('users')
+  .set({ active: false })
+  .where({ email: 'old@example.com' })
+  .execute()
+```
+
+## Update Multiple Records
+
+```typescript
+// Update all matching records
+await db
+  .updateTable('users')
+  .set({ status: 'inactive' })
+  .where('last_login', '<', '2024-01-01')
+  .execute()
+
+// Update with multiple conditions
+await db
+  .updateTable('users')
+  .set({ verified: true })
+  .where({ active: true })
+  .andWhere({ email_verified: true })
+  .execute()
+```
+
+## Update Many by Condition
+
+```typescript
+// Update many records matching conditions
+await db.updateMany('users', { active: false }, { status: 'archived' })
+// Updates all users where active = false, setting status = 'archived'
+```
+
+## Increment and Decrement
+
+```typescript
+// Increment a column value
+await db
+  .updateTable('posts')
+  .increment('views', 1)
+  .where({ id: 123 })
+  .execute()
+
 // Decrement a column value
 await db
-  .updateFrom('products')
+  .updateTable('products')
   .decrement('stock', 5)
   .where({ id: 456 })
   .execute()
@@ -18,9 +84,13 @@ If your model has timestamps enabled, `updated_at` is automatically updated:
 ```typescript
 
 // updated_at is automatically set
-await db.update('users', 1, {
-  name: 'New Name',
-})
+await db
+  .updateTable('users')
+  .set({
+    name: 'New Name',
+  })
+  .where({ id: 1 })
+  .execute()
 // Equivalent to: SET name = 'New Name', updated_at = NOW()
 
 ```
@@ -32,7 +102,7 @@ Get the updated record back:
 ```typescript
 
 const updated = await db
-  .updateFrom('users')
+  .updateTable('users')
   .set({ name: 'Updated Name' })
   .where({ id: 1 })
   .returning(['id', 'name', 'updated_at'])
@@ -51,7 +121,7 @@ Update only if conditions are met:
 
 // Update only active users
 const result = await db
-  .updateFrom('users')
+  .updateTable('users')
   .set({ newsletter_sent: true })
   .where({ active: true })
   .where({ newsletter_sent: false })
@@ -90,16 +160,20 @@ const db = createQueryBuilder<typeof schema>({
 ```typescript
 
 // Update a JSON column
-await db.update('users', 1, {
-  preferences: {
-    theme: 'dark',
-    notifications: true,
-  },
-})
+await db
+  .updateTable('users')
+  .set({
+    preferences: {
+      theme: 'dark',
+      notifications: true,
+    },
+  })
+  .where({ id: 1 })
+  .execute()
 
 // Update nested JSON (if supported by your database)
 await db
-  .updateFrom('users')
+  .updateTable('users')
   .set({
     'preferences.theme': 'light',
   })
@@ -116,7 +190,7 @@ Efficiently update multiple records:
 
 // Update many records with the same values
 await db
-  .updateFrom('posts')
+  .updateTable('posts')
   .set({ published: true, published_at: new Date() })
   .where('id', 'IN', [1, 2, 3, 4, 5])
   .execute()
@@ -129,13 +203,17 @@ await db
 
 await db.transaction(async (trx) => {
   // Update user
-  await trx.update('users', userId, {
-    status: 'premium',
-  })
+  await trx
+    .updateTable('users')
+    .set({
+      status: 'premium',
+    })
+    .where({ id: userId })
+    .execute()
 
   // Update related subscription
   await trx
-    .updateFrom('subscriptions')
+    .updateTable('subscriptions')
     .set({ active: true, upgraded_at: new Date() })
     .where({ user_id: userId })
     .execute()
@@ -203,20 +281,24 @@ const db = createQueryBuilder<typeof schema>({
 // Various update operations
 async function updateUsers() {
   // Update single record
-  await db.update('users', 1, {
-    name: 'John Smith',
-  })
+  await db
+    .updateTable('users')
+    .set({
+      name: 'John Smith',
+    })
+    .where({ id: 1 })
+    .execute()
 
   // Update with conditions
   await db
-    .updateFrom('users')
+    .updateTable('users')
     .set({ status: 'inactive' })
     .where('last_login', '<', '2024-01-01')
     .execute()
 
   // Increment login count
   await db
-    .updateFrom('users')
+    .updateTable('users')
     .increment('login_count', 1)
     .where({ id: 1 })
     .execute()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -136,7 +136,7 @@ await db
 // Conditional delete (Chris's data cleanup)
 await db
   .deleteFrom('sessions')
-  .where(['last_activity', '<', new Date(Date.now() - 30 _ 24 _ 60 _ 60 _ 1000)])
+  .where(['last_activity', '<', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)])
   .execute()
 ```
 
@@ -381,7 +381,7 @@ query-builder file ./scripts/analytics.sql --output results.json
 
 ```bash
 # Performance analysis for Chris's dashboard queries
-query-builder explain "SELECT _ FROM users JOIN teams ON users.team_id = teams.id WHERE users.active = true"
+query-builder explain "SELECT * FROM users JOIN teams ON users.team_id = teams.id WHERE users.active = true"
 
 # Avery's e-commerce query optimization
 query-builder explain "SELECT p._, c.name as category_name FROM products p JOIN categories c ON p.category_id = c.id WHERE p.featured = true"
@@ -394,7 +394,7 @@ query-builder explain --analyze "SELECT u.name, COUNT(p.id) as post_count FROM u
 
 ```bash
 # Parameterized queries (use with caution)
-query-builder unsafe "SELECT _ FROM users WHERE id = $1 AND team_id = $2" --params "[1, 3]"
+query-builder unsafe "SELECT * FROM users WHERE id = $1 AND team_id = $2" --params "[1, 3]"
 
 # Bulk operations with transaction support
 query-builder file ./scripts/bulk_update.sql --transaction --batch-size 1000

--- a/packages/bun-query-builder/README.md
+++ b/packages/bun-query-builder/README.md
@@ -33,7 +33,7 @@ await QueryBuilder
 
 // Update
 await QueryBuilder
-  .update('users')
+  .updateTable('users')
   .set({ active: false })
   .where('id', '=', 1)
   .execute()


### PR DESCRIPTION
The write-path documentation taught an API the builder has never had. Every sample on these pages throws on its first line.

## Methods that do not exist

`db.update`, `db.insert`, `db.delete`, `db.execute`, `db.truncate`, `db.prepare`, `db.explain`, `db.beginTransaction`, `db.subquery`, `db.restore`, `db.forceDelete`, plus the chained `.update()` / `.updateFrom()` forms — ~40 call sites. `docs/api/reference.md` listed `update(table)` in its method table, and `packages/bun-query-builder/README.md` used one in its example.

I enumerated the 62 methods the builder actually exports and mapped against that, so the replacements are the real surface rather than a guess:

| documented | actual |
| --- | --- |
| `db.update(t, id, v)` | `db.updateTable(t).set(v).where({ id })` |
| `db.insert(t, v)` | `db.create(t, v)` — identical signature |
| `db.delete(t, id)` | `db.remove(t, id)` — identical signature |
| `db.execute(sql)` / `db.prepare(sql)` | `db.unsafe(sql)` |
| `db.explain(sql)` | `db.selectFrom(t).where(…).explain()` |
| `db.truncate(t)` | `Model.truncate()`, or `db.unsafe('TRUNCATE TABLE t')` |
| `db.restore(t, id)` | `model.restore()`, or clear the column via `updateTable` |
| `db.subquery(q)` | `db.raw('(SELECT …)', params)` |

## Not everything was a rename

There is no manual transaction control — no `beginTransaction`/`commit`/`rollback`, and no `rollbackToSavepoint`. Both `transaction()` and `savepoint()` own their lifecycle through a callback: return to commit, throw to roll back. Those sections were rewritten around the real API, including the batch-checkpoint example, which was built entirely on the imaginary one and is now a per-chunk `savepoint()` that actually does what the prose claimed.

`restore` and `truncate` are model-layer operations, not builder methods, and are shown there now with the query-builder equivalent alongside.

While rewriting the transaction docs I added the warning that the sibling bug in #1065 makes concrete: use `tx`, not `db`, inside the callback — `db` holds a different connection, so work issued through it is not part of the transaction.

## Two mechanical corruptions, both from `eaa3b24 chore: fix lint errors`

**Six pages lost their heads.** `select`, `insert`, `update`, `delete`, `joins`, `raw-queries` each began mid-code-block — no H1, no intro, the first example's opening fence and the whole "Basic …" section gone, so the page opened on an orphaned `.get()`. Restored from `eaa3b24^`, anchored on the surviving body so the edits those files have had since are preserved. Fence counts are now even on every page (they weren't).

**132 identifiers had `_` rewritten to `*`** — `created*at`, `user*id`, `avg*age` — and the multiplication in `7 * 24 * 60 * 60 * 1000` went the other way to `7 _ 24 _ …`. `docs/advanced/distributed.md:554` had `60 _ 60 * 1000`, half-converted, which is what gives the cause away. Fixed with a guard that leaves `SELECT *`, `COUNT(*)` and `**bold**` untouched; `/_ ... _/` block comments restored to `/* ... */`.

## Verification

Every `db.` / `trx.` / `tx.` / `sp.` call across `docs/` and both READMEs now resolves to a real exported method — checked mechanically against the live method list, not by eye. Fence parity is even across all pages. No `[A-Za-z0-9]*[A-Za-z0-9]` mangling remains.

Docs-only: typecheck 0, lint 0 errors, suite 1698 pass / 4 skip / 0 fail, unchanged.

Worth pairing with a docs-lint test so this class can't come back silently — noted as follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
