### PR TITLE
fix(orm): an eager load that resolves nothing should say so

### DIFF
--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -1451,6 +1451,69 @@ interface ResolvedRelation {
   pivotTimestamps?: boolean
 }
 
+/**
+ * Relation kinds `resolveRelation` can actually resolve, and the ones a model
+ * may declare. `ModelDefinition` accepts considerably more than the resolver
+ * implements, which is the more confusing half of the silent-miss problem
+ * below: a `morphMany` is accepted by the types, encouraged by autocomplete,
+ * and then does nothing at all.
+ */
+const RESOLVABLE_RELATION_KINDS = ['hasMany', 'hasOne', 'belongsTo', 'belongsToMany'] as const
+const DECLARABLE_RELATION_KINDS = [
+  ...RESOLVABLE_RELATION_KINDS,
+  'hasOneThrough',
+  'hasManyThrough',
+  'morphOne',
+  'morphMany',
+  'morphTo',
+  'morphToMany',
+  'morphedByMany',
+] as const
+
+/** Every relation name declared under `kind`, in declaration order. */
+function relationNamesFor(definition: ModelDefinition, kind: string): string[] {
+  const rel = (definition as unknown as Record<string, unknown>)[kind]
+  if (!rel)
+    return []
+  if (Array.isArray(rel))
+    return rel.map(item => (typeof item === 'string' ? item : String((item as any)?.model ?? ''))).filter(Boolean)
+  if (typeof rel === 'object')
+    return Object.keys(rel as Record<string, unknown>)
+  if (typeof rel === 'string')
+    return [rel]
+  return []
+}
+
+/**
+ * Why an eager load found nothing, phrased for the person who typed the name.
+ *
+ * `eagerLoadRelation` used to `return` here. A misspelled relation loaded
+ * nothing and said nothing — indistinguishable from a relation that genuinely
+ * has no rows — and so did every relation kind the resolver does not implement.
+ * Both are mistakes worth surfacing, and they need different wording: one is a
+ * typo, the other is a gap in this library that no amount of squinting at the
+ * model will explain.
+ */
+function unresolvedRelationMessage(definition: ModelDefinition, relationName: string): string {
+  const model = definition.name ?? definition.table ?? 'model'
+
+  const declaredUnder = DECLARABLE_RELATION_KINDS.filter(kind =>
+    relationNamesFor(definition, kind).some(n => n.toLowerCase() === relationName.toLowerCase()),
+  )
+  const unsupported = declaredUnder.filter(k => !(RESOLVABLE_RELATION_KINDS as readonly string[]).includes(k))
+
+  if (unsupported.length > 0) {
+    return `[orm] '${model}' declares '${relationName}' as ${unsupported.join('/')}, which eager loading does not support yet. `
+      + `Supported kinds: ${RESOLVABLE_RELATION_KINDS.join(', ')}. `
+      + `Load it with a manual query for now — see stacksjs/bun-query-builder#1068.`
+  }
+
+  const available = RESOLVABLE_RELATION_KINDS.flatMap(kind => relationNamesFor(definition, kind))
+  return available.length > 0
+    ? `[orm] '${model}' has no relation '${relationName}'. Available: ${available.join(', ')}.`
+    : `[orm] '${model}' has no relation '${relationName}' — it declares no relations at all.`
+}
+
 function resolveRelation(definition: ModelDefinition, relationName: string): ResolvedRelation | null {
   const parentName = definition.name
   const parentTable = definition.table
@@ -2527,7 +2590,8 @@ class ModelQueryBuilder<
         relationCache.clear()
       relationCache.set(cacheKey, rel)
     }
