### PR TITLE
fix(client): an empty list is a predicate, not the absence of one

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -184,6 +184,38 @@ function renderSelectColumn(col: unknown): string {
   )
 }
 
+/**
+ * Constant predicates, for the cases where a collection is empty.
+ *
+ * `1 = 0` and `1 = 1` take no parameters and parse identically on SQLite,
+ * Postgres and MySQL, which is the point: the alternatives are engine-specific.
+ * `IN ()` is the example that motivated these — SQLite parses it and matches
+ * nothing, while Postgres and MySQL reject it as a syntax error, so the same
+ * call site behaved differently depending on where it ran.
+ */
+const FALSE_PREDICATE = '1 = 0'
+const TRUE_PREDICATE = '1 = 1'
+
+/**
+ * Render `col IN (…)` / `col NOT IN (…)`, including the empty case.
+ *
+ * An empty `IN` is FALSE (nothing is a member of the empty set) and an empty
+ * `NOT IN` is TRUE (everything is a non-member). Those constants are not
+ * interchangeable and the mirror is easy to get backwards: writing FALSE for
+ * `NOT IN` would silently drop every row from any query whose exclusion list
+ * happened to come back empty — the same shape of silent, widening-or-narrowing
+ * failure as the `IN ()` bug itself.
+ *
+ * Shared rather than inlined at each call site because there are four of them
+ * (`whereIn`, `orWhereIn`, `whereNotIn`, `orWhereNotIn`) and they have already
+ * drifted once.
+ */
+function renderInPredicate(column: string, values: any[], negated: boolean, placeholders: string): string {
+  if (values.length === 0)
+    return negated ? TRUE_PREDICATE : FALSE_PREDICATE
+  return `${column} ${negated ? 'NOT IN' : 'IN'} (${placeholders})`
+}
+
 // Pre-compiled regex patterns for performance
 const SQL_PATTERNS = {
   SELECT_STAR: /^SELECT\s+\*/i,
@@ -4793,7 +4825,20 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return this as any
       },
       whereAny(cols: string[], op: WhereOperator, value: any) {
-        if (cols.length === 0) return this as any
+        // An empty disjunction is FALSE, not absent. Returning `this` emitted
+        // the identity of the wrong connective, so a `.filter()` that removed
+        // every column WIDENED the query to all the rows it existed to
+        // exclude — silently, and in the dangerous direction.
+        //
+        // `whereAll([])` and `whereNone([])` keep their no-op just below,
+        // because TRUE genuinely is their identity. The asymmetry is the point,
+        // not an inconsistency to tidy up.
+        if (cols.length === 0) {
+          const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
+          text += ` ${kw} (${FALSE_PREDICATE})`
+          built = null
+          return this as any
+        }
         const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const idx = whereParams.length + 1
         const conds = cols.map((c, i) => `${c} ${op} ${getPlaceholder(idx + i)}`)
@@ -4876,7 +4921,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` ${keyword} ${column} IN (${placeholders})`
+          text += ` ${keyword} ${renderInPredicate(column, values, false, placeholders)}`
           whereParams.push(...values)
         }
         else {
@@ -4889,7 +4934,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         validateIdentifier(String(column), 'orWhereIn(column)')
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` OR ${column} IN (${placeholders})`
+          text += ` OR ${renderInPredicate(column, values, false, placeholders)}`
           whereParams.push(...values)
         }
         else {
@@ -4903,7 +4948,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` ${keyword} ${column} NOT IN (${placeholders})`
+          text += ` ${keyword} ${renderInPredicate(column, values, true, placeholders)}`
           whereParams.push(...values)
         }
         else {
@@ -4916,7 +4961,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         validateIdentifier(String(column), 'orWhereNotIn(column)')
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` OR ${column} NOT IN (${placeholders})`
+          text += ` OR ${renderInPredicate(column, values, true, placeholders)}`
           whereParams.push(...values)
         }
         else {

--- a/packages/bun-query-builder/test/client.empty-collections.test.ts
+++ b/packages/bun-query-builder/test/client.empty-collections.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, createQueryBuilder } from '../src'
+
+/**
+ * Regression coverage for the two smaller defects reported in
+ * stacksjs/bun-query-builder#1083.
+ *
+ * `whereIn(col, [])` emitted `IN ()`. SQLite parses that and matches nothing,
+ * which is the sane reading; Postgres and MySQL reject it as a syntax error. So
+ * one call site behaved differently depending on which engine it ran against —
+ * portable-looking code that was not portable.
+ *
+ * `whereAny([], op, value)` returned the builder untouched, so the predicate
+ * vanished entirely. An empty column list is nearly always a `.filter()` that
+ * removed everything, and the consequence was MORE rows than intended: the
+ * query silently widened to include everything the filter existed to exclude.
+ *
+ * Both now emit a constant predicate. `1 = 0` and `1 = 1` take no parameters
+ * and parse identically on all three engines.
+ *
+ * The mirror case is the one to be careful about: an empty `NOT IN` is TRUE,
+ * not FALSE. Nothing is a member of the empty set, so everything is a
+ * non-member. Writing `1 = 0` there would silently drop every row from any
+ * query whose exclusion list happened to come back empty — the same class of
+ * silent, direction-flipping bug being fixed here.
+ */
+
+const schema = buildDatabaseSchema({
+  Row: {
+    name: 'Row',
+    table: 'm',
+    primaryKey: 'id',
+    attributes: { id: { validation: { rule: {} } }, s: { validation: { rule: {} } } },
+  },
+} as any)
+
+const sqlOf = (build: (q: any) => any): string =>
+  String(build(createQueryBuilder<typeof schema>({ schema }).selectFrom('m').selectAll()).toSQL())
+
+describe('empty collections emit a constant predicate (#1083)', () => {
+  it('whereIn with an empty list matches nothing instead of emitting IN ()', () => {
+    const sql = sqlOf(q => q.whereIn('id', []))
+
+    expect(sql).not.toContain('IN ()')
+    expect(sql).toContain('1 = 0')
+  })
+
+  it('whereNotIn with an empty list matches everything', () => {
+    // THE TRAP. Excluding nothing excludes nothing — this must be TRUE.
+    // `1 = 0` here would silently return zero rows whenever an exclusion list
+    // came back empty.
+    const sql = sqlOf(q => q.whereNotIn('id', []))
+
+    expect(sql).toContain('1 = 1')
+    expect(sql).not.toContain('1 = 0')
+  })
+
+  it('whereAny with no columns matches nothing instead of vanishing', () => {
+    const sql = sqlOf(q => q.where('s', '=', 'p').whereAny([], 'like', '%x%'))
+
+    expect(sql).toContain('1 = 0')
+    // The earlier filter must survive alongside it.
+    expect(sql).toContain('s = ')
+  })
+
+  it('whereAll and whereNone with no columns stay no-ops', () => {
+    // TRUE genuinely is their identity, so dropping the term is correct here.
+    // The asymmetry with whereAny is deliberate.
+    const baseline = sqlOf(q => q.where('s', '=', 'p'))
+
+    expect(sqlOf(q => q.where('s', '=', 'p').whereAll([], 'like', '%x%'))).toBe(baseline)
+    expect(sqlOf(q => q.where('s', '=', 'p').whereNone([], 'like', '%x%'))).toBe(baseline)
+  })
+
+  it('leaves a non-empty IN untouched', () => {
+    const sql = sqlOf(q => q.whereIn('id', [1, 2, 3]))
+
+    expect(sql).toContain('IN (')
+    expect(sql).not.toContain('1 = 0')
+  })
+})


