### PR TITLE
fix(sqlite): a nested query's bindings were being thrown away

### DIFF
--- a/packages/bun-query-builder/src/db.ts
+++ b/packages/bun-query-builder/src/db.ts
@@ -263,15 +263,38 @@ function createSQLiteSQL(filename: string): SQL {
     for (let i = 0; i < values.length; i++) {
       const value = values[i]
 
-      // Handle raw SQL markers (from sql('identifier') or sql.raw())
-      if (value && typeof value === 'object' && (value.__raw || value.raw)) {
-        const rawValue = value.__raw ? value.value : (typeof value.raw === 'string' ? value.raw : value.raw())
-        sql += rawValue + (strings[i + 1] || '')
-      }
-      // Handle query objects (nested queries)
-      else if (value && typeof value === 'object' && 'sql' in value && 'values' in value) {
+      // Handle query objects (nested queries) FIRST.
+      //
+      // Order matters, and getting it wrong is stacksjs/bun-query-builder#1084.
+      // The queries this wrapper hands back (see the object returned below)
+      // carry `raw: () => sql` so callers can read their text — which means
+      // they satisfy the raw-marker test underneath as well. With that branch
+      // first, interpolating one query into another spliced its SQL TEXT and
+      // silently threw away its `values`, so the placeholders arrived with no
+      // bindings behind them:
+      //
+      //   db.selectFrom('t').where('id', '>', 0).paginate(5)
+      //   -> SQLite query expected 3 values, received 2
+      //
+      // and the COUNT half of the same call failed the other way: bun:sqlite
+      // only arity-checks when some values are passed, so `WHERE id > ?` bound
+      // the placeholder to NULL, matched nothing, and reported total 0 rather
+      // than throwing. `paginate` nests twice, which is why it was the loudest
+      // victim, but every method that composes a query into a template — the
+      // pagination family, exists/first/value, the soft-delete filter — was
+      // dropping bindings the same way.
+      //
+      // The discriminator is `values` being an ARRAY: raw markers carry
+      // `__raw` and no `values`, and Bun's native query objects expose `values`
+      // as a method, so neither is captured here.
+      if (value && typeof value === 'object' && typeof value.sql === 'string' && Array.isArray(value.values)) {
         sql += value.sql + (strings[i + 1] || '')
         params.push(...value.values)
+      }
+      // Handle raw SQL markers (from sql('identifier') or sql.raw())
+      else if (value && typeof value === 'object' && (value.__raw || value.raw)) {
+        const rawValue = value.__raw ? value.value : (typeof value.raw === 'string' ? value.raw : value.raw())
+        sql += rawValue + (strings[i + 1] || '')
       }
       // Handle arrays - expand to placeholders
       else if (Array.isArray(value)) {

--- a/packages/bun-query-builder/test/client.paginate-bindings.test.ts
+++ b/packages/bun-query-builder/test/client.paginate-bindings.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, config, createQueryBuilder, setConfig } from '../src'
+import { resetConnection } from '../src/db'
+
+/**
+ * Regression coverage for stacksjs/bun-query-builder#1084.
+ *
+ * `paginate()` threw `SQLite query expected 3 values, received 2` on any query
+ * whose WHERE contributed a binding, and the arithmetic named the cause: the
+ * shortfall was always exactly the number of parameters the WHERE needed, and
+ * `whereNull` — the one where-form that adds SQL text but no bindings — was the
+ * one that worked.
+ *
+ * The bug was NOT in `paginate`. It was in the bun:sqlite wrapper's
+ * tagged-template interpolation (`processTaggedTemplate` in db.ts). The queries
+ * that wrapper returns carry `raw: () => sql` so callers can read their text,
+ * which also made them satisfy the raw-marker branch that was tested FIRST. So
+ * interpolating one query into another spliced its SQL text and discarded its
+ * `values`, leaving placeholders with nothing behind them.
+ *
+ * `paginate` nests twice — once for `COUNT(*) FROM (…)` and once for
+ * `… LIMIT ? OFFSET ?` — which made it the loudest victim, but everything that
+ * composes a query into a template was affected. The count half failed more
+ * quietly than the page half: bun:sqlite only arity-checks when some values are
+ * passed, so `WHERE id > ?` bound the placeholder to NULL, matched nothing, and
+ * reported `total: 0` instead of throwing. That is why these tests assert
+ * `meta.total` explicitly rather than only that `paginate()` does not throw.
+ *
+ * These must run against the library's own SQLite connection (config-driven,
+ * via `resetConnection()`), NOT an injected `new SQL(...)`. An injected
+ * connection routes around the wrapper entirely, so the bug is invisible — that
+ * is precisely why the existing pagination tests never caught this.
+ */
+
+const schema = buildDatabaseSchema({
+  Row: {
+    name: 'Row',
+    table: 'p_rows',
+    primaryKey: 'id',
+    attributes: { id: { validation: { rule: {} } }, executed_at: { validation: { rule: {} } } },
+  },
+} as any)
+
+let saved: { dialect: any, database: any }
+
+beforeEach(async () => {
+  saved = { dialect: config.dialect, database: { ...config.database } }
+  setConfig({ dialect: 'sqlite', database: { database: ':memory:' } })
+  resetConnection()
+
+  const db = createQueryBuilder<typeof schema>({ schema })
+  await db.unsafe('CREATE TABLE p_rows (id INTEGER PRIMARY KEY, executed_at TEXT)')
+  for (let i = 1; i <= 20; i++)
+    await db.unsafe(`INSERT INTO p_rows (id, executed_at) VALUES (${i}, ${i > 13 ? `'done'` : 'NULL'})`)
+})
+
+afterEach(() => {
+  setConfig({ dialect: saved.dialect, database: saved.database } as any)
+  resetConnection()
+})
+
+const qb = () => createQueryBuilder<typeof schema>({ schema })
+
+describe('paginate carries the WHERE clause bindings (#1084)', () => {
+  it('pages a filtered query instead of throwing', async () => {
+    // Was: SQLite query expected 3 values, received 2
+    const result: any = await qb().selectFrom('p_rows').selectAll().where('id', '>', 10).paginate(5)
+
+    expect(result.data.map((r: any) => r.id)).toEqual([11, 12, 13, 14, 15])
+  })
+
+  it('counts only the filtered rows', async () => {
+    // A separate assertion on purpose: the count query failed SILENTLY (bound
+    // the placeholder to NULL and matched nothing), so it would have reported
+    // total 0 even once the page query stopped throwing.
+    const result: any = await qb().selectFrom('p_rows').selectAll().where('id', '>', 10).paginate(5)
+
+    expect(result.meta.total).toBe(10)
+    expect(result.meta.total).not.toBe(0)
+  })
+
+  it('binds a whereIn list', async () => {
+    // Was: expected 5 values, received 2 — the shortfall is the list length.
+    const result: any = await qb().selectFrom('p_rows').selectAll().whereIn('id', [1, 2, 3]).paginate(5)
+
+    expect(result.data.map((r: any) => r.id)).toEqual([1, 2, 3])
+    expect(result.meta.total).toBe(3)
+  })
+
+  it('still works for a where-form that contributes no bindings', async () => {
+    // whereNull was the case that always worked; it must not regress.
+    const result: any = await qb().selectFrom('p_rows').selectAll().whereNull('executed_at').paginate(5)
+
+    expect(result.meta.total).toBe(13)
+  })
+
+  it('still works with no filter at all', async () => {
+    const result: any = await qb().selectFrom('p_rows').selectAll().paginate(5)
+
+    expect(result.data.length).toBe(5)
+    expect(result.meta.total).toBe(20)
+  })
+})
+
+describe('other query-composing methods see the WHERE (#1084)', () => {
+  // Same root cause, quieter symptoms: these returned the un-filtered answer
+  // rather than throwing, because their nested fragment lost its bindings.
+  it('exists() respects the filter', async () => {
+    expect(await qb().selectFrom('p_rows').selectAll().where('id', '>', 10).exists()).toBe(true)
+    expect(await qb().selectFrom('p_rows').selectAll().where('id', '>', 999).exists()).toBe(false)
+  })
+
+  it('first() returns a row matching the filter', async () => {
+    const row: any = await qb().selectFrom('p_rows').selectAll().where('id', '>', 10).first()
+
+    expect(row?.id).toBe(11)
+  })
+
+  it('count() agrees with the number of rows get() returns', async () => {
+    // The cheapest tripwire for this whole family: if a composing path loses
+    // its bindings again, these two stop matching.
+    const q = () => qb().selectFrom('p_rows').selectAll().where('id', '>', 10)
+    const rows: any = await q().get()
+
+    expect(Number(await q().count())).toBe(rows.length)
+  })
+})


### PR DESCRIPTION
Closes #1084.

## The bug isn't in `paginate()`

The report's own arithmetic pointed at the cause: the shortfall was always exactly the number of parameters the WHERE contributed, and `whereNull` — the one where-form that adds SQL text but *no* bindings — was the one that worked.

It's in the bun:sqlite wrapper's tagged-template interpolation. The query objects that wrapper returns carry `raw: () => sql` so callers can read their text — which also makes them satisfy the **raw-marker branch that was tested first**. So interpolating one query into another took that branch: spliced the nested query's SQL text, discarded its `values`. The nested-query branch below, the one that merges params, was unreachable for the wrapper's own queries.

Reordered so the nested-query case is tested first, discriminating on `values` being an **array** — raw markers carry `__raw` and no `values`, and Bun's native query objects expose `values` as a *method*, so neither is captured.

## The count query failed more quietly than the page query

`paginate` nests twice — `COUNT(*) FROM (…)` and `… LIMIT ? OFFSET ?`. bun:sqlite only arity-checks when *some* values are passed, so while the page query threw, the count query bound `WHERE id > ?` to NULL, matched nothing, and returned **`total: 0`**.

Fixing only the page query would have replaced a loud crash with a wrong answer. The tests assert `meta.total` explicitly for that reason.

```
before:  .where('id','>',10).paginate(5)  ->  THREW: expected 3 values, received 2
after:   .where('id','>',10).paginate(5)  ->  data=[11..15]  total=10
```

## It was never just pagination

Everything that composes a query into a template was affected — including two the report doesn't mention, both silent:

- `exists()` returned `false` for filtered queries that had rows
- `first()` returned a row from outside the filter

**Postgres was never affected** — it uses Bun's native SQL, not this wrapper. That's also why the tests must run against the library's own connection rather than an injected `new SQL(...)`: an injected connection routes around the wrapper entirely, which is exactly why the existing pagination tests never caught this.

## Verification

8 new tests. Verified they discriminate: **5 of 8 fail against the unfixed `db.ts`.**

Typecheck 0, lint 0, suite **1719 pass / 4 skip / 0 fail** (+8).

## Not in this PR

#1083 (the `orWhere` grouping bug) is a much larger change — the select builder has no WHERE term list at all, just an appended string, so fixing precedence means introducing one across ~40 append sites in `client.ts` plus the parallel implementation in `orm.ts`. It also **changes emitted SQL** for existing users, so it wants its own PR and its own changelog entry. Investigated and specced; not started.

Also found while investigating, worth separate issues: the ORM's `paginate(page, perPage)` takes its arguments in the **opposite order** to the query builder's `paginate(perPage, page)` — confirmed empirically, and it silently returns the wrong page rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