-    if (!rel) return
+    if (!rel)
+      throw new Error(unresolvedRelationMessage(this._definition as ModelDefinition, relationName))
 
     if (rel.type === 'hasMany' || rel.type === 'hasOne') {
       // Get parent IDs

--- a/packages/bun-query-builder/test/orm.unknown-relation.test.ts
+++ b/packages/bun-query-builder/test/orm.unknown-relation.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression coverage for stacksjs/bun-query-builder#1068.
+ *
+ * `eagerLoadRelation` used to `return` when it could not resolve a relation
+ * name. A misspelling therefore loaded nothing and reported nothing, which is
+ * indistinguishable from a relation that genuinely has no rows — the property
+ * is simply absent from the result and no error is raised anywhere.
+ *
+ * The same silence covered every relation kind the resolver does not implement.
+ * `ModelDefinition` accepts `morphOne`, `morphMany`, `morphTo`, `morphToMany`,
+ * `morphedByMany`, `hasOneThrough` and `hasManyThrough`; `resolveRelation`
+ * handles four kinds — `hasMany`, `hasOne`, `belongsTo`, `belongsToMany`.
+ * Declaring any of the others type-checks, autocompletes, and does nothing.
+ *
+ * Both now throw, and they say different things: one is the caller's typo, the
+ * other is a gap in this library that staring at the model will never explain.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { configureOrm, createModel, createTableFromModel, getDatabase } from '../src/orm'
+
+const Author = createModel({
+  name: 'RelAuthor',
+  table: 'rel_authors',
+  primaryKey: 'id',
+  autoIncrement: true,
+  hasMany: { books: 'RelBook' },
+  // Accepted by the types, never resolved by the loader.
+  morphMany: { annotations: 'RelNote' },
+  attributes: { name: { type: 'string', fillable: true } },
+} as const)
+
+const Book = createModel({
+  name: 'RelBook',
+  table: 'rel_books',
+  primaryKey: 'id',
+  autoIncrement: true,
+  attributes: {
+    title: { type: 'string', fillable: true },
+    rel_author_id: { type: 'number', fillable: true },
+  },
+} as const)
+
+const Loner = createModel({
+  name: 'RelLoner',
+  table: 'rel_loners',
+  primaryKey: 'id',
+  autoIncrement: true,
+  attributes: { name: { type: 'string', fillable: true } },
+} as const)
+
+describe('unknown eager-load relations (#1068)', () => {
+  beforeAll(() => {
+    configureOrm({ database: ':memory:' })
+  })
+
+  beforeEach(async () => {
+    const db = getDatabase()
+    db.run('DROP TABLE IF EXISTS rel_authors')
+    db.run('DROP TABLE IF EXISTS rel_books')
+    db.run('DROP TABLE IF EXISTS rel_loners')
+    await createTableFromModel(Author.getDefinition())
+    await createTableFromModel(Book.getDefinition())
+    await createTableFromModel(Loner.getDefinition())
+    await Author.create({ name: 'Le Guin' })
+    await Loner.create({ name: 'Solo' })
+  })
+
+  afterAll(() => getDatabase().close())
+
+  it('throws on a misspelled relation instead of loading nothing', async () => {
+    // Previously: resolved to undefined, returned, and produced a result with no
+    // `boks` property and no complaint.
+    await expect(Author.with('boks').get()).rejects.toThrow(/no relation 'boks'/)
+  })
+
+  it('lists the relations that do exist, so the typo is obvious', async () => {
+    await expect(Author.with('boks').get()).rejects.toThrow(/Available: books/)
+  })
+
+  it('says so plainly when the model declares no relations at all', async () => {
+    await expect(Loner.with('anything').get()).rejects.toThrow(/declares no relations at all/)
+  })
+
+  it('distinguishes a declared-but-unsupported kind from a typo', async () => {
+    // `annotations` IS declared — as morphMany, which the loader cannot resolve.
+    // Telling the user "no such relation" here would send them looking for a
+    // misspelling that isn't there.
+    const err = await Author.with('annotations').get().catch((e: Error) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toMatch(/declares 'annotations' as morphMany/)
+    expect((err as Error).message).toMatch(/does not support yet/)
+    expect((err as Error).message).not.toMatch(/no relation/)
+  })
+
+  it('still loads a supported relation', async () => {
+    // The guard must not break the working path — and note the relation
+    // resolution is cached per model+name, so this also covers the cache.
+    const rows = await Author.with('books').get()
+    expect(rows.length).toBe(1)
+    await expect(Author.with('books').get()).resolves.toBeDefined()
+  })
+})


### PR DESCRIPTION
Closes #1068.

`eagerLoadRelation` returned silently when it couldn't resolve a relation name. A misspelling loaded nothing and reported nothing — the property is simply absent from the result, no error anywhere, and the outcome is indistinguishable from a relation that genuinely has no rows. `.with('psots')` looked exactly like a post with no comments.

The same silence covered every relation kind the resolver doesn't implement. `ModelDefinition` accepts `morphOne`, `morphMany`, `morphTo`, `morphToMany`, `morphedByMany`, `hasOneThrough` and `hasManyThrough`; `resolveRelation` handles four — `hasMany`, `hasOne`, `belongsTo`, `belongsToMany`. Declaring any of the rest type-checks, autocompletes, and does nothing at runtime.

## Two mistakes, two messages

```
[orm] 'Author' has no relation 'boks'. Available: books.

[orm] 'Author' declares 'annotations' as morphMany, which eager loading does not
support yet. Supported kinds: hasMany, hasOne, belongsTo, belongsToMany. Load it
with a manual query for now — see #1068.
```

The distinction is the point. Telling someone "no such relation" when the relation is right there in their model — just of a kind this library never implemented — sends them hunting for a typo that doesn't exist. A model with no relations at all says that outright instead of printing an empty list.

The throw sits **after** the per-model+name resolution cache, so a repeat call behaves like the first rather than quietly succeeding on a cached null.

## Tests

Five cases: misspelling throws, the message lists what does exist, a relation-less model says so, a declared-but-unsupported kind gets the other message (and explicitly *not* the "no relation" wording), and the supported path still loads.

Verified they discriminate: against the unfixed `orm.ts`, **4 of 5 fail**.

Typecheck 0, lint 0 errors, suite **1704 pass / 4 skip / 0 fail**.

## Noticed while testing, not fixed here

`resolveRelation` derives the related table from the model **name** rather than its declared `table`, so a model named `URBook` with `table: 'ur_books'` sends the loader looking for `u_r_books`. I renamed my fixtures around it rather than widening this PR — worth its own issue if you agree it's wrong.

This is also a **behaviour change worth a deliberate look**: code that today relies on `.with()` quietly ignoring an unknown name will now throw. That's the intent, but it could surface in an app that had a typo it never noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
