### PR TITLE
fix(client): honour the hooks a builder was constructed with

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -4,7 +4,7 @@
 import type { SchemaMeta } from './meta'
 import type { ResolvedPivot } from './pivot'
 import type { DatabaseSchema } from './schema'
-import type { QueryBuilderOptions } from './types'
+import type { QueryBuilderOptions, QueryHooks } from './types'
 import { config, getPlaceholder, getPlaceholders, isMysqlLike, setConfig } from './config'
 import type { DriverConnection } from './db'
 import { bunSql, getOrCreateBunSql, resetConnection } from './db'
@@ -2533,6 +2533,21 @@ interface InternalState {
   schema?: any
   txDefaults?: TransactionOptions
   /**
+   * Lifecycle hooks for this builder specifically.
+   *
+   * `createQueryBuilder({ schema, meta, hooks })` is the form the docs have
+   * shown for a long time, and it did not exist: `hooks` was not a member of
+   * this interface, so the call was a `TS2353` excess-property error. The
+   * obvious workaround made it worse rather than better — `as any` compiled,
+   * and then the hooks never fired, because every hook site read the
+   * process-wide `config.hooks` and nothing ever looked at builder state. A
+   * builder that appeared configured silently ignored every hook it was given.
+   *
+   * These merge OVER `config.hooks` per key (see `activeHooks`), so a global
+   * logger or tracer keeps firing for builders that only override one hook.
+   */
+  hooks?: QueryHooks
+  /**
    * Set on the builder handed to a `transaction()` callback. A nested
    * `transaction()` must open a SAVEPOINT (`tx.savepoint(...)`) rather than a
    * new top-level transaction (`tx.begin(...)`) — Bun's driver throws "cannot
@@ -2766,6 +2781,25 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
   const meta = state?.meta
   const schema = state?.schema
 
+  /**
+   * The hooks this builder should fire.
+   *
+   * Read through this rather than reaching for `config.hooks` directly, for the
+   * same reason statements go through `_sql`: a builder can be handed its own,
+   * and ignoring them makes a configured builder silently do nothing.
+   *
+   * Resolved per call, not captured once, because `setConfig({ hooks })` may
+   * land after the builder is constructed — the usual
+   * `export const db = createQueryBuilder(...)` at module scope followed by
+   * configuration at boot. Merged per key so a global logger still fires for a
+   * builder that overrides only `beforeCreate`.
+   */
+  function activeHooks(): QueryHooks | undefined {
+    if (!state?.hooks)
+      return config.hooks
+    return { ...config.hooks, ...state.hooks }
+  }
+
   // `whereCreatedAt` → `created_at` resolution for the dynamic-where Proxy,
   // cached per (table, prop): the schema is fixed for this builder, and the
   // resolution (regex strip + snake-case + column scan) otherwise re-runs on
@@ -2894,7 +2928,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
   }
 
   function runWithHooks<T = any>(q: any, kind: 'select' | 'insert' | 'update' | 'delete' | 'raw', opts?: { signal?: AbortSignal, timeoutMs?: number }): Promise<T> {
-    const hooks = config.hooks
+    const hooks = activeHooks()
     const slowMs = hooks?.slowQueryThresholdMs
     const slowEnabled = slowMs != null && slowMs >= 0
     const hasSlowQuery = Boolean(hooks?.onSlowQuery || slowEnabled)
@@ -5605,7 +5639,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return text
       },
       async get() {
-        const hooks = config.hooks
+        const hooks = activeHooks()
         const hasQueryHooks = hooks && (hooks.onQueryStart || hooks.onQueryEnd || hooks.onQueryError || hooks.startSpan || hasSlowQueryHook(hooks))
 
         // Ultra-fast path: skip unsafe() entirely, use _prepareStatement for direct stmt access
@@ -5683,7 +5717,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       },
       async first() {
         // Ultra-fast path: skip overhead, prepare statement directly from text
-        const fHooks = config.hooks
+        const fHooks = activeHooks()
         const fHasQueryHooks = fHooks && (fHooks.onQueryStart || fHooks.onQueryEnd || fHooks.onQueryError || fHooks.startSpan || hasSlowQueryHook(fHooks))
         if (!config.softDeletes?.enabled && !useCache && !timeoutMs && !abortSignal && !fHasQueryHooks) {
           const prepareFn = _sql._prepareStatement
@@ -5778,7 +5812,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         }
 
         // Ultra-fast path
-        const cHooks = config.hooks
+        const cHooks = activeHooks()
         const cHasHooks = cHooks && (cHooks.onQueryStart || cHooks.onQueryEnd || cHooks.onQueryError || cHooks.startSpan || hasSlowQueryHook(cHooks))
         if (!config.softDeletes?.enabled && !useCache && !timeoutMs && !abortSignal && !cHasHooks) {
           const prepareFn = _sql._prepareStatement
@@ -5804,7 +5838,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           : `SELECT AVG(${column}) as a FROM ${table}`
 
         // Ultra-fast path
-        const aHooks = config.hooks
+        const aHooks = activeHooks()
         const aHasHooks = aHooks && (aHooks.onQueryStart || aHooks.onQueryEnd || aHooks.onQueryError || aHooks.startSpan || hasSlowQueryHook(aHooks))
         if (!config.softDeletes?.enabled && !useCache && !timeoutMs && !abortSignal && !aHasHooks) {
           const prepareFn = _sql._prepareStatement
@@ -6496,7 +6530,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         },
         execute() {
           // Ultra-fast path: use _prepareStatement to skip unsafe() and runWithHooks overhead
-          const hooks = config.hooks
+          const hooks = activeHooks()
           const hasHooks = hooks && (hooks.onQueryStart || hooks.onQueryEnd || hooks.onQueryError || hooks.startSpan || hooks.beforeCreate || hooks.afterCreate || hasSlowQueryHook(hooks))
           if (!hasHooks) {
             const prepareFn = _sql._prepareStatement
@@ -6914,7 +6948,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         },
         async execute() {
           try {
-            await config.hooks?.beforeDelete?.({ table: String(table), where: whereCondition })
+            await activeHooks()?.beforeDelete?.({ table: String(table), where: whereCondition })
           }
           catch (err) {
             throw err
@@ -6923,7 +6957,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           const result = mutationCount(await runWithHooks(ensureDelBuilt(), 'delete'))
 
           try {
-            await config.hooks?.afterDelete?.({ table: String(table), where: whereCondition, result })
+            await activeHooks()?.afterDelete?.({ table: String(table), where: whereCondition, result })
           }
           catch {}
 
@@ -7049,7 +7083,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
     },
     async reserve() {
       const reserved = await (bunSql as any).reserve()
-      const qb = createQueryBuilder<DB>({ sql: reserved, meta, schema }) as any
+      const qb = createQueryBuilder<DB>({ sql: reserved, meta, schema, hooks: state?.hooks }) as any
       qb.release = () => reserved.release()
       return qb
     },
@@ -7117,7 +7151,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         opts.logger?.({ type: 'start', attempt })
         const start = Date.now()
         return await (txConn as any)[txMethod](async (tx: any) => {
-          const qb = createQueryBuilder<DB>({ sql: tx, meta, schema, inTransaction: true })
+          const qb = createQueryBuilder<DB>({ sql: tx, meta, schema, hooks: state?.hooks, inTransaction: true })
 
           // Transaction isolation + read-only mode — dialect-specific
           // SQL, with a clear "not supported" path for SQLite. The
@@ -7226,14 +7260,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       return await s.savepoint(async (sp: any) => {
         // Carry the flag: a savepoint body is still inside a transaction, so a
         // nested savepoint()/transaction() from here must nest, not begin.
-        const qb = createQueryBuilder<DB>({ sql: sp, meta, schema, inTransaction: true })
+        const qb = createQueryBuilder<DB>({ sql: sp, meta, schema, hooks: state?.hooks, inTransaction: true })
         return await fn(qb)
       })
     },
     async beginDistributed(name, fn) {
       const txConn: any = state?.sql ?? bunSql
       const res = await (txConn as any).beginDistributed(name, async (tx: any) => {
-        const qb = createQueryBuilder<DB>({ sql: tx, meta, schema })
+        const qb = createQueryBuilder<DB>({ sql: tx, meta, schema, hooks: state?.hooks })
         return await fn(qb)
       })
       return res as any
@@ -7382,13 +7416,13 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
     async rawQuery(query: string) {
       const start = Date.now()
       try {
-        config.hooks?.onQueryStart?.({ sql: query, kind: 'raw' })
+        activeHooks()?.onQueryStart?.({ sql: query, kind: 'raw' })
         const res = await (_sql as any).unsafe(query)
-        config.hooks?.onQueryEnd?.({ sql: query, durationMs: Date.now() - start, kind: 'raw' })
+        activeHooks()?.onQueryEnd?.({ sql: query, durationMs: Date.now() - start, kind: 'raw' })
         return res
       }
       catch (err) {
-        config.hooks?.onQueryError?.({ sql: query, error: err, durationMs: Date.now() - start, kind: 'raw' })
+        activeHooks()?.onQueryError?.({ sql: query, error: err, durationMs: Date.now() - start, kind: 'raw' })
         throw err
       }
     },
@@ -7397,7 +7431,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
 
       // beforeCreate hook
       try {
-        await config.hooks?.beforeCreate?.({ table: String(table), data: values })
+        await activeHooks()?.beforeCreate?.({ table: String(table), data: values })
       }
       catch (err) {
         throw err
@@ -7424,7 +7458,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
 
         // afterCreate hook
         try {
-          await config.hooks?.afterCreate?.({ table: String(table), data: values, result: row })
+          await activeHooks()?.afterCreate?.({ table: String(table), data: values, result: row })
         }
         catch {}
 
@@ -7448,7 +7482,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
 
         // afterCreate hook
         try {
-          await config.hooks?.afterCreate?.({ table: String(table), data: values, result: row })
+          await activeHooks()?.afterCreate?.({ table: String(table), data: values, result: row })
         }
         catch {}
 

--- a/packages/bun-query-builder/test/client.builder-hooks.test.ts
+++ b/packages/bun-query-builder/test/client.builder-hooks.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, config, createQueryBuilder, setConfig } from '../src'
+import { resetConnection } from '../src/db'
+
+/**
+ * `createQueryBuilder({ hooks })` — per-builder lifecycle hooks.
+ *
+ * The form has been in the docs and the README for a long time and did not
+ * exist: `hooks` was not a member of the builder's internal state, so the call
+ * was a `TS2353` excess-property error. What made it worth a test rather than a
+ * type tweak is the workaround. `as any` compiled, and then the hooks never
+ * fired — every hook site read the process-wide `config.hooks` and nothing
+ * looked at builder state — so a builder that appeared configured silently
+ * ignored every hook it had been handed. A silent no-op is worse than the
+ * compile error in front of it.
+ */
+
+const schema = buildDatabaseSchema({
+  User: {
+    name: 'User',
+    table: 'users',
+    primaryKey: 'id',
+    attributes: { id: { validation: { rule: {} } }, name: { validation: { rule: {} } } },
+  },
+} as any)
+
+let saved: { dialect: any, database: any, hooks: any }
+
+beforeEach(async () => {
+  saved = { dialect: config.dialect, database: { ...config.database }, hooks: config.hooks }
+  setConfig({ dialect: 'sqlite', database: { database: ':memory:' }, hooks: {} })
+  resetConnection()
+  await createQueryBuilder<typeof schema>({ schema })
+    .unsafe('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)')
+})
+
+afterEach(() => {
+  setConfig({ dialect: saved.dialect, database: saved.database, hooks: saved.hooks } as any)
+  resetConnection()
+})
+
+describe('createQueryBuilder({ hooks })', () => {
+  it('fires the hooks it was given', async () => {
+    const seen: string[] = []
+    // No cast: this is the compile error the issue was about.
+    const db = createQueryBuilder<typeof schema>({
+      schema,
+      hooks: { onQueryStart: e => void seen.push(String(e.kind)) },
+    })
+
+    await db.selectFrom('users').execute()
+
+    expect(seen).toEqual(['select'])
+  })
+
+  it('leaves a builder without hooks on the global ones', async () => {
+    const seen: string[] = []
+    setConfig({ hooks: { onQueryStart: () => void seen.push('global') } })
+
+    await createQueryBuilder<typeof schema>({ schema }).selectFrom('users').execute()
+
+    expect(seen).toEqual(['global'])
+  })
+
+  it('merges per key, so a global hook still fires when a builder overrides a different one', async () => {
+    // The reason this merges rather than replaces: an app-wide logger or tracer
+    // should not go quiet because one builder wanted a `beforeCreate`.
+    const globals: string[] = []
+    const locals: string[] = []
+    setConfig({ hooks: { onQueryStart: () => void globals.push('global') } })
+
+    const db = createQueryBuilder<typeof schema>({
+      schema,
+      hooks: { onQueryEnd: () => void locals.push('local') },
+    })
+    await db.selectFrom('users').execute()
+
+    expect(globals).toEqual(['global'])
+    expect(locals).toEqual(['local'])
+  })
+
+  it('lets a builder hook override the global one of the same name', async () => {
+    const order: string[] = []
+    setConfig({ hooks: { onQueryStart: () => void order.push('global') } })
+
+    const db = createQueryBuilder<typeof schema>({
+      schema,
+      hooks: { onQueryStart: () => void order.push('builder') },
+    })
+    await db.selectFrom('users').execute()
+
+    expect(order).toEqual(['builder'])
+  })
+
+  it('passes its hooks down to the transaction callback builder', async () => {
+    // The tx callback gets a NEW builder around the transaction's connection;
+    // without threading, it silently lost the parent's hooks.
+    const seen: string[] = []
+    const db = createQueryBuilder<typeof schema>({
+      schema,
+      hooks: { onQueryStart: () => void seen.push('tx') },
+    })
+
+    await db.transaction(async (tx) => {
+      await tx.selectFrom('users').execute()
+    })
+
+    expect(seen.length).toBeGreaterThan(0)
+  })
+
+  it('sees hooks configured after the builder was constructed', async () => {
+    // `export const db = createQueryBuilder(...)` at module scope, then
+    // `setConfig({ hooks })` at boot, is the ordinary shape of an app. Capturing
+    // hooks once at construction would silently miss all of them.
+    const seen: string[] = []
+    const db = createQueryBuilder<typeof schema>({ schema })
+
+    setConfig({ hooks: { onQueryStart: () => void seen.push('late') } })
+    await db.selectFrom('users').execute()
+
+    expect(seen).toEqual(['late'])
+  })
+})


### PR DESCRIPTION
Closes #1071.

`createQueryBuilder({ schema, meta, hooks })` appears in the README and a dozen doc pages, and did not exist — `hooks` was not a member of the builder's internal state, so the call was a `TS2353` excess-property error.

**The compile error was the harmless half.** `as any` silences it, and then the hooks never fire: every hook site read the process-wide `config.hooks` and nothing looked at builder state. A builder that appeared configured ignored every hook it was handed, with no error at any point. A silent no-op is worse than the compile error standing in front of it.

## The fix

`hooks` joins the builder's state, and the 16 read sites go through an `activeHooks()` resolver instead of reaching for `config.hooks` directly — the same rule `_sql` follows after #1065, for the same reason: a builder can be handed its own, and ignoring that makes it silently do nothing.

Two decisions worth calling out, both behaviour rather than plumbing:

- **Hooks merge over the global ones per key.** An app-wide logger or tracer shouldn't go quiet because one builder wanted a `beforeCreate`. A builder hook of the same name still takes precedence.
- **They resolve per call, not once at construction.** `export const db = createQueryBuilder(...)` at module scope followed by `setConfig({ hooks })` at boot is the ordinary shape of an app; capturing at construction would silently miss every hook in it.

`transaction`, `savepoint` and `reserve` each build a fresh builder around a different connection — all three now carry the parent's hooks, so hooks don't evaporate on entering a transaction.

## Tests

Six cases: the previously-impossible form fires (no cast), a builder without hooks still gets the global ones, per-key merge, same-name override, transaction inheritance, and hooks configured after construction.

Verified they discriminate: against the unfixed `client.ts`, **4 of the 6 fail**.

Typecheck 0, lint 0 errors, suite **1705 pass / 4 skip / 0 fail**.

One note for review: I hit an infinite recursion partway through — the mechanical rewrite of `config.hooks` → `activeHooks()` also rewrote the reference *inside* `activeHooks` itself, which showed up as `RangeError: Maximum call stack size exceeded` on the first query. Fixed and covered by the tests, but worth a glance at that function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
