### PR TITLE
fix(deps): main is red — kysely bumped past its adapter's peer range

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/benchmark": {
       "name": "@bun-query-builder/benchmark",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "dependencies": {
         "@prisma/adapter-better-sqlite3": "^7.9.1",
         "@prisma/client": "6.19.3",
@@ -25,7 +25,7 @@
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "drizzle-orm": "^0.45.2",
-        "kysely": "^0.29.5",
+        "kysely": "^0.28.14",
         "kysely-bun-sqlite": "^0.4.0",
         "mitata": "^1.0.34",
         "prisma": "6.19.3",
@@ -38,7 +38,7 @@
     },
     "packages/bun-query-builder": {
       "name": "bun-query-builder",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "bin": {
         "query-builder": "./dist/bin/cli.js",
         "qbx": "./dist/bin/cli.js",
@@ -485,7 +485,7 @@
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "kysely": ["kysely@0.29.5", "", {}, "sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ=="],
+    "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "kysely-bun-sqlite": ["kysely-bun-sqlite@0.4.0", "", { "dependencies": { "bun-types": "^1.1.31" }, "peerDependencies": { "kysely": "^0.28.2" } }, "sha512-2EkQE5sT4ewiw7IWfJsAkpxJ/QPVKXKO5sRYI/xjjJIJlECuOdtG+ssYM0twZJySrdrmuildNPFYVreyu1EdZg=="],
 
@@ -762,8 +762,6 @@
     "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "electron/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
-
-    "kysely-bun-sqlite/kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -20,7 +20,7 @@
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "drizzle-orm": "^0.45.2",
-    "kysely": "^0.29.5",
+    "kysely": "^0.28.14",
     "kysely-bun-sqlite": "^0.4.0",
     "mitata": "^1.0.34",
     "prisma": "6.19.3",

--- a/packages/bun-query-builder/src/types.ts
+++ b/packages/bun-query-builder/src/types.ts
@@ -514,7 +514,12 @@ export interface QueryBuilderConfig {
  * `QueryBuilderConfig`. If one is ever added, give it a clause here too: a
  * mapped type shreds its methods exactly like a function's.
  */
-export type DeepPartial<T> = T extends (...args: any[]) => any // eslint-disable-line pickier/no-unused-vars -- `args` names a parameter in a function TYPE, not a binding
+// `args` names a parameter in a function TYPE, not a binding, so there is
+// nothing that could reference it. The trailing `eslint-disable-line` form this
+// used to carry stopped being honoured in pickier 0.1.56; only the
+// next-line form is.
+// eslint-disable-next-line pickier/no-unused-vars
+export type DeepPartial<T> = T extends (...args: any[]) => any
   ? T
   : T extends readonly (infer E)[]
     ? readonly E[]


### PR DESCRIPTION
**`main` is red and cannot be released.** #999 merged with a failing typecheck. Two breakages, both from that PR, neither reaching published users.

## 1. kysely bumped past its adapter's peer range

`kysely` went `^0.28.14 → ^0.29.5`. For a 0.x package a minor **is** a breaking change, so "update all non-major" was a misnomer — and `kysely-bun-sqlite` declares peer `kysely: ^0.28.2`.

It therefore resolved its own nested copy, leaving the benchmark with two Kysely installs at once: `BunSqliteDialect` typed against one, `new Kysely()` against the other. Structurally identical, nominally incompatible:

```
packages/benchmark/src/lib/db-clients.ts(221,5): error TS2769
  Type 'BunSqliteDialect' is not assignable to type 'Dialect'.
    The types returned by 'createAdapter().acquireMigrationLock' are incompatible…
```

Pinned back inside the adapter's range. Nothing in the benchmark uses a 0.29 API, so there's nothing to gain by chasing it until `kysely-bun-sqlite` supports it.

## 2. pickier stopped honouring the suppression form

`pickier` went `^0.1.32 → ^0.1.56`, and 0.1.56 no longer accepts the trailing `// eslint-disable-line` form — only `// eslint-disable-next-line`. So the suppression on `DeepPartial`'s type-level `args` parameter silently stopped applying and lint went red too.

Verified against 0.1.56 directly rather than guessing:

| form | result |
| --- | --- |
| `// eslint-disable-line pickier/no-unused-vars -- reason` | still errors |
| `// eslint-disable-line pickier/no-unused-vars` | still errors |
| `// eslint-disable-next-line pickier/no-unused-vars` | passes |

Moved to the next-line form. It was trailing originally to keep the JSDoc attached to the type, so I confirmed the doc block still lands on `DeepPartial` in the emitted `dist/types.d.ts` — it does.

## Scope

Both are benchmark/tooling only. **No published consumer is affected, and v0.2.26 on npm is fine.** What this blocks is CI, and therefore the next release.

## Verification

Typecheck 0, lint 0, suite **1719 pass / 4 skip / 0 fail**.

Worth considering separately: "all non-major" grouping treats 0.x minors as non-breaking, which is what let this through. Constraining that group to `>=1.0.0`, or excluding packages with declared peer ranges, would stop the same shape recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