### PR DESCRIPTION
Refs #1083 — the two smaller defects reported at the end of that issue. **The `orWhere` grouping bug, which is its headline, is not in here** (see below).

## `whereIn(col, [])` emitted `IN ()`

SQLite parses that and matches nothing — the sane reading. Postgres and MySQL reject it. Verified against live Postgres:

```
IN ()      (old emit)  ->  REJECTED: syntax error at or near ")"
1 = 0      (new emit)  ->  0 rows
NOT IN ()  (old emit)  ->  REJECTED: syntax error at or near ")"
1 = 1      (new emit)  ->  3 rows
```

So the same call site behaved differently depending on the engine. It now emits `1 = 0`, which takes no parameters, parses identically everywhere, and preserves SQLite's answer.

**The mirror needed care**, and is why the four `IN` sites now go through one shared renderer rather than four inline copies: an empty `NOT IN` is **TRUE**, not FALSE. Nothing is a member of the empty set, so everything is a non-member. Writing the false constant there would silently drop every row from any query whose exclusion list happened to come back empty — the same shape of quiet, direction-flipping failure being fixed. There's a test named as the trap.

## `whereAny([], op, value)` silently vanished

It returned the builder untouched, so the predicate disappeared and the query widened to include everything the filter existed to exclude:

```
before:  .where('s','=','p').whereAny([], 'like', '%x%')  ->  WHERE s = ?
after:   .where('s','=','p').whereAny([], 'like', '%x%')  ->  WHERE s = ? AND (1 = 0)
```

An empty column list is nearly always a `.filter()` that removed everything, so the failure lands exactly where someone is least likely to look — and it fails toward *more* rows.

`whereAll([])` and `whereNone([])` keep their no-op, because TRUE genuinely is their identity. That asymmetry is deliberate and asserted, so the next reader doesn't tidy it into a bug.

## Verification

5 new tests; **3 of 5 fail against the unfixed `client.ts`**. Non-empty `IN` is asserted unchanged.

Typecheck 0, lint 0, suite **1724 pass / 4 skip / 0 fail**.

## Why the `orWhere` fix isn't here

It's a much larger change than it looks. The select builder has no WHERE term list — just a string that 43 call sites append to (`whereConditions` exists but is dead: 24 pushes, 0 reads). Fixing precedence means introducing a real term list across all of them, plus the parallel `_wheres` implementation in `orm.ts`. It also **changes emitted SQL for existing users**, so it needs its own PR, its own changelog entry as a behaviour change, and a grouping API (`whereGroup`) shipped alongside so the old reading stays expressible.

It's fully investigated and specced — I just didn't want to land a half-finished refactor of SQL generation on the end of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
