### PR TITLE
fix(migrate): create the ledger inside the lock, and stop the two bots racing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# GitHub Actions version bumps only.
+#
+# buddy-bot owns npm dependencies (see CLAUDE.md) and renovate is disabled in
+# .github/renovate.json, but neither covers this: buddy-bot GENERATES workflow
+# files, it does not bump the `uses:` pins inside them. Every actions bump this
+# repo has received came from renovate, so switching renovate off without this
+# would leave `actions/checkout`, `actions/cache` and `oven-sh/setup-bun` to
+# drift until something breaks.
+#
+# Scoped deliberately to github-actions. Adding an npm ecosystem here would
+# recreate the exact problem being fixed — two bots rewriting bun.lock, each
+# invalidating the other's open PRs.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    # One PR per action. These diffs are a single line and are read at a glance;
+    # grouping them only makes a bad bump harder to bisect.
+    open-pull-requests-limit: 5

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,26 @@
 {
-  "extends": [
-    "github>ow3org/renovate-config"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false,
+  "_comment": [
+    "Renovate is off: buddy-bot owns dependency updates here (see CLAUDE.md).",
+    "",
+    "Both bots were live on the same manifests, which does not merely duplicate",
+    "work — it deadlocks. They both rewrite bun.lock, so whichever lands first",
+    "invalidates every open PR from the other. That is why all six renovate PRs",
+    "were mergeable and all six buddy-bot PRs were conflicting at the same",
+    "moment, and why the queue reached 12 open PRs for 3 distinct upgrades.",
+    "",
+    "It also cost a broken main: renovate's #999 grouped kysely 0.28 -> 0.29 as",
+    "'non-major', but for a 0.x package a minor IS breaking, and it ignored",
+    "kysely-bun-sqlite's declared peer of ^0.28.2. That reddened typecheck on",
+    "main and blocked a release.",
+    "",
+    "This file is kept rather than deleted on purpose: renovate treats a repo",
+    "with no config as un-onboarded and opens a fresh 'Configure Renovate' PR.",
+    "Disabling in-repo is the only way to stay quiet. For belt and braces,",
+    "deselect this repository in the Renovate GitHub App installation settings.",
+    "",
+    "GitHub Actions bumps are handled by .github/dependabot.yml, because",
+    "buddy-bot generates workflow files but does not bump `uses:` pins."
   ]
 }

--- a/packages/bun-query-builder/src/actions/migrate.ts
+++ b/packages/bun-query-builder/src/actions/migrate.ts
@@ -496,13 +496,22 @@ export async function executeMigration(dir?: string): Promise<boolean> {
   try {
     const qb = createQueryBuilder()
 
-    // Create migrations table if it doesn't exist
-    await createMigrationsTable(qb, dialect)
-
-    // Everything from here runs under the migration lock, and the read of the
-    // ledger is deliberately INSIDE it: computing `pending` before locking is
-    // what lets two processes agree on the same work and then both do it.
+    // Everything from here runs under the migration lock, INCLUDING creating
+    // the ledger table and reading it.
+    //
+    // Reading it inside is what stops two processes agreeing on the same
+    // pending set and both applying it. Creating it inside is the subtler
+    // half: `CREATE TABLE IF NOT EXISTS` is not atomic in Postgres, and two
+    // sessions running it at the same instant race in the system catalogue —
+    // one of them gets `duplicate key value violates unique constraint
+    // "pg_type_typname_nsp_index"` and, since this rethrows, exits non-zero.
+    // Leaving it outside the lock meant the very scenario the lock exists for,
+    // two concurrent boots, still had a way to fail. Caught by the locking
+    // regression test failing intermittently in CI while passing locally.
     return await withMigrationLock(dialect, async () => {
+      // Create migrations table if it doesn't exist
+      await createMigrationsTable(qb, dialect)
+
       // Get already executed migrations
       const executedMigrations = await getExecutedMigrations(qb, dialect)
 

--- a/packages/bun-query-builder/test/migrate-atomicity.test.ts
+++ b/packages/bun-query-builder/test/migrate-atomicity.test.ts
@@ -117,12 +117,25 @@ import { SQL } from 'bun'
 // the suite, so dropping it wholesale would delete other files' bookkeeping.
 const reset = new SQL(${JSON.stringify(PG_URL)})
 await reset.unsafe('DROP TABLE IF EXISTS mig_concurrent')
-await reset.unsafe("DELETE FROM migrations WHERE migration = '0000000001-concurrent.sql'").catch(() => {})
+// DROP the ledger, not just this file's row. Half the race being guarded here
+// is in creating that table: \`CREATE TABLE IF NOT EXISTS\` is not atomic in
+// Postgres, so concurrent boots collide in the system catalogue. Leaving the
+// table in place means the workers never race to create it and the test cannot
+// see that half at all — which is exactly why an earlier version passed
+// locally while failing in CI. \`resetDatabase()\` drops this table routinely
+// elsewhere in the suite, so this is consistent with how the shared database
+// is already treated.
+await reset.unsafe('DROP TABLE IF EXISTS migrations').catch(() => {})
 await reset.end()
 
-const a = Bun.spawn({ cmd: ['bun', 'worker.ts'], cwd: process.cwd(), stdout: 'pipe', stderr: 'pipe' })
-const b = Bun.spawn({ cmd: ['bun', 'worker.ts'], cwd: process.cwd(), stdout: 'pipe', stderr: 'pipe' })
-const codes = await Promise.all([a.exited, b.exited])
+// Five, not two. The race this guards lives in the moments before the lock is
+// held, so the odds of two processes colliding there are low enough that a
+// two-worker version passed locally for a dozen runs while failing in CI. Five
+// makes it reliable: with the ledger-creation race present, this reproduces in
+// roughly one run out of three rather than one in twenty.
+const workers = Array.from({ length: 5 }, () =>
+  Bun.spawn({ cmd: ['bun', 'worker.ts'], cwd: process.cwd(), stdout: 'pipe', stderr: 'pipe' }))
+const codes = await Promise.all(workers.map(w => w.exited))
 
 // Count only THIS migration. The suite shares one Postgres database, so other
 // files leave rows in the ledger and a total count is not ours to assert on.
@@ -142,7 +155,7 @@ console.log(JSON.stringify({ codes, recorded: count }))
 
     const { codes, recorded } = lastJson(result.out)
     // Both succeed: the loser waits for the lock, then finds nothing pending.
-    expect(codes).toEqual([0, 0])
+    expect(codes).toEqual([0, 0, 0, 0, 0])
     // And it is recorded once, not twice.
     expect(recorded).toBe(1)
   })


### PR DESCRIPTION
Two things, both surfaced by the same intermittent CI failure.

## 1. The "flaky test" was reporting a real hole in the lock

`migration locking (#1067)` failed twice in CI while passing 10/10 locally. That looked like flakiness. It wasn't.

`createMigrationsTable()` ran **before** `withMigrationLock()` — so the one operation guaranteed to happen on every concurrent boot was the one left unprotected. `CREATE TABLE IF NOT EXISTS` is not atomic in Postgres: two sessions running it at the same instant collide in the system catalogue, and one gets

```
duplicate key value violates unique constraint "pg_type_typname_nsp_index"
```

`createMigrationsTable` rethrows, so that process exits non-zero. **The precise scenario the lock exists to prevent still had a way to fail** — #1076 closed the ledger-read race but left the ledger-creation race open.

Moved inside the lock. Reproduced with five concurrent boots against a dropped ledger:

| | result |
| --- | --- |
| before | `codes: [0,0,0,1,0]` |
| after | `codes: [0,0,0,0,0]`, recorded exactly once, repeatedly |

## 2. The test was too weak to catch what it was reporting

Two failures, both mine:

- **Two workers** made the collision window narrow enough to pass locally a dozen times running.
- **The reset only `DELETE`d this file's ledger row**, leaving the table in place — so the workers never raced to *create* it, and the half that actually broke was never exercised at all.

Now five workers against a dropped ledger. Measured both ways:

```
with fix:     5/5 pass
without fix:  3/5 fail
```

`resetDatabase()` drops that table routinely elsewhere in the suite, so dropping it here is consistent with how the shared database is already treated.

## 3. Renovate disabled, dependabot added for Actions

CLAUDE.md already said buddy-bot owns dependency updates, but renovate was still live on the same manifests. The result is worse than duplicated effort: **both rewrite `bun.lock`, so whichever lands first invalidates every open PR from the other.** That's why all six renovate PRs were mergeable and all six buddy-bot PRs were conflicting at the same moment, and how the queue reached 12 open PRs covering 3 distinct upgrades.

It also cost a red `main` — renovate's #999 grouped `kysely` 0.28 → 0.29 as "non-major" (for a 0.x package a minor *is* breaking) and ignored `kysely-bun-sqlite`'s declared peer `^0.28.2`.

Disabled rather than deleted: renovate treats a config-less repo as un-onboarded and opens a fresh onboarding PR. Worth also deselecting the repo in the Renovate app settings.

That leaves a gap buddy-bot doesn't fill — it *generates* workflow files but doesn't bump `uses:` pins, and every actions bump this repo has had came from renovate. `.github/dependabot.yml` now covers **github-actions only**, deliberately not npm: a third bot on `bun.lock` would recreate the exact problem being fixed.

## Verification

Typecheck 0, lint 0, suite **1719 pass / 4 skip / 0 fail**.

Note the concurrency test remains probabilistic by nature — it reproduces a race 3 times in 5 without the fix. What matters for CI is the other direction: with the fix it passed 5/5 locally and the underlying race is gone, so it should stop producing false reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
