### PR TITLE
test(pg): make the Postgres-gated tests actually run in CI

### DIFF
--- a/packages/bun-query-builder/test/client.transaction-connection.test.ts
+++ b/packages/bun-query-builder/test/client.transaction-connection.test.ts
@@ -30,19 +30,11 @@ import { join, resolve } from 'node:path'
 import process from 'node:process'
 import { SQL } from 'bun'
 import { describe, expect, it } from 'bun:test'
+import { PG_URL, probePostgres } from './pg'
 
-const PG_URL = `postgres://${process.env.USER}@localhost:5432/postgres`
+const pgAvailable = await probePostgres()
 
-let pgAvailable = false
-try {
-  const probe = new SQL(PG_URL)
-  await probe.unsafe('SELECT 1')
-  await probe.end()
-  pgAvailable = true
-}
-catch {
-  pgAvailable = false
-}
+
 
 describe.skipIf(!pgAvailable)('builder-local connection routing', () => {
   it('keeps transactional writes inside the transaction, and reads inside it current', () => {

--- a/packages/bun-query-builder/test/integration.postgres.test.ts
+++ b/packages/bun-query-builder/test/integration.postgres.test.ts
@@ -14,18 +14,10 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { SQL } from 'bun'
 import { describe, expect, it } from 'bun:test'
+import { PG_URL, probePostgres } from './pg'
 
-const PG_URL = `postgres://${process.env.USER}@localhost:5432/postgres`
-let pgAvailable = false
-try {
-  const probe = new SQL(PG_URL)
-  await probe.unsafe('SELECT 1')
-  await probe.end()
-  pgAvailable = true
-}
-catch {
-  pgAvailable = false
-}
+const pgAvailable = await probePostgres()
+
 
 describe.skipIf(!pgAvailable)('Postgres integration (#1038)', () => {
   it('runs ORM CRUD + relations + raw builder against live Postgres', () => {
@@ -47,7 +39,9 @@ await raw.unsafe('CREATE TABLE _qb_users (id serial primary key, name text, age 
 await raw.unsafe('CREATE TABLE _qb_posts (id serial primary key, title text, pguser_id int)')
 await raw.end()
 
-setConfig({ dialect: 'postgres', database: { database: 'postgres', username: process.env.USER, host: 'localhost', port: 5432, password: '' } })
+// Configure from the same URL the gate probed, not a second hand-built copy of
+// it — the two drifting is what made this file skip in CI.
+setConfig({ dialect: 'postgres', database: { url: URL } })
 resetConnection()
 
 // defineModel registers in the model registry, so relations resolve to the

--- a/packages/bun-query-builder/test/migrate-atomicity.test.ts
+++ b/packages/bun-query-builder/test/migrate-atomicity.test.ts
@@ -24,20 +24,12 @@ import { join, resolve } from 'node:path'
 import process from 'node:process'
 import { SQL } from 'bun'
 import { describe, expect, it } from 'bun:test'
+import { PG_URL, probePostgres } from './pg'
+
+const pgAvailable = await probePostgres()
 
 const SRC = resolve(import.meta.dir, '../src/index.ts')
-const PG_URL = `postgres://${process.env.USER}@localhost:5432/postgres`
 
-let pgAvailable = false
-try {
-  const probe = new SQL(PG_URL)
-  await probe.unsafe('SELECT 1')
-  await probe.end()
-  pgAvailable = true
-}
-catch {
-  pgAvailable = false
-}
 
 /** A throwaway workspace with a migrations directory. */
 function workspace(files: Record<string, string>): string {

--- a/packages/bun-query-builder/test/pg.ts
+++ b/packages/bun-query-builder/test/pg.ts
@@ -1,0 +1,55 @@
+/**
+ * The Postgres a gated test should connect to, and whether it is reachable.
+ *
+ * Several tests can only be written against a real pooled driver — the
+ * transaction data leak (#1065), the migration lock (#1067), the ORM
+ * integration pass (#1038) — so they gate on a live server and skip without
+ * one. That gate was quietly wrong in CI.
+ *
+ * Each of those files built its own URL as
+ * `postgres://${process.env.USER}@localhost:5432/postgres`, which describes a
+ * developer machine: a peer-authenticated server owned by the current user,
+ * no password. CI is not that. It starts Postgres 17 as a service with
+ * `POSTGRES_USER=postgres`, `POSTGRES_PASSWORD=postgres`, `POSTGRES_DB=test_db`
+ * and exports `DATABASE_URL`. On a runner, `process.env.USER` is `runner`, so
+ * every probe failed with
+ *
+ *     FATAL: password authentication failed for user "runner"
+ *
+ * the gate read that as "no Postgres here", and the tests SKIPPED. CI stayed
+ * green while the guards for the two most severe bugs in the release never
+ * ran at all — the worst shape for a test to be in, because the green tick
+ * says the opposite.
+ *
+ * So: prefer what the environment tells us, fall back to the local shape.
+ */
+
+import { SQL } from 'bun'
+import process from 'node:process'
+
+export const PG_URL: string
+  = process.env.DATABASE_URL
+    ?? process.env.POSTGRES_URL
+    ?? `postgres://${process.env.USER ?? 'postgres'}@localhost:5432/postgres`
+
+/**
+ * Whether that server actually answers.
+ *
+ * A function rather than an awaited constant so this module needs no top-level
+ * await: the rule against it exists to keep one out of the shipped bundle, and
+ * suppressing it in a helper to save three callers one line each is a poor
+ * trade. Callers await it at the top of their own `.test.ts`, where the rule
+ * does not apply. The URL above is the part that was wrong and the part worth
+ * sharing; this is three lines of probe.
+ */
+export async function probePostgres(): Promise<boolean> {
+  try {
+    const probe = new SQL(PG_URL)
+    await probe.unsafe('SELECT 1')
+    await probe.end()
+    return true
+  }
+  catch {
+    return false
+  }
+}


### PR DESCRIPTION
The Postgres-gated tests were skipping in CI, and CI was green because of it.

## What was happening

Each gated file built its own URL as `` postgres://${process.env.USER}@localhost:5432/postgres `` — a developer machine: peer-authenticated server owned by the current user, no password. CI is not that. It starts Postgres 17 as a service with `POSTGRES_USER=postgres`, `POSTGRES_PASSWORD=postgres`, `POSTGRES_DB=test_db`, and exports `DATABASE_URL`.

On a runner `process.env.USER` is `runner`, so every probe failed:

```
FATAL:  password authentication failed for user "runner"
```

The gate read that as "no Postgres here" and skipped. The last CI run on `main`:

```
CI:     1695 pass / 8 skip / 0 fail
local:  1719 pass / 4 skip / 0 fail
```

Among those extra skips were the regression guards for the two most severe bugs in this release — the write surviving `ROLLBACK` (#1065) and the concurrent migrate collision (#1067). **A guard that cannot run on the machine gating releases is worse than no guard**, because the green tick claims the opposite.

## The fix

One shared `test/pg.ts`: URL prefers `DATABASE_URL`, then `POSTGRES_URL`, then the local shape. Three files stop hand-building it, so they can't drift apart again.

`integration.postgres.test.ts` also built a **second** copy of the connection inside its subprocess script (`username: process.env.USER, password: ''`) which would have failed even once the gate opened — it uses the probed URL now.

The probe is a function rather than an awaited constant, so the helper needs no top-level await; callers await it in their own `.test.ts` where the rule doesn't apply. Suppressing the rule in a helper to save three callers one line each seemed a poor trade.

## Verified three ways

| environment | result |
| --- | --- |
| `DATABASE_URL` → postgres/postgres (CI shape) | 4 gated tests **run** (were skipping) |
| no `DATABASE_URL` (local) | still run |
| `DATABASE_URL` → unreachable | skip cleanly, don't fail |

Full suite **1719 pass / 4 skip / 0 fail** with and without `DATABASE_URL`. The 4 remaining skips are gated on a built `dist/` and embedded PGlite, not Postgres.

Typecheck 0, lint 0 errors.

After this merges, the CI test job should report ~1699 pass / 4 skip rather than 1695 / 8 — worth confirming on the first run, since that number is the whole point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
