### PR TITLE
fix(client): orWhere now groups, so an earlier where keeps applying (#1083)

### DIFF
--- a/docs/features/builder.md
+++ b/docs/features/builder.md
@@ -112,12 +112,27 @@ const adults = await db
   .where(['age', '>=', 18])
   .execute()
 
-// Complex conditions with multiple filters
+// Complex conditions with multiple filters.
+//
+// A chained `orWhere` groups with the term immediately before it, so this is
+//   active AND age >= 18 AND (country IN (...) OR role = 'admin')
+// If you mean "all three filters, OR an admin", make the conjunction explicit
+// with whereGroup — see the note under Logical grouping below.
 const eligibleUsers = await db
   .selectFrom('users')
   .where({ active: true })
   .andWhere(['age', '>=', 18])
   .andWhere(['country', 'in', ['US', 'CA', 'GB']])
+  .orWhere(['role', '=', 'admin'])
+  .execute()
+
+// "Everything above, OR an admin":
+const eligibleOrAdmin = await db
+  .selectFrom('users')
+  .whereGroup(qb => qb
+    .where({ active: true })
+    .andWhere(['age', '>=', 18])
+    .andWhere(['country', 'in', ['US', 'CA', 'GB']]))
   .orWhere(['role', '=', 'admin'])
   .execute()
 
@@ -246,7 +261,7 @@ const averyPrefs = await db
 
 - **Use indexes**: Ensure filtered columns have appropriate database indexes
 - **Parameterized queries**: The builder automatically parameterizes values for SQL injection safety
-- **Logical grouping**: Use `orWhere` and `andWhere` to create clear logical groups
+- **Logical grouping**: A chained `orWhere` groups with the term before it — `.where(a).where(b).orWhere(c)` is `a AND (b OR c)`. Use `whereGroup(cb)` / `orWhereGroup(cb)` when you need the other reading, `(a AND b) OR c`
 - **Dynamic filters**: Build conditions conditionally based on user input or application state
 - **JSON performance**: Be mindful that JSON operations may require special indexes
 

--- a/docs/guide/where.md
+++ b/docs/guide/where.md
@@ -74,6 +74,48 @@ const users = await db
   .get()
 ```
 
+#### How `orWhere` groups
+
+A chained `orWhere` groups with the term immediately before it, and that group
+is ANDed into the rest of the chain:
+
+```typescript
+db.selectFrom('posts')
+  .where('status', '=', 'pending')
+  .where('title', 'like', term)
+  .orWhere('content', 'like', term)
+
+// WHERE status = ? AND (title like ? OR content like ?)
+```
+
+In other words `OR` binds **tighter** than `AND` here — the inverse of raw SQL,
+and the reading the chain has when you say it out loud. It also matches what
+`whereAny` already does.
+
+This matters because the other reading fails silently and in the widening
+direction. Under raw SQL precedence the same chain means
+`(status AND title) OR content`, so every row matching `content` comes back
+regardless of its status — a valid query, no warning, and a result set that
+looks like data rather than an error.
+
+To get `(a AND b) OR c`, use `whereGroup`:
+
+```typescript
+db.selectFrom('posts')
+  .whereGroup(qb => qb.where('status', '=', 'pending').where('title', 'like', term))
+  .orWhere('content', 'like', term)
+
+// WHERE (status = ? AND title like ?) OR content like ?
+```
+
+Two notes:
+
+- An object passed to `where`/`orWhere` is a **single** term, so
+  `.where({ a, b }).orWhere(c)` means `(a AND b) OR c`.
+- A `whereRaw`/`orWhereRaw` fragment is also a single term and is **not**
+  auto-parenthesised. If your fragment contains a top-level `OR`, bracket it
+  yourself.
+
 ## Special Where Methods
 
 ### whereIn / whereNotIn
@@ -207,6 +249,21 @@ const users = await db
 
 // Generates: WHERE active = true AND (role = 'admin' OR role = 'moderator')
 ```
+
+`whereGroup(callback)` is the same thing under an explicit name, and
+`orWhereGroup(callback)` ORs the group onto the query instead of ANDing it:
+
+```typescript
+db.selectFrom('users')
+  .where('active', '=', true)
+  .orWhereGroup(qb => qb.where('role', '=', 'admin').where('verified', '=', true))
+
+// WHERE active = ? OR (role = ? AND verified = ?)
+```
+
+A callback that adds no conditions **throws**. A group that contributed nothing
+would drop out of the query and leave it matching every row the filter existed
+to exclude, which is the failure this API exists to prevent.
 
 ## Existence Checks
 

--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -10,6 +10,8 @@ import type { DriverConnection } from './db'
 import { bunSql, getOrCreateBunSql, resetConnection } from './db'
 import { resolvePivot } from './pivot'
 import { singularizerFor } from './inflect'
+import type { WhereTerm } from './sql-fragments'
+import { FALSE_PREDICATE, renderInPredicate, renderWhereTerms } from './sql-fragments'
 
 export { resetConnection }
 
@@ -182,38 +184,6 @@ function renderSelectColumn(col: unknown): string {
   throw new TypeError(
     `[query-builder] select(): unsupported column ${String(col)} — pass a column name, a string[], or a SQL fragment (e.g. sql\`count(*) as c\`)`,
   )
-}
-
-/**
- * Constant predicates, for the cases where a collection is empty.
- *
- * `1 = 0` and `1 = 1` take no parameters and parse identically on SQLite,
- * Postgres and MySQL, which is the point: the alternatives are engine-specific.
- * `IN ()` is the example that motivated these — SQLite parses it and matches
- * nothing, while Postgres and MySQL reject it as a syntax error, so the same
- * call site behaved differently depending on where it ran.
- */
-const FALSE_PREDICATE = '1 = 0'
-const TRUE_PREDICATE = '1 = 1'
-
-/**
- * Render `col IN (…)` / `col NOT IN (…)`, including the empty case.
- *
- * An empty `IN` is FALSE (nothing is a member of the empty set) and an empty
- * `NOT IN` is TRUE (everything is a non-member). Those constants are not
- * interchangeable and the mirror is easy to get backwards: writing FALSE for
- * `NOT IN` would silently drop every row from any query whose exclusion list
- * happened to come back empty — the same shape of silent, widening-or-narrowing
- * failure as the `IN ()` bug itself.
- *
- * Shared rather than inlined at each call site because there are four of them
- * (`whereIn`, `orWhereIn`, `whereNotIn`, `orWhereNotIn`) and they have already
- * drifted once.
- */
-function renderInPredicate(column: string, values: any[], negated: boolean, placeholders: string): string {
-  if (values.length === 0)
-    return negated ? TRUE_PREDICATE : FALSE_PREDICATE
-  return `${column} ${negated ? 'NOT IN' : 'IN'} (${placeholders})`
 }
 
 // Pre-compiled regex patterns for performance
@@ -846,6 +816,47 @@ export interface BaseSelectQueryBuilder<
    */
   orWhereNotLike: (column: keyof DB[TTable]['columns'] & string, pattern: string, caseSensitive?: boolean) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
   orWhereNotILike?: (column: keyof DB[TTable]['columns'] & string, pattern: string) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /**
+   * # `whereGroup`
+   *
+   * A parenthesised group of conditions, ANDed onto the query.
+   *
+   * A chained `orWhere` groups with the term immediately before it, so
+   * `.where(a).where(b).orWhere(c)` means `a AND (b OR c)`. This is the escape
+   * hatch for the other reading — `(a AND b) OR c` — which chaining alone can
+   * no longer express. Throws if the callback adds no conditions, rather than
+   * leaving the query unfiltered.
+   *
+   * @example
+   * ```ts
+   * // (status = 'live' AND role = 'admin') OR owner_id = 7
+   * db.selectFrom('users')
+   *   .whereGroup(b => b.where('status', '=', 'live').where('role', '=', 'admin'))
+   *   .orWhere('owner_id', '=', 7)
+   * ```
+   */
+  whereGroup: (callback: (builder: SelectQueryBuilder<DB, TTable, TSelected, TJoined>) => unknown) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /**
+   * # `orWhereGroup`
+   *
+   * A parenthesised group of conditions, ORed onto the query.
+   */
+  orWhereGroup: (callback: (builder: SelectQueryBuilder<DB, TTable, TSelected, TJoined>) => unknown) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /** OR-connected counterpart of `whereNull`. */
+  orWhereNull: (column: keyof DB[TTable]['columns'] & string) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /** OR-connected counterpart of `whereNotNull`. */
+  orWhereNotNull: (column: keyof DB[TTable]['columns'] & string) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /** OR-connected counterpart of `whereBetween`. */
+  orWhereBetween: (column: keyof DB[TTable]['columns'] & string, start: any, end: any) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /** OR-connected counterpart of `whereExists`. */
+  orWhereExists: (subquery: { toSQL: () => any }) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  /**
+   * OR-connected counterpart of `whereRaw`.
+   *
+   * A raw fragment is one term and is not auto-parenthesised — if it contains a
+   * top-level `OR`, bracket it yourself.
+   */
+  orWhereRaw: (fragment: SqlFragment) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
   // where any/all/none on list of columns
   /**
    * # `whereAny`
@@ -3159,12 +3170,28 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       ? `SELECT ${columns.join(', ')} FROM ${String(table)}`
       : `SELECT * FROM ${String(table)}`
 
+    // The WHERE clause is a TERM LIST, not text appended to `text`. Each term
+    // records the connector its caller asked for, and the body is rendered at
+    // emit time by renderWhereTerms(), which brackets each maximal OR-run with
+    // the term that opens it.
+    //
+    // A `whereConditions: string[]` used to live here with 25 pushes and zero
+    // reads — a structured representation nobody ever wired to the emit path,
+    // which is exactly why `orWhere` shipped as flat text and mis-grouped.
+    // See stacksjs/bun-query-builder#1083.
+    const whereTerms: WhereTerm[] = []
+    const whereParams: unknown[] = []
+    // Set once a set operator closes the current SELECT. Terms pushed after a
+    // UNION/INTERSECT/EXCEPT belong to the RIGHT-hand SELECT and must render at
+    // the end of `text`, or their params would bind in the wrong order.
+    let whereTail = false
+
     // Lazy building: don't prepare statement until execution
     // built is initialized lazily to avoid expensive template tag calls on every query
     let built: any = null
     const ensureBuilt = () => {
       if (built === null) {
-        const finalText = reorderSelectClauses(text)
+        const finalText = reorderSelectClauses(currentSql())
         built = whereParams.length > 0
           ? _sql.unsafe(finalText, whereParams)
           : _sql.unsafe(finalText)
@@ -3172,17 +3199,168 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       return built
     }
 
+    /** Record one WHERE predicate. The connector is the caller's intent, not a
+     *  position — renderWhereTerms() decides what the first term emits. */
+    const pushWhere = (conn: 'AND' | 'OR', clause: string) => {
+      whereTerms.push({ conn, sql: clause })
+      built = null
+    }
+
+    // Kept so the existing call sites need no edit. Callers pass 'WHERE' to
+    // mean "a where-type clause" (whereLike/whereExists/whereILike/the dynamic
+    // whereX proxy all do); only 'OR' is a real disjunction.
     const addWhereText = (prefix: 'WHERE' | 'AND' | 'OR', clause: string) => {
-      const hasWhere = SQL_PATTERNS.WHERE.test(text)
-      // When a WHERE already exists the new clause needs a CONNECTOR, not a
-      // second WHERE keyword. Callers pass 'WHERE' to mean "a where-type
-      // clause" (whereLike/whereExists/whereILike/dynamic whereX all do); if
-      // one is chained after an existing WHERE, that must become AND — emitting
-      // a literal second `WHERE` produced invalid SQL (`WHERE a = ? WHERE b = ?`).
-      // 'OR'/'AND' connectors pass through unchanged. The first clause is always
-      // forced to WHERE regardless of the requested prefix.
-      const p = !hasWhere ? 'WHERE' : (prefix === 'WHERE' ? 'AND' : prefix)
-      text = `${text} ${p} ${clause}`
+      pushWhere(prefix === 'OR' ? 'OR' : 'AND', clause)
+    }
+
+    // Index of the first TOP-LEVEL clause that must follow WHERE, or -1.
+    // Paren-depth scan so a subquery's own ORDER BY/LIMIT doesn't match.
+    const TAIL_CLAUSE = /\(|\)|\b(?:GROUP\s+BY|HAVING|ORDER\s+BY|LIMIT|OFFSET|WINDOW|UNION|INTERSECT|EXCEPT|FOR\s+UPDATE|FOR\s+SHARE|LOCK\s+IN\s+SHARE\s+MODE)\b/gi
+    const firstTailIndex = (s: string): number => {
+      TAIL_CLAUSE.lastIndex = 0
+      let depth = 0
+      let m: RegExpExecArray | null
+      // eslint-disable-next-line no-cond-assign
+      while ((m = TAIL_CLAUSE.exec(s))) {
+        if (m[0] === '(') { depth++ }
+        else if (m[0] === ')') { depth = Math.max(0, depth - 1) }
+        else if (depth === 0) { return m.index }
+      }
+      return -1
+    }
+
+    /**
+     * `text` with the rendered WHERE spliced in ahead of the first trailing
+     * clause.
+     *
+     * EVERY path that emits executable SQL must go through this. The WHERE no
+     * longer lives in `text`, so reading `text` directly now yields a query
+     * with no filter at all — the worst failure mode available here, and the
+     * reason this function exists rather than the splice being inlined.
+     *
+     * Splicing rather than appending also fixes `.where(a).orderBy(c).orWhere(b)`,
+     * which used to emit `… ORDER BY c ASC OR b` and fail to parse.
+     */
+    const currentSql = (): string => {
+      const body = renderWhereTerms(whereTerms)
+      if (!body)
+        return text
+      if (whereTail) {
+        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
+        return `${text} ${kw} ${body}`
+      }
+      const cut = firstTailIndex(text)
+      return cut >= 0
+        ? `${text.slice(0, cut)}WHERE ${body} ${text.slice(cut)}`
+        : `${text} WHERE ${body}`
+    }
+
+    /**
+     * A parenthesised sub-group: the escape hatch for `(a AND b) OR c`, the one
+     * shape the new precedence rule can no longer express by chaining alone.
+     *
+     * The callback receives a fresh builder over the same table and only its
+     * WHERE state is harvested — nothing else it touches has any effect.
+     */
+    const addWhereGroup = (conn: 'AND' | 'OR', cb: (b: any) => unknown) => {
+      const sub: any = makeSelect(table as any)
+      cb(sub)
+      const st = sub.__whereState?.() as { body: string, params: unknown[] } | undefined
+      if (!st || !st.body) {
+        // Fails closed, for the same reason where() throws on a condition it
+        // does not understand: a group that contributed nothing would leave the
+        // query matching every row the filter existed to exclude.
+        throw new TypeError(
+          '[query-builder] whereGroup(callback): the callback added no conditions. '
+          + 'Add at least one where()/orWhere() to the builder it receives.',
+        )
+      }
+      const offset = whereParams.length
+      // The sub-builder numbered its placeholders from $1; on Postgres they
+      // have to continue ours. `?` dialects need no renumbering.
+      const body = offset > 0 && config.dialect === 'postgres'
+        ? st.body.replace(/\$(\d+)/g, (_m: string, n: string) => `$${Number(n) + offset}`)
+        : st.body
+      whereParams.push(...st.params)
+      pushWhere(conn, `(${body})`)
+    }
+
+    /**
+     * The body of `andWhere` and `orWhere`.
+     *
+     * These were two near-identical 75-line copies that differed only in the
+     * connector they emitted — which is exactly how the OR variant came to be
+     * the one that mis-grouped. One implementation, connector as a parameter.
+     */
+    const addBooleanWhere = (self: any, conn: 'AND' | 'OR', label: string, expr: any, op?: WhereOperator, value?: any) => {
+      if (typeof expr === 'string' && op !== undefined) {
+        validateIdentifier(String(expr), `${label}(column)`)
+        assertSafeWhereOperator(op, `${label}(operator)`)
+        const paramIndex = whereParams.length + 1
+        whereParams.push(value)
+        pushWhere(conn, `${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`)
+        return self
+      }
+
+      // Array format: ['column', 'op', value]
+      if (Array.isArray(expr)) {
+        const [col, rawOp, val] = expr
+        const colName = String(col)
+        validateIdentifier(colName, `${label}(column)`)
+        const operator = assertSafeWhereOperator(rawOp, `${label}(operator)`)
+
+        if (operator === 'in' || operator === 'not in') {
+          const values = Array.isArray(val) ? val : [val]
+          const placeholders = getPlaceholders(values.length, whereParams.length + 1)
+          const clause = renderInPredicate(colName, values, operator === 'not in', placeholders)
+          whereParams.push(...values)
+          pushWhere(conn, clause)
+        }
+        else {
+          const paramIndex = whereParams.length + 1
+          whereParams.push(val)
+          pushWhere(conn, `${colName} ${operator} ${getPlaceholder(paramIndex)}`)
+        }
+        return self
+      }
+
+      // Callback: a parenthesised group, same as where(callback)/whereGroup().
+      if (typeof expr === 'function') {
+        addWhereGroup(conn, expr)
+        return self
+      }
+
+      // Object format: { name: 'Alice', age: 25 }
+      if (expr && typeof expr === 'object' && !('raw' in expr)) {
+        const conditions: string[] = []
+        for (const key of Object.keys(expr)) {
+          validateIdentifier(key, `${label}(column)`)
+          const v = (expr as any)[key]
+          if (Array.isArray(v)) {
+            const placeholders = getPlaceholders(v.length, whereParams.length + 1)
+            conditions.push(renderInPredicate(key, v, false, placeholders))
+            whereParams.push(...v)
+          }
+          else {
+            const paramIndex = whereParams.length + 1
+            conditions.push(`${key} = ${getPlaceholder(paramIndex)}`)
+            whereParams.push(v)
+          }
+        }
+        // One term. `orWhere({a, b})` means "OR (a AND b)", so the conjunction
+        // has to be bracketed — un-bracketed it bound only `a` to the OR.
+        if (conditions.length > 0)
+          pushWhere(conn, conditions.length > 1 ? `(${conditions.join(' AND ')})` : conditions[0])
+        return self
+      }
+
+      // Raw expressions
+      if (expr && typeof (expr as any).raw !== 'undefined') {
+        pushWhere(conn, (expr as any).raw)
+        return self
+      }
+
+      return self
     }
 
     // Append a UNION/UNION ALL (extensible to INTERSECT/EXCEPT) while MERGING
@@ -3190,6 +3368,15 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
     // ours on Postgres — previously the set-op appended text only, dropping the
     // right side's params and colliding `$1`. See stacksjs/bun-query-builder#1029.
     const appendSetOp = (op: string, other: { toSQL: () => any, __rawState?: () => { sql: string, params: unknown[] } }) => {
+      // Params are one flat array in push order, so the WHERE text has to
+      // precede the set operator's params in the emitted string. Materialize it
+      // into `text` now; terms added after this point belong to the RIGHT-hand
+      // SELECT and render at the end — which is what the old text-append did.
+      if (whereTerms.length > 0) {
+        text = currentSql()
+        whereTerms.length = 0
+      }
+      whereTail = true
       const st = other.__rawState?.()
       if (st) {
         const offset = whereParams.length
@@ -3314,9 +3501,6 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       joinedTables.add(resolved.pivotTable)
     }
 
-    // Track WHERE conditions and parameters for proper merging
-    const whereConditions: string[] = []
-    const whereParams: unknown[] = []
 
     // Helper function to add columns to the SELECT clause
     const addToSelectClause = (columnsToAdd: string): void => {
@@ -4131,11 +4315,10 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           throw new Error(`[query-builder] Unsupported relationship type '${type}' for whereHas`)
         }
 
-        built = sql`${ensureBuilt()} WHERE EXISTS (${sql([subquerySQL] as any)})`
-        try {
-          addWhereText('WHERE', `EXISTS (${subquerySQL})`)
-        }
-        catch {}
+        // The record of truth is the term list; ensureBuilt() renders from it.
+        // This used to ALSO assign `built = sql`${ensureBuilt()} WHERE ...``, a
+        // parallel representation carrying an unconditional WHERE keyword. See #1083.
+        addWhereText('WHERE', `EXISTS (${subquerySQL})`)
 
         return this as any
       },
@@ -4184,11 +4367,8 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           throw new Error(`[query-builder] Unsupported relationship type '${type}' for whereDoesntHave`)
         }
 
-        built = sql`${ensureBuilt()} WHERE NOT EXISTS (${sql([subquerySQL] as any)})`
-        try {
-          addWhereText('WHERE', `NOT EXISTS (${subquerySQL})`)
-        }
-        catch {}
+        // See the note in whereHas: the term list is the single record.
+        addWhereText('WHERE', `NOT EXISTS (${subquerySQL})`)
 
         return this as any
       },
@@ -4235,11 +4415,10 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           throw new Error(`[query-builder] Unsupported relationship type '${type}' for has`)
         }
 
-        built = sql`${ensureBuilt()} WHERE EXISTS (${sql([subquerySQL] as any)})`
-        try {
-          addWhereText('WHERE', `EXISTS (${subquerySQL})`)
-        }
-        catch {}
+        // The record of truth is the term list; ensureBuilt() renders from it.
+        // This used to ALSO assign `built = sql`${ensureBuilt()} WHERE ...``, a
+        // parallel representation carrying an unconditional WHERE keyword. See #1083.
+        addWhereText('WHERE', `EXISTS (${subquerySQL})`)
 
         return this as any
       },
@@ -4286,11 +4465,8 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           throw new Error(`[query-builder] Unsupported relationship type '${type}' for doesntHave`)
         }
 
-        built = sql`${ensureBuilt()} WHERE NOT EXISTS (${sql([subquerySQL] as any)})`
-        try {
-          addWhereText('WHERE', `NOT EXISTS (${subquerySQL})`)
-        }
-        catch {}
+        // See the note in whereHas: the term list is the single record.
+        addWhereText('WHERE', `NOT EXISTS (${subquerySQL})`)
 
         return this as any
       },
@@ -4423,17 +4599,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         const val = value === undefined ? opOrValue : value
         const paramIndex = whereParams.length + 1
         const clause = `${resolved.pivotTable}.${column} ${op} ${getPlaceholder(paramIndex)}`
-        whereConditions.push(clause)
         whereParams.push(val)
-        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${kw} ${clause}`
-        built = null
+        pushWhere('AND', clause)
         if (resolved.hasConfig)
           pivotConfigRelations.add(relation)
         return this as any
       },
       wherePivotIn(relation: string, column: string, values: any[]) {
-        if (!meta || !Array.isArray(values) || values.length === 0)
+        if (!meta || !Array.isArray(values))
           return this as any
         const resolved = resolvePivotLocal(relation)
         if (!resolved) {
@@ -4443,13 +4616,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         validateIdentifier(column, 'wherePivotIn (column)')
         ensurePivotJoined(resolved)
 
+        // An empty list is FALSE, not absent: `return this` here dropped the
+        // predicate and widened the query to every row it existed to exclude.
+        // `wherePivotNotIn([])` keeps its no-op below — non-membership in the
+        // empty set is TRUE, so dropping the term there is correct. See #1083.
         const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-        const clause = `${resolved.pivotTable}.${column} IN (${placeholders})`
-        whereConditions.push(clause)
+        const clause = renderInPredicate(`${resolved.pivotTable}.${column}`, values, false, placeholders)
         whereParams.push(...values)
-        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${kw} ${clause}`
-        built = null
+        pushWhere('AND', clause)
         if (resolved.hasConfig)
           pivotConfigRelations.add(relation)
         return this as any
@@ -4467,11 +4641,8 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
 
         const placeholders = getPlaceholders(values.length, whereParams.length + 1)
         const clause = `${resolved.pivotTable}.${column} NOT IN (${placeholders})`
-        whereConditions.push(clause)
         whereParams.push(...values)
-        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${kw} ${clause}`
-        built = null
+        pushWhere('AND', clause)
         if (resolved.hasConfig)
           pivotConfigRelations.add(relation)
         return this as any
@@ -4485,11 +4656,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         validateIdentifier(resolved.pivotTable, 'wherePivotNull (pivot table)')
         validateIdentifier(column, 'wherePivotNull (column)')
         ensurePivotJoined(resolved)
-        const clause = `${resolved.pivotTable}.${column} IS NULL`
-        whereConditions.push(clause)
-        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${kw} ${clause}`
-        built = null
+        pushWhere('AND', `${resolved.pivotTable}.${column} IS NULL`)
         if (resolved.hasConfig)
           pivotConfigRelations.add(relation)
         return this as any
@@ -4503,19 +4670,12 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         validateIdentifier(resolved.pivotTable, 'wherePivotNotNull (pivot table)')
         validateIdentifier(column, 'wherePivotNotNull (column)')
         ensurePivotJoined(resolved)
-        const clause = `${resolved.pivotTable}.${column} IS NOT NULL`
-        whereConditions.push(clause)
-        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${kw} ${clause}`
-        built = null
+        pushWhere('AND', `${resolved.pivotTable}.${column} IS NOT NULL`)
         if (resolved.hasConfig)
           pivotConfigRelations.add(relation)
         return this as any
       },
       where(expr: any, op?: WhereOperator, value?: any) {
-        // Helper to get the correct keyword (WHERE for first condition, AND for subsequent)
-        const getWhereKeyword = () => SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-
         if (typeof expr === 'string' && op !== undefined) {
           // Boundary validation: the column and operator are interpolated
           // into SQL text (values stay parameterized). Compile-time types
@@ -4533,19 +4693,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           if (operator === 'in' || operator === 'not in') {
             const values = Array.isArray(value) ? value : [value]
             const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-            const clause = `${String(expr)} ${operator.toUpperCase()} (${placeholders})`
-            whereConditions.push(clause)
+            const clause = renderInPredicate(String(expr), values, operator === 'not in', placeholders)
             whereParams.push(...values)
-            text = `${text} ${getWhereKeyword()} ${clause}`
-            built = null
+            pushWhere('AND', clause)
             return this
           }
           const paramIndex = whereParams.length + 1
-          whereConditions.push(`${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`)
           whereParams.push(value)
-          // Update built and text immediately
-          text = `${text} ${getWhereKeyword()} ${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`
-          built = null
+          pushWhere('AND', `${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`)
           return this
         }
 
@@ -4559,17 +4714,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           if (operator === 'in' || operator === 'not in') {
             const values = Array.isArray(val) ? val : [val]
             const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-            whereConditions.push(`${colName} ${operator.toUpperCase()} (${placeholders})`)
+            const clause = renderInPredicate(colName, values, operator === 'not in', placeholders)
             whereParams.push(...values)
-            text = `${text} ${getWhereKeyword()} ${colName} ${operator.toUpperCase()} (${placeholders})`
-            built = null
+            pushWhere('AND', clause)
           }
           else {
             const paramIndex = whereParams.length + 1
-            whereConditions.push(`${colName} ${operator} ${getPlaceholder(paramIndex)}`)
             whereParams.push(val)
-            text = `${text} ${getWhereKeyword()} ${colName} ${operator} ${getPlaceholder(paramIndex)}`
-            built = null
+            pushWhere('AND', `${colName} ${operator} ${getPlaceholder(paramIndex)}`)
           }
 
           return this
@@ -4586,30 +4738,27 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
             const value = whereObject[key]
             if (Array.isArray(value)) {
               const placeholders = getPlaceholders(value.length, whereParams.length + 1)
-              conditions.push(`${key} IN (${placeholders})`)
-              whereConditions.push(`${key} IN (${placeholders})`)
+              conditions.push(renderInPredicate(key, value, false, placeholders))
               whereParams.push(...value)
             }
             else {
               const paramIndex = whereParams.length + 1
               conditions.push(`${key} = ${getPlaceholder(paramIndex)}`)
-              whereConditions.push(`${key} = ${getPlaceholder(paramIndex)}`)
               whereParams.push(value)
             }
           }
 
-          if (conditions.length > 0) {
-            text = `${text} ${getWhereKeyword()} ${conditions.join(' AND ')}`
-            built = null
-          }
+          // One term, not one per key: an object literal is a single
+          // conjunction, so a later `.orWhere(z)` must OR against the whole of
+          // it rather than against its last key.
+          if (conditions.length > 0)
+            pushWhere('AND', conditions.length > 1 ? `(${conditions.join(' AND ')})` : conditions[0])
           return this
         }
 
         // Handle raw expressions
         if (isRawExpression(expr)) {
-          whereConditions.push(expr.raw)
-          text = `${text} ${getWhereKeyword()} ${expr.raw}`
-          built = null
+          pushWhere('AND', expr.raw)
           return this
         }
 
@@ -4619,17 +4768,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // A `where` that fails open is a data leak in any application where the
         // filter is the access check, and nothing anywhere says it happened.
         //
-        // The callback form is the one people actually write, because that is
-        // how Kysely and Knex express an `OR` group. It is not supported here -
-        // `whereNested`, `whereAny` and the `orWhere*` helpers are - so it says
-        // so instead of ignoring it.
+        // The callback form is the one people actually write, because it is how
+        // Kysely and Knex express a group, and docs/guide/where.md has shown it
+        // for longer than the builder has rejected it. It is now a real group —
+        // see addWhereGroup, which still throws if the callback adds nothing, so
+        // the fails-closed guarantee is unchanged.
         if (typeof expr === 'function') {
-          throw new TypeError(
-            'where(callback) is not supported. This builder has no expression callback, and '
-            + 'ignoring one silently would leave the query matching every row the filter was '
-            + 'meant to exclude. Use whereNested(subquery), whereAny(...), or the orWhere* '
-            + 'helpers to build a grouped condition.',
-          )
+          addWhereGroup('AND', expr)
+          return this
         }
 
         if (expr === undefined || expr === null) {
@@ -4648,52 +4794,83 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       // where helpers
       whereNull(column: string) {
         validateIdentifier(String(column), 'whereNull(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${keyword} ${String(column)} IS NULL`
-        built = null
+        pushWhere('AND', `${String(column)} IS NULL`)
         return this
       },
       whereNotNull(column: string) {
         validateIdentifier(String(column), 'whereNotNull(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${keyword} ${String(column)} IS NOT NULL`
-        built = null
+        pushWhere('AND', `${String(column)} IS NOT NULL`)
         return this
+      },
+      orWhereNull(column: string) {
+        validateIdentifier(String(column), 'orWhereNull(column)')
+        pushWhere('OR', `${String(column)} IS NULL`)
+        return this as any
+      },
+      orWhereNotNull(column: string) {
+        validateIdentifier(String(column), 'orWhereNotNull(column)')
+        pushWhere('OR', `${String(column)} IS NOT NULL`)
+        return this as any
       },
       whereBetween(column: string, start: any, end: any) {
         validateIdentifier(String(column), 'whereBetween(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         // Dialect-aware placeholders: Postgres needs `$n`, not `?` (#1027).
         const i = whereParams.length + 1
-        text = `${text} ${keyword} ${String(column)} BETWEEN ${getPlaceholder(i)} AND ${getPlaceholder(i + 1)}`
         whereParams.push(start, end)
-        built = null
+        pushWhere('AND', `${String(column)} BETWEEN ${getPlaceholder(i)} AND ${getPlaceholder(i + 1)}`)
         return this
       },
+      orWhereBetween(column: string, start: any, end: any) {
+        validateIdentifier(String(column), 'orWhereBetween(column)')
+        const i = whereParams.length + 1
+        whereParams.push(start, end)
+        pushWhere('OR', `${String(column)} BETWEEN ${getPlaceholder(i)} AND ${getPlaceholder(i + 1)}`)
+        return this as any
+      },
       whereExists(subquery: { toSQL: () => any }) {
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text = `${text} ${keyword} EXISTS (${subquery.toSQL()})`
-        built = null
+        pushWhere('AND', `EXISTS (${subquery.toSQL()})`)
         return this
+      },
+      orWhereExists(subquery: { toSQL: () => any }) {
+        pushWhere('OR', `EXISTS (${subquery.toSQL()})`)
+        return this as any
+      },
+      /**
+       * A parenthesised group of conditions.
+       *
+       * This is the escape hatch for `(a AND b) OR c` — the shape that chaining
+       * alone can no longer express now that a chained `orWhere` groups with the
+       * term before it. See renderWhereTerms and #1083.
+       */
+      whereGroup(cb: (b: any) => unknown) {
+        addWhereGroup('AND', cb)
+        return this as any
+      },
+      orWhereGroup(cb: (b: any) => unknown) {
+        addWhereGroup('OR', cb)
+        return this as any
+      },
+      /** Internal: the rendered WHERE body and its params, harvested by whereGroup(). */
+      __whereState() {
+        return { body: renderWhereTerms(whereTerms), params: [...whereParams] }
       },
       whereJsonContains(column: string, json: unknown) {
         // Dialect-aware JSON containment. Previously hardcoded Postgres `@>`,
         // which is a syntax error on MySQL/SQLite and ignored the configured
         // `jsonContainsMode`. See stacksjs/bun-query-builder#1026.
         validateIdentifier(String(column), 'whereJsonContains(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const dialect = config.dialect
         const idx = whereParams.length + 1
         if (dialect === 'postgres') {
           // operator (`@>`, default) or function (`jsonb_contains`) per config.
           if (config.sql?.jsonContainsMode === 'function')
-            text += ` ${keyword} jsonb_contains(${column}, ${getPlaceholder(idx)})`
+            pushWhere('AND', `jsonb_contains(${column}, ${getPlaceholder(idx)})`)
           else
-            text += ` ${keyword} ${column} @> ${getPlaceholder(idx)}`
+            pushWhere('AND', `${column} @> ${getPlaceholder(idx)}`)
           whereParams.push(JSON.stringify(json))
         }
         else if (isMysqlLike(dialect)) {
-          text += ` ${keyword} JSON_CONTAINS(${column}, ${getPlaceholder(idx)})`
+          pushWhere('AND', `JSON_CONTAINS(${column}, ${getPlaceholder(idx)})`)
           whereParams.push(JSON.stringify(json))
         }
         else {
@@ -4703,18 +4880,17 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           // value must be present.
           if (Array.isArray(json)) {
             const conds = json.map((_, i) => `EXISTS (SELECT 1 FROM json_each(${column}) WHERE json_each.value = ${getPlaceholder(idx + i)})`)
-            text += ` ${keyword} (${conds.join(' AND ')})`
+            pushWhere('AND', `(${conds.join(' AND ')})`)
             for (const v of json) whereParams.push(v as any)
           }
           else if (json !== null && typeof json === 'object') {
             throw new Error('[query-builder] whereJsonContains: object containment is not supported on SQLite — pass a scalar or array, or use whereJsonPath.')
           }
           else {
-            text += ` ${keyword} EXISTS (SELECT 1 FROM json_each(${column}) WHERE json_each.value = ${getPlaceholder(idx)})`
+            pushWhere('AND', `EXISTS (SELECT 1 FROM json_each(${column}) WHERE json_each.value = ${getPlaceholder(idx)})`)
             whereParams.push(json as any)
           }
         }
-        built = null
         return this as any
       },
       whereJsonPath(path: string, op: WhereOperator, value: any) {
@@ -4733,19 +4909,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           throw new TypeError(`[query-builder] whereJsonPath(path): refusing to use '${path}' — contains characters outside the allowed JSON-path set`)
 
         const dialect = config.dialect
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const idx = whereParams.length + 1
-        if (dialect === 'postgres') {
-          text += ` ${keyword} ${path} ${op} ${getPlaceholder(idx)}`
-        }
-        else if (isMysqlLike(dialect)) {
-          text += ` ${keyword} JSON_EXTRACT(${path}) ${op} ${getPlaceholder(idx)}`
-        }
-        else {
-          text += ` ${keyword} json_extract(${path}) ${op} ${getPlaceholder(idx)}`
-        }
+        if (dialect === 'postgres')
+          pushWhere('AND', `${path} ${op} ${getPlaceholder(idx)}`)
+        else if (isMysqlLike(dialect))
+          pushWhere('AND', `JSON_EXTRACT(${path}) ${op} ${getPlaceholder(idx)}`)
+        else
+          pushWhere('AND', `json_extract(${path}) ${op} ${getPlaceholder(idx)}`)
         whereParams.push(value)
-        built = null
         return this as any
       },
       // The LIKE/ILIKE family records the clause in `text` + `whereParams`
@@ -4834,46 +5005,36 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // because TRUE genuinely is their identity. The asymmetry is the point,
         // not an inconsistency to tidy up.
         if (cols.length === 0) {
-          const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-          text += ` ${kw} (${FALSE_PREDICATE})`
-          built = null
+          pushWhere('AND', `(${FALSE_PREDICATE})`)
           return this as any
         }
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const idx = whereParams.length + 1
         const conds = cols.map((c, i) => `${c} ${op} ${getPlaceholder(idx + i)}`)
-        text += ` ${keyword} (${conds.join(' OR ')})`
         for (let i = 0; i < cols.length; i++) whereParams.push(value)
-        built = null
+        pushWhere('AND', `(${conds.join(' OR ')})`)
         return this as any
       },
       whereAll(cols: string[], op: WhereOperator, value: any) {
         if (cols.length === 0) return this as any
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const idx = whereParams.length + 1
         const conds = cols.map((c, i) => `${c} ${op} ${getPlaceholder(idx + i)}`)
-        text += ` ${keyword} (${conds.join(' AND ')})`
         for (let i = 0; i < cols.length; i++) whereParams.push(value)
-        built = null
+        pushWhere('AND', `(${conds.join(' AND ')})`)
         return this as any
       },
       whereNone(cols: string[], op: WhereOperator, value: any) {
         if (cols.length === 0) return this as any
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const idx = whereParams.length + 1
         const conds = cols.map((c, i) => `${c} ${op} ${getPlaceholder(idx + i)}`)
-        text += ` ${keyword} NOT (${conds.join(' OR ')})`
         for (let i = 0; i < cols.length; i++) whereParams.push(value)
-        built = null
+        pushWhere('AND', `NOT (${conds.join(' OR ')})`)
         return this as any
       },
       whereNotBetween(column: string, start: any, end: any) {
         validateIdentifier(String(column), 'whereNotBetween(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const i = whereParams.length + 1
-        text += ` ${keyword} ${column} NOT BETWEEN ${getPlaceholder(i)} AND ${getPlaceholder(i + 1)}`
         whereParams.push(start, end)
-        built = null
+        pushWhere('AND', `${column} NOT BETWEEN ${getPlaceholder(i)} AND ${getPlaceholder(i + 1)}`)
         return this as any
       },
       whereDate(column: string, op: WhereOperator, date: string | Date) {
@@ -4887,253 +5048,101 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           : typeof date === 'string'
             ? date
             : (() => { throw new TypeError(`[query-builder] whereDate(date): expected string or Date, got ${typeof date}`) })()
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const idx = whereParams.length + 1
-        text += ` ${keyword} ${column} ${op} ${getPlaceholder(idx)}`
         whereParams.push(dateString)
-        built = null
+        pushWhere('AND', `${column} ${op} ${getPlaceholder(idx)}`)
         return this as any
       },
+      // A raw fragment is ONE term and is deliberately not auto-parenthesised —
+      // wrapping would churn emitted SQL for no correctness gain. A fragment
+      // containing a top-level OR must bracket itself; see docs/guide/where.md.
       whereRaw(fragment: any) {
-        const frag = renderRawFragment(fragment, 'whereRaw(fragment)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text += ` ${keyword} ${frag}`
-        built = null
+        pushWhere('AND', renderRawFragment(fragment, 'whereRaw(fragment)'))
+        return this as any
+      },
+      orWhereRaw(fragment: any) {
+        pushWhere('OR', renderRawFragment(fragment, 'orWhereRaw(fragment)'))
         return this as any
       },
       whereColumn(left: string, op: WhereOperator, right: string) {
         validateIdentifier(left, 'whereColumn(left)')
         validateIdentifier(right, 'whereColumn(right)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
-        text += ` ${keyword} ${left} ${op} ${right}`
-        built = null
+        pushWhere('AND', `${left} ${op} ${right}`)
         return this as any
       },
       orWhereColumn(left: string, op: WhereOperator, right: string) {
         validateIdentifier(left, 'orWhereColumn(left)')
         validateIdentifier(right, 'orWhereColumn(right)')
-        text += ` OR ${left} ${op} ${right}`
-        built = null
+        pushWhere('OR', `${left} ${op} ${right}`)
         return this as any
       },
       whereIn(column: string, values: any[] | { toSQL: () => any }) {
         validateIdentifier(String(column), 'whereIn(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` ${keyword} ${renderInPredicate(column, values, false, placeholders)}`
+          const clause = renderInPredicate(column, values, false, placeholders)
           whereParams.push(...values)
+          pushWhere('AND', clause)
         }
         else {
-          text += ` ${keyword} ${column} IN (${String((values as any).toSQL())})`
+          pushWhere('AND', `${column} IN (${String((values as any).toSQL())})`)
         }
-        built = null
         return this as any
       },
       orWhereIn(column: string, values: any[] | { toSQL: () => any }) {
         validateIdentifier(String(column), 'orWhereIn(column)')
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` OR ${renderInPredicate(column, values, false, placeholders)}`
+          const clause = renderInPredicate(column, values, false, placeholders)
           whereParams.push(...values)
+          pushWhere('OR', clause)
         }
         else {
-          text += ` OR ${column} IN (${String((values as any).toSQL())})`
+          pushWhere('OR', `${column} IN (${String((values as any).toSQL())})`)
         }
-        built = null
         return this as any
       },
       whereNotIn(column: string, values: any[] | { toSQL: () => any }) {
         validateIdentifier(String(column), 'whereNotIn(column)')
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` ${keyword} ${renderInPredicate(column, values, true, placeholders)}`
+          const clause = renderInPredicate(column, values, true, placeholders)
           whereParams.push(...values)
+          pushWhere('AND', clause)
         }
         else {
-          text += ` ${keyword} ${column} NOT IN (${String((values as any).toSQL())})`
+          pushWhere('AND', `${column} NOT IN (${String((values as any).toSQL())})`)
         }
-        built = null
         return this as any
       },
       orWhereNotIn(column: string, values: any[] | { toSQL: () => any }) {
         validateIdentifier(String(column), 'orWhereNotIn(column)')
         if (Array.isArray(values)) {
           const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-          text += ` OR ${renderInPredicate(column, values, true, placeholders)}`
+          const clause = renderInPredicate(column, values, true, placeholders)
           whereParams.push(...values)
+          pushWhere('OR', clause)
         }
         else {
-          text += ` OR ${column} NOT IN (${String((values as any).toSQL())})`
+          pushWhere('OR', `${column} NOT IN (${String((values as any).toSQL())})`)
         }
-        built = null
         return this as any
       },
       whereNested(fragment: any) {
-        const keyword = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
         const inner = fragment.toSQL ? String(fragment.toSQL()) : String(fragment)
-        text += ` ${keyword} (${inner})`
-        built = null
+        pushWhere('AND', `(${inner})`)
         return this as any
       },
       orWhereNested(fragment: any) {
         const inner = fragment.toSQL ? String(fragment.toSQL()) : String(fragment)
-        text += ` OR (${inner})`
-        built = null
+        pushWhere('OR', `(${inner})`)
         return this as any
       },
       andWhere(expr: any, op?: WhereOperator, value?: any) {
-        if (typeof expr === 'string' && op !== undefined) {
-          validateIdentifier(String(expr), 'andWhere(column)')
-          assertSafeWhereOperator(op, 'andWhere(operator)')
-          const paramIndex = whereParams.length + 1
-          whereConditions.push(`${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`)
-          whereParams.push(value)
-          text = `${text} AND ${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`
-          built = null
-          return this
-        }
-
-        // Handle array format: ['column', 'op', value]
-        if (Array.isArray(expr)) {
-          const [col, op, val] = expr
-          const colName = String(col)
-          validateIdentifier(colName, 'andWhere(column)')
-          const operator = assertSafeWhereOperator(op, 'andWhere(operator)')
-
-          if (operator === 'in' || operator === 'not in') {
-            const values = Array.isArray(val) ? val : [val]
-            const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-            whereConditions.push(`${colName} ${operator.toUpperCase()} (${placeholders})`)
-            whereParams.push(...values)
-            text = `${text} AND ${colName} ${operator.toUpperCase()} (${placeholders})`
-            built = null
-          }
-          else {
-            const paramIndex = whereParams.length + 1
-            whereConditions.push(`${colName} ${operator} ${getPlaceholder(paramIndex)}`)
-            whereParams.push(val)
-            text = `${text} AND ${colName} ${operator} ${getPlaceholder(paramIndex)}`
-            built = null
-          }
-
-          return this
-        }
-
-        // Handle object format: { name: 'Alice', age: 25 }
-        if (expr && typeof expr === 'object' && !('raw' in expr)) {
-          const keys = Object.keys(expr)
-          const conditions: string[] = []
-
-          for (const key of keys) {
-            const value = (expr as any)[key]
-            if (Array.isArray(value)) {
-              const placeholders = getPlaceholders(value.length, whereParams.length + 1)
-              conditions.push(`${key} IN (${placeholders})`)
-              whereConditions.push(`${key} IN (${placeholders})`)
-              whereParams.push(...value)
-            }
-            else {
-              const paramIndex = whereParams.length + 1
-              conditions.push(`${key} = ${getPlaceholder(paramIndex)}`)
-              whereConditions.push(`${key} = ${getPlaceholder(paramIndex)}`)
-              whereParams.push(value)
-            }
-          }
-
-          if (conditions.length > 0) {
-            text = `${text} AND ${conditions.join(' AND ')}`
-            built = null
-          }
-          return this
-        }
-
-        // Handle raw expressions
-        if (expr && typeof (expr as any).raw !== 'undefined') {
-          whereConditions.push((expr as any).raw)
-          text = `${text} AND ${(expr as any).raw}`
-          built = null
-          return this
-        }
-
-        return this
+        return addBooleanWhere(this, 'AND', 'andWhere', expr, op, value)
       },
       orWhere(expr: any, op?: WhereOperator, value?: any) {
-        if (typeof expr === 'string' && op !== undefined) {
-          validateIdentifier(String(expr), 'orWhere(column)')
-          assertSafeWhereOperator(op, 'orWhere(operator)')
-          const paramIndex = whereParams.length + 1
-          whereConditions.push(`OR ${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`)
-          whereParams.push(value)
-          text = `${text} OR ${String(expr)} ${String(op)} ${getPlaceholder(paramIndex)}`
-          built = null
-          return this
-        }
-
-        // Handle array format: ['column', 'op', value]
-        if (Array.isArray(expr)) {
-          const [col, op, val] = expr
-          const colName = String(col)
-          validateIdentifier(colName, 'orWhere(column)')
-          const operator = assertSafeWhereOperator(op, 'orWhere(operator)')
-
-          if (operator === 'in' || operator === 'not in') {
-            const values = Array.isArray(val) ? val : [val]
-            const placeholders = getPlaceholders(values.length, whereParams.length + 1)
-            whereConditions.push(`OR ${colName} ${operator.toUpperCase()} (${placeholders})`)
-            whereParams.push(...values)
-            text = `${text} OR ${colName} ${operator.toUpperCase()} (${placeholders})`
-            built = null
-          }
-          else {
-            const paramIndex = whereParams.length + 1
-            whereConditions.push(`OR ${colName} ${operator} ${getPlaceholder(paramIndex)}`)
-            whereParams.push(val)
-            text = `${text} OR ${colName} ${operator} ${getPlaceholder(paramIndex)}`
-            built = null
-          }
-
-          return this
-        }
-
-        // Handle object format: { name: 'Alice', age: 25 }
-        if (expr && typeof expr === 'object' && !('raw' in expr)) {
-          const keys = Object.keys(expr)
-          const conditions: string[] = []
-
-          for (const key of keys) {
-            const value = (expr as any)[key]
-            if (Array.isArray(value)) {
-              const placeholders = getPlaceholders(value.length, whereParams.length + 1)
-              conditions.push(`${key} IN (${placeholders})`)
-              whereConditions.push(`OR ${key} IN (${placeholders})`)
-              whereParams.push(...value)
-            }
-            else {
-              const paramIndex = whereParams.length + 1
-              conditions.push(`${key} = ${getPlaceholder(paramIndex)}`)
-              whereConditions.push(`OR ${key} = ${getPlaceholder(paramIndex)}`)
-              whereParams.push(value)
-            }
-          }
-
-          if (conditions.length > 0) {
-            text = `${text} OR ${conditions.join(' AND ')}`
-            built = null
-          }
-          return this
-        }
-
-        // Handle raw expressions
-        if (expr && typeof (expr as any).raw !== 'undefined') {
-          whereConditions.push(`OR ${(expr as any).raw}`)
-          text = `${text} OR ${(expr as any).raw}`
-          built = null
-          return this
-        }
-
-        return this
+        return addBooleanWhere(this, 'OR', 'orWhere', expr, op, value)
       },
       orderBy(column: string, direction: 'asc' | 'desc' = 'asc') {
         // Compose-aware: detect an existing ORDER BY clause and append the
@@ -5439,7 +5448,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // text — most toSQL() calls never execute the returned handle.
         // ensureBuilt() still runs (memoized) if execute()/values()/raw()
         // is actually invoked.
-        const sqlText = reorderSelectClauses(text)
+        const sqlText = reorderSelectClauses(currentSql())
         return {
           sql: sqlText,
           toString: () => sqlText,
@@ -5498,7 +5507,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // so a concurrent INSERT/DELETE can't desync `total` from `data.length`.
         // The caller owns the transaction (and thus the isolation level).
         if (opts.tx) {
-          const baseSql = reorderSelectClauses(text)
+          const baseSql = reorderSelectClauses(currentSql())
           const baseParams = [...whereParams]
           const cRows = await opts.tx.unsafe(`SELECT COUNT(*) as c FROM (${baseSql}) as sub`, baseParams) as any[]
           const total = Number(cRows?.[0]?.c ?? 0)
@@ -5712,7 +5721,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return (ensureBuilt() as any).simple()
       },
       toText() {
-        return text
+        return currentSql()
       },
       async get() {
         const hooks = activeHooks()
@@ -5722,15 +5731,16 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         if (!config.softDeletes?.enabled && !useCache && !timeoutMs && !abortSignal && !hasQueryHooks) {
           const prepareFn = _sql._prepareStatement
           if (prepareFn) {
-            const stmt = prepareFn(text)
+            const stmt = prepareFn(currentSql())
             return hydratePivotRows(whereParams.length > 0 ? stmt.all(...whereParams) : stmt.all())
           }
         }
 
         // Build query at execution time (statement will be cached by db-clients.ts)
+        const getText = currentSql()
         built = whereParams.length > 0
-          ? _sql.unsafe(text, whereParams)
-          : _sql.unsafe(text)
+          ? _sql.unsafe(getText, whereParams)
+          : _sql.unsafe(getText)
 
         // Fast path: no soft-deletes, no cache, no timeout, no signal, no hooks
         if (!config.softDeletes?.enabled && !useCache && !timeoutMs && !abortSignal && !hasQueryHooks) {
@@ -5754,9 +5764,12 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           const col = config.softDeletes.column
           const tbl = String(table)
           const hasCol = schema ? Boolean((schema as any)[tbl]?.columns?.[col]) : true
-          if (hasCol && !SQL_PATTERNS.DELETED_AT.test(text)) {
-            finalQuery = sql`${ensureBuilt()} WHERE ${sql(String(col))} IS ${onlyTrashed ? sql`NOT NULL` : sql`NULL`}`
+          if (hasCol && !SQL_PATTERNS.DELETED_AT.test(currentSql())) {
+            // Record the term, then rebuild. The previous version composed
+            // `sql`${ensureBuilt()} WHERE ...`` as well, which appended a second
+            // unconditional WHERE keyword on top of any filter already present.
             addWhereText('WHERE', `${String(col)} IS ${onlyTrashed ? 'NOT ' : ''}NULL`)
+            finalQuery = ensureBuilt()
           }
         }
 
@@ -5798,7 +5811,8 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         if (!config.softDeletes?.enabled && !useCache && !timeoutMs && !abortSignal && !fHasQueryHooks) {
           const prepareFn = _sql._prepareStatement
           if (prepareFn) {
-            const firstText = text.includes(' LIMIT ') ? text : `${text} LIMIT 1`
+            const base = currentSql()
+            const firstText = base.includes(' LIMIT ') ? base : `${base} LIMIT 1`
             const stmt = prepareFn(firstText)
             const rows = whereParams.length > 0 ? stmt.all(...whereParams) : stmt.all()
             return hydratePivotRow(rows[0]) as any
@@ -5874,14 +5888,17 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // `rows[0]` silently returns just the first group's count.
         // Wrap in a subquery when GROUP BY is present.
         // See stacksjs/stacks#1862 #26.
-        const fromIdx = text.indexOf(' FROM ')
-        const hasGroupBy = / GROUP BY /i.test(text)
+        // Rebuild from currentSql(), not `text` — the WHERE lives in the term
+        // list now, and slicing `text` here would count the UNFILTERED table.
+        const src = currentSql()
+        const fromIdx = src.indexOf(' FROM ')
+        const hasGroupBy = / GROUP BY /i.test(src)
         let countText: string
         if (hasGroupBy) {
-          countText = `SELECT COUNT(*) as c FROM (${text}) AS _bqb_count_sub`
+          countText = `SELECT COUNT(*) as c FROM (${src}) AS _bqb_count_sub`
         }
         else if (fromIdx !== -1) {
-          countText = `SELECT COUNT(*) as c${text.substring(fromIdx)}`
+          countText = `SELECT COUNT(*) as c${src.substring(fromIdx)}`
         }
         else {
           countText = `SELECT COUNT(*) as c FROM ${table}`
@@ -5908,9 +5925,10 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       },
       async avg(column: string) {
         // Build optimized AVG query without subquery or helpers
-        const fromIdx = text.indexOf(' FROM ')
+        const src = currentSql()
+        const fromIdx = src.indexOf(' FROM ')
         const avgText = fromIdx !== -1
-          ? `SELECT AVG(${column}) as a${text.substring(fromIdx)}`
+          ? `SELECT AVG(${column}) as a${src.substring(fromIdx)}`
           : `SELECT AVG(${column}) as a FROM ${table}`
 
         // Ultra-fast path
@@ -5933,9 +5951,10 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return Number(row?.a ?? 0)
       },
       async sum(column: string) {
-        const fromIdx = text.indexOf(' FROM ')
+        const src = currentSql()
+        const fromIdx = src.indexOf(' FROM ')
         const sumText = fromIdx !== -1
-          ? `SELECT SUM(${column}) as s${text.substring(fromIdx)}`
+          ? `SELECT SUM(${column}) as s${src.substring(fromIdx)}`
           : `SELECT SUM(${column}) as s FROM ${table}`
         const q = whereParams.length > 0
           ? _sql.unsafe(sumText, whereParams)
@@ -5945,9 +5964,10 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return Number(row?.s ?? 0)
       },
       async max(column: string) {
-        const fromIdx = text.indexOf(' FROM ')
+        const src = currentSql()
+        const fromIdx = src.indexOf(' FROM ')
         const maxText = fromIdx !== -1
-          ? `SELECT MAX(${column}) as m${text.substring(fromIdx)}`
+          ? `SELECT MAX(${column}) as m${src.substring(fromIdx)}`
           : `SELECT MAX(${column}) as m FROM ${table}`
         const q = whereParams.length > 0
           ? _sql.unsafe(maxText, whereParams)
@@ -5957,9 +5977,10 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return row?.m
       },
       async min(column: string) {
-        const fromIdx = text.indexOf(' FROM ')
+        const src = currentSql()
+        const fromIdx = src.indexOf(' FROM ')
         const minText = fromIdx !== -1
-          ? `SELECT MIN(${column}) as m${text.substring(fromIdx)}`
+          ? `SELECT MIN(${column}) as m${src.substring(fromIdx)}`
           : `SELECT MIN(${column}) as m FROM ${table}`
         const q = whereParams.length > 0
           ? _sql.unsafe(minText, whereParams)
@@ -6009,7 +6030,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       // by union()/unionAll() on the other side to merge params and renumber
       // placeholders. See stacksjs/bun-query-builder#1029.
       __rawState() {
-        return { sql: reorderSelectClauses(text), params: [...whereParams] }
+        return { sql: reorderSelectClauses(currentSql()), params: [...whereParams] }
       },
       raw() {
         return (ensureBuilt() as any).raw()
@@ -6067,20 +6088,13 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
             return () => receiver
           const column = chosen
           return (value: any) => {
-            const expr = Array.isArray(value)
-              ? sql`${sql(column)} IN ${sql(value as any)}`
-              : sql`${sql(column)} = ${value}`
-            built = isOr
-              ? sql`${ensureBuilt()} OR ${expr}`
-              : isAnd
-                ? sql`${ensureBuilt()} AND ${expr}`
-                : sql`${ensureBuilt()} WHERE ${expr}`
-            // Mirror into text AND whereParams with dialect-aware
-            // placeholders. The params must be pushed: any later call that
-            // invalidates `built` (orderBy, limit, ...) rebuilds from
-            // text+whereParams, and the previous version left the value
-            // only inside the template-built query — the rebuilt statement
-            // had a dangling placeholder. Same bug class as #1028.
+            // Record the term and let ensureBuilt() rebuild from it.
+            //
+            // This used to ALSO assign `built = sql\`${ensureBuilt()} OR …\``,
+            // a second representation of the same predicate that appended a
+            // bare top-level OR — so the dynamic `orWhereX` proxy mis-grouped
+            // even where the text path did not. It was the query object
+            // actually executed. See #1083.
             if (Array.isArray(value)) {
               const phs = getPlaceholders(value.length, whereParams.length + 1)
               addWhereText(isOr ? 'OR' : isAnd ? 'AND' : 'WHERE', `${column} IN (${phs})`)
@@ -6175,21 +6189,20 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         ?? (Array.isArray(subExec?.values) ? subExec.values : [])
       const baseText = `SELECT * FROM (${subText}) AS ${String(alias)}`
 
-      // Append a WHERE/AND/OR condition, returning the new (text, params).
-      // `hasWhere` is tracked explicitly rather than regex-tested: the SUBQUERY
-      // text contains its own `WHERE` inside the parens, so SQL_PATTERNS.WHERE
-      // would falsely report the OUTER query already has one and emit `AS u AND
-      // …` (syntax error) for the first outer condition.
+      // Render one condition into a clause, returning it plus the extended
+      // params. The connector is NOT applied here: the caller records it as a
+      // term and renderWhereTerms() decides the shape at emit time, which is
+      // what stops a chained `orWhere` from mis-grouping (#1083). It also
+      // retires the `hasWhere` flag this used to thread through every method —
+      // the flag existed because the SUBQUERY text contains its own `WHERE`
+      // inside the parens, so regex-testing for one reported the OUTER query as
+      // already having a WHERE. A term list has no such question to ask.
       const appendWhere = (
-        text: string,
         params: any[],
-        hasWhere: boolean,
         expr: any,
         op: WhereOperator | undefined,
         value: any,
-        connector: 'WHERE' | 'AND' | 'OR',
-      ): { text: string, params: any[] } => {
-        const kw = !hasWhere ? 'WHERE' : (connector === 'WHERE' ? 'AND' : connector)
+      ): { clause: string | null, params: any[] } => {
         const out = [...params]
         const cmp = (col: string, operator: string, val: any): string => {
           validateIdentifier(col, 'selectFromSub where(column)')
@@ -6205,73 +6218,126 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return `${col} ${o} ${ph}`
         }
         let clause: string
-        if (typeof expr === 'string' && op !== undefined)
+        if (typeof expr === 'string' && op !== undefined) {
           clause = cmp(expr, op, value)
-        else if (Array.isArray(expr) && expr.length === 3)
+        }
+        else if (Array.isArray(expr) && expr.length === 3) {
           clause = cmp(expr[0], expr[1], expr[2])
-        else if (expr && typeof expr === 'object')
-          clause = Object.entries(expr).map(([k, v]) => cmp(k, '=', v)).join(' AND ')
-        else
-          return { text, params }
-        return { text: `${text} ${kw} ${clause}`, params: out }
+        }
+        else if (expr && typeof expr === 'object') {
+          const parts = Object.entries(expr).map(([k, v]) => cmp(k, '=', v))
+          // One term: `orWhere({a, b})` means "OR (a AND b)".
+          clause = parts.length > 1 ? `(${parts.join(' AND ')})` : parts[0]
+        }
+        else {
+          return { clause: null, params }
+        }
+        return { clause, params: out }
       }
 
       // Build the base API. makeSub() is the single factory; every mutating
-      // method returns a fresh builder over the new (text, params, hasWhere).
-      function makeSub(text: string, params: any[], hasWhere = false): BaseSelectQueryBuilder<DB, any, any, any> {
+      // method returns a fresh builder over the new (baseText, terms, params,
+      // tail). `text` is DERIVED — the WHERE is rendered from the term list and
+      // spliced between the SELECT body and the trailing clauses, so a `where`
+      // added after an `orderBy` still lands in front of it.
+      function makeSub(baseText: string, terms: WhereTerm[], params: any[], tail = ''): BaseSelectQueryBuilder<DB, any, any, any> {
+        const body = renderWhereTerms(terms)
+        const text = body ? `${baseText} WHERE ${body}${tail}` : `${baseText}${tail}`
         const build = (): any => params.length > 0 ? _sql.unsafe(text, params) : _sql.unsafe(text)
+        const withTerm = (conn: 'AND' | 'OR', expr: any, op: WhereOperator | undefined, value: any) => {
+          const r = appendWhere(params, expr, op, value)
+          return r.clause === null
+            ? makeSub(baseText, terms, params, tail) as any
+            : makeSub(baseText, [...terms, { conn, sql: r.clause }], r.params, tail) as any
+        }
+        /**
+         * A parenthesised sub-group. The callback gets a minimal collector that
+         * records terms and params in the outer builder's numbering, so the
+         * group's placeholders continue rather than restart.
+         */
+        const withGroup = (conn: 'AND' | 'OR', cb: (b: any) => unknown) => {
+          const gTerms: WhereTerm[] = []
+          let gParams = [...params]
+          const add = (c: 'AND' | 'OR') => (expr: any, op?: WhereOperator, value?: any) => {
+            const r = appendWhere(gParams, expr, op, value)
+            if (r.clause !== null) {
+              gTerms.push({ conn: c, sql: r.clause })
+              gParams = r.params
+            }
+            return collector
+          }
+          const collector: any = { where: add('AND'), andWhere: add('AND'), orWhere: add('OR') }
+          cb(collector)
+          const body = renderWhereTerms(gTerms)
+          if (!body) {
+            // Same fails-closed rule as the main builder: a group that
+            // contributed nothing would leave the query matching everything.
+            throw new TypeError(
+              '[query-builder] selectFromSub.whereGroup(callback): the callback added no conditions. '
+              + 'Add at least one where()/orWhere() to the builder it receives.',
+            )
+          }
+          return makeSub(baseText, [...terms, { conn, sql: `(${body})` }], gParams, tail) as any
+        }
         const base: BaseSelectQueryBuilder<DB, any, any, any> = {
         distinct() {
-          return makeSub(text.replace(/^SELECT\s+/i, 'SELECT DISTINCT '), params, hasWhere) as any
+          return makeSub(baseText.replace(/^SELECT\s+/i, 'SELECT DISTINCT '), terms, params, tail) as any
         },
         distinctOn(...columns: any[]) {
           const cols = columns.map(String).join(', ')
-          return makeSub(text.replace(/^SELECT\s+/i, `SELECT DISTINCT ON (${cols}) `), params, hasWhere) as any
+          return makeSub(baseText.replace(/^SELECT\s+/i, `SELECT DISTINCT ON (${cols}) `), terms, params, tail) as any
         },
         selectRaw(fragment: any) {
           const frag = renderRawFragment(fragment, 'selectFromSub.selectRaw(fragment)')
-          const fromIdx = text.indexOf(' FROM ')
-          const newText = fromIdx !== -1
-            ? `${text.slice(0, fromIdx)}, ${frag}${text.slice(fromIdx)}`
-            : `${text}, ${frag}`
-          return makeSub(newText, params, hasWhere) as any
+          const fromIdx = baseText.indexOf(' FROM ')
+          const newBase = fromIdx !== -1
+            ? `${baseText.slice(0, fromIdx)}, ${frag}${baseText.slice(fromIdx)}`
+            : `${baseText}, ${frag}`
+          return makeSub(newBase, terms, params, tail) as any
         },
         where(expr: any, op?: WhereOperator, value?: any) {
-          const r = appendWhere(text, params, hasWhere, expr, op, value, 'WHERE')
-          return makeSub(r.text, r.params, true) as any
+          return withTerm('AND', expr, op, value)
         },
         andWhere(expr: any, op?: WhereOperator, value?: any) {
-          const r = appendWhere(text, params, hasWhere, expr, op, value, 'AND')
-          return makeSub(r.text, r.params, true) as any
+          return withTerm('AND', expr, op, value)
         },
         orWhere(expr: any, op?: WhereOperator, value?: any) {
-          const r = appendWhere(text, params, hasWhere, expr, op, value, 'OR')
-          return makeSub(r.text, r.params, true) as any
+          return withTerm('OR', expr, op, value)
+        },
+        // Supported here because `orWhere` is: now that a chained OR groups
+        // with the term before it, this is the only way to express the other
+        // reading. The rest of the where-family keeps the deliberate
+        // subqueryNotSupported() throw further down.
+        whereGroup(cb: any) {
+          return withGroup('AND', cb)
+        },
+        orWhereGroup(cb: any) {
+          return withGroup('OR', cb)
         },
         orderBy(column: string, direction: 'asc' | 'desc' = 'asc') {
           validateIdentifier(String(column), 'selectFromSub.orderBy(column)')
           const dir = direction === 'asc' ? 'ASC' : 'DESC'
           // Compose-aware: a second orderBy appends with a comma.
-          const newText = SQL_PATTERNS.ORDER_BY.test(text)
-            ? `${text}, ${column} ${dir}`
-            : `${text} ORDER BY ${column} ${dir}`
-          return makeSub(newText, params, hasWhere) as any
+          const newTail = SQL_PATTERNS.ORDER_BY.test(tail)
+            ? `${tail}, ${column} ${dir}`
+            : `${tail} ORDER BY ${column} ${dir}`
+          return makeSub(baseText, terms, params, newTail) as any
         },
         limit(n: number) {
           if (!Number.isInteger(n) || n < 0)
             throw new TypeError(`[query-builder] selectFromSub.limit(n): expected non-negative integer, got ${n}`)
-          const newText = SQL_PATTERNS.LIMIT.test(text)
-            ? text.replace(SQL_PATTERNS.LIMIT, ` LIMIT ${n}`)
-            : `${text} LIMIT ${n}`
-          return makeSub(newText, params, hasWhere) as any
+          const newTail = SQL_PATTERNS.LIMIT.test(tail)
+            ? tail.replace(SQL_PATTERNS.LIMIT, ` LIMIT ${n}`)
+            : `${tail} LIMIT ${n}`
+          return makeSub(baseText, terms, params, newTail) as any
         },
         offset(n: number) {
           if (!Number.isInteger(n) || n < 0)
             throw new TypeError(`[query-builder] selectFromSub.offset(n): expected non-negative integer, got ${n}`)
-          const newText = SQL_PATTERNS.OFFSET.test(text)
-            ? text.replace(SQL_PATTERNS.OFFSET, ` OFFSET ${n}`)
-            : `${text} OFFSET ${n}`
-          return makeSub(newText, params, hasWhere) as any
+          const newTail = SQL_PATTERNS.OFFSET.test(tail)
+            ? tail.replace(SQL_PATTERNS.OFFSET, ` OFFSET ${n}`)
+            : `${tail} OFFSET ${n}`
+          return makeSub(baseText, terms, params, newTail) as any
         },
         toSQL() {
           return makeExecutableQuery(build(), text) as any
@@ -6378,8 +6444,13 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         whereJsonContains: subqueryNotSupported('whereJsonContains'),
         whereJsonPath: subqueryNotSupported('whereJsonPath'),
         whereNull: subqueryNotSupported('whereNull'),
+        orWhereNull: subqueryNotSupported('orWhereNull'),
         whereNotNull: subqueryNotSupported('whereNotNull'),
+        orWhereNotNull: subqueryNotSupported('orWhereNotNull'),
         whereExists: subqueryNotSupported('whereExists'),
+        orWhereExists: subqueryNotSupported('orWhereExists'),
+        orWhereBetween: subqueryNotSupported('orWhereBetween'),
+        orWhereRaw: subqueryNotSupported('orWhereRaw'),
         whereJsonDoesntContain: subqueryNotSupported('whereJsonDoesntContain'),
         whereJsonContainsKey: subqueryNotSupported('whereJsonContainsKey'),
         whereJsonDoesntContainKey: subqueryNotSupported('whereJsonDoesntContainKey'),
@@ -6454,7 +6525,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return base
       }
 
-      return makeSub(baseText, subParams) as any
+      return makeSub(baseText, [], subParams) as any
     },
     insertInto<TTable extends keyof DB & string>(table: TTable) {
       let built: any

--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -34,6 +34,8 @@ import { getOrCreateBunSql } from './db'
 import { applySqliteBootstrapPragmas } from './sqlite-pragmas'
 import { normalizeRelationList } from './relation-utils'
 import { singularizerFor, toTableName as sharedToTableName } from './inflect'
+import type { WhereTerm } from './sql-fragments'
+import { renderInPredicate, renderWhereTerms } from './sql-fragments'
 
 /**
  * Current timestamp formatted for the active dialect.
@@ -2477,9 +2479,8 @@ class ModelQueryBuilder<
    * Shared by buildQuery, count, aggregates, delete, and update.
    */
   private buildWhereClauses(params: unknown[]): string {
-    const clauses: string[] = []
-    for (let i = 0; i < this._wheres.length; i++) {
-      const w = this._wheres[i]
+    const terms: WhereTerm[] = []
+    for (const w of this._wheres) {
       let clause: string
 
       if (w.raw) {
@@ -2491,8 +2492,11 @@ class ModelQueryBuilder<
         clause = w.operator === '=' ? `${col} IS NULL` : `${col} IS NOT NULL`
       }
       else if (w.operator === 'in' || w.operator === 'not in') {
+        // `IN ()` is a syntax error on Postgres and MySQL while SQLite parses
+        // it, so the empty case renders as a constant predicate instead — see
+        // renderInPredicate for why the NOT IN mirror is TRUE, not FALSE.
         const arr = w.value as unknown[]
-        clause = `${sqlColumn(w.column!)} ${w.operator.toUpperCase()} (${arr.map(() => '?').join(', ')})`
+        clause = renderInPredicate(sqlColumn(w.column!), arr, w.operator === 'not in', arr.map(() => '?').join(', '))
         params.push(...arr)
       }
       else {
@@ -2500,9 +2504,13 @@ class ModelQueryBuilder<
         params.push(w.value)
       }
 
-      clauses.push(i === 0 ? clause : `${w.boolean.toUpperCase()} ${clause}`)
+      terms.push({ conn: w.boolean === 'or' ? 'OR' : 'AND', sql: clause })
     }
-    return clauses.join(' ')
+    // Was a flat join: `clauses.push(i === 0 ? clause : `${BOOL} ${clause}`)`.
+    // SQL binds AND tighter than OR, so `.where(a).whereLike(b).orWhereLike(c)`
+    // meant `(a AND b) OR c` and returned every row `a` was meant to exclude.
+    // renderWhereTerms brackets each OR-run instead. See #1083.
+    return renderWhereTerms(terms)
   }
 
   /**

--- a/packages/bun-query-builder/src/sql-fragments.ts
+++ b/packages/bun-query-builder/src/sql-fragments.ts
@@ -1,0 +1,99 @@
+/**
+ * SQL fragment renderers shared by the select builder (`client.ts`) and the ORM
+ * query builder (`orm.ts`).
+ *
+ * They live here rather than in either builder because the two had independent
+ * copies of the same defect: both joined their WHERE terms as flat text, so
+ * `orWhere` produced an ungrouped `OR` and SQL's native precedence silently
+ * re-associated the chain. Two implementations of one rule is how they drifted;
+ * one implementation is how they stop.
+ *
+ * See stacksjs/bun-query-builder#1083.
+ */
+
+/**
+ * A single WHERE predicate plus the connector the CALLER asked for.
+ *
+ * The connector belongs to the term rather than sitting between terms because
+ * the first term's connector is meaningless — nothing precedes it — and
+ * carrying it anyway is what lets a leading `.orWhere(x)` render as `WHERE x`
+ * instead of the `FROM t OR x` syntax error it used to emit.
+ */
+export interface WhereTerm {
+  conn: 'AND' | 'OR'
+  sql: string
+}
+
+/**
+ * Constant predicates, for the cases where a collection is empty.
+ *
+ * `1 = 0` and `1 = 1` take no parameters and parse identically on SQLite,
+ * Postgres and MySQL, which is the point: the alternatives are engine-specific.
+ * `IN ()` is the example that motivated these — SQLite parses it and matches
+ * nothing, while Postgres and MySQL reject it as a syntax error, so the same
+ * call site behaved differently depending on where it ran.
+ */
+export const FALSE_PREDICATE = '1 = 0'
+export const TRUE_PREDICATE = '1 = 1'
+
+/**
+ * Render a WHERE body (without the `WHERE` keyword) from an ordered term list.
+ *
+ * Each MAXIMAL RUN of `OR` terms is bracketed together with the term that opens
+ * it, so a chain groups the way it reads:
+ *
+ *     .where(a).where(b).orWhere(c)   ->  a AND (b OR c)
+ *     .where(a).orWhere(b).where(c)   ->  (a OR b) AND c
+ *
+ * In effect `OR` binds TIGHTER than `AND` in chain order — the inverse of raw
+ * SQL. That is a deliberate choice for a fluent builder, and it is already what
+ * `whereAny`/`whereAll`/`whereNone` and the ORM's `whereGroup` do; `orWhere`
+ * was the odd one out. Previously the terms were concatenated as flat text and
+ * SQL's precedence re-associated `a AND b OR c` to `(a AND b) OR c`, so the
+ * first filter stopped applying to any row the `OR` matched — silently, and in
+ * the direction that returns MORE rows.
+ *
+ * The brackets are omitted when the body has a single top-level piece, so a
+ * plain two-term `.where(a).orWhere(b)` and any all-`AND` chain still render
+ * byte-for-byte as before. The escape hatch for the one shape this rule can no
+ * longer express directly — `(a AND b) OR c` — is `whereGroup(cb)`.
+ */
+export function renderWhereTerms(terms: readonly WhereTerm[]): string {
+  if (terms.length === 0)
+    return ''
+
+  const runs: WhereTerm[][] = []
+  for (const term of terms) {
+    if (term.conn === 'OR' && runs.length > 0)
+      runs[runs.length - 1].push(term)
+    else
+      runs.push([term])
+  }
+
+  return runs
+    .map((run, i) => {
+      const body = run.map(t => t.sql).join(' OR ')
+      // A run only needs brackets when there is something outside it to bind
+      // against. `(a OR b)` alone and `a OR b` alone mean the same thing, and
+      // not adding the parens keeps existing emitted SQL unchanged.
+      const piece = run.length > 1 && runs.length > 1 ? `(${body})` : body
+      return i === 0 ? piece : `${run[0].conn} ${piece}`
+    })
+    .join(' ')
+}
+
+/**
+ * Render `col IN (…)` / `col NOT IN (…)`, including the empty case.
+ *
+ * An empty `IN` is FALSE (nothing is a member of the empty set) and an empty
+ * `NOT IN` is TRUE (everything is a non-member). Those constants are not
+ * interchangeable and the mirror is easy to get backwards: writing FALSE for
+ * `NOT IN` would silently drop every row from any query whose exclusion list
+ * happened to come back empty — the same shape of silent, widening-or-narrowing
+ * failure as the `IN ()` bug itself.
+ */
+export function renderInPredicate(column: string, values: any[], negated: boolean, placeholders: string): string {
+  if (values.length === 0)
+    return negated ? TRUE_PREDICATE : FALSE_PREDICATE
+  return `${column} ${negated ? 'NOT IN' : 'IN'} (${placeholders})`
+}

--- a/packages/bun-query-builder/test/client.dynamic-where.test.ts
+++ b/packages/bun-query-builder/test/client.dynamic-where.test.ts
@@ -48,6 +48,13 @@ describe('dynamic whereX/orWhereX/andWhereX methods', () => {
       .limit(10)
 
     expect(typeof q.toSQL).toBe('function')
+    // Assert the emitted string, not just that a builder came back. The
+    // dynamic proxy mis-grouped too — `email = ? AND name = ? OR role = ? AND
+    // created_at = ?` — and it did so through a second code path (it also
+    // assigned `built = sql`${ensureBuilt()} OR ...``, which was the query
+    // actually executed). See #1083.
+    const s = String(q.toSQL())
+    expect(s).toContain('WHERE email = $1 AND (name = $2 OR role = $3) AND created_at = $4')
   })
 
   it('treats array values as IN and scalars as =', () => {

--- a/packages/bun-query-builder/test/client.dynamic-where.test.ts
+++ b/packages/bun-query-builder/test/client.dynamic-where.test.ts
@@ -53,8 +53,10 @@ describe('dynamic whereX/orWhereX/andWhereX methods', () => {
     // created_at = ?` — and it did so through a second code path (it also
     // assigned `built = sql`${ensureBuilt()} OR ...``, which was the query
     // actually executed). See #1083.
-    const s = String(q.toSQL())
-    expect(s).toContain('WHERE email = $1 AND (name = $2 OR role = $3) AND created_at = $4')
+    // Placeholders normalised: the dialect comes from process-wide config, and
+    // this assertion is about grouping, not about `?` vs `$n`.
+    const s = String(q.toSQL()).replace(/\$\d+/g, '?')
+    expect(s).toContain('WHERE email = ? AND (name = ? OR role = ?) AND created_at = ?')
   })
 
   it('treats array values as IN and scalars as =', () => {

--- a/packages/bun-query-builder/test/client.or-where-precedence.e2e.test.ts
+++ b/packages/bun-query-builder/test/client.or-where-precedence.e2e.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The `orWhere` grouping fix (#1083), measured in rows rather than SQL text.
+ *
+ * Asserting the emitted string proves the shape changed. Only row counts prove
+ * the shape was WRONG — and wrong in the dangerous direction, returning a
+ * superset of what was asked for rather than erroring. Every `it` here carries
+ * the pre-fix number next to the post-fix one, because "10, not 80" is the
+ * whole report and a bare `toBe(10)` loses it.
+ *
+ * Fixture: 118 rows, matching the numbers in the issue.
+ *   ids   1-40   create_t{i}_table
+ *   ids  41-80   alter_t{i}_table
+ *   ids  81-118  create_i{i}_index
+ *   batch = id <= 59 ? 1 : 2
+ *
+ * So `%create%` matches 78 rows, `%table%` matches 80, and `id <= 10` matches
+ * 10 — the overlaps are what make the mis-grouping visible.
+ */
+
+import { SQL } from 'bun'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, createQueryBuilder } from '../src'
+
+const schema = buildDatabaseSchema({
+  Migration: {
+    name: 'Migration',
+    table: 'migrations',
+    primaryKey: 'id',
+    attributes: {
+      id: { validation: { rule: {} } },
+      migration: { validation: { rule: {} } },
+      batch: { validation: { rule: {} } },
+    },
+  },
+} as any)
+
+let sql: SQL
+
+beforeAll(async () => {
+  sql = new SQL('sqlite://:memory:')
+  await sql.unsafe('CREATE TABLE migrations (id INTEGER PRIMARY KEY, migration TEXT, batch INTEGER)')
+  for (let i = 1; i <= 118; i++) {
+    const name = i <= 40 ? `create_t${i}_table` : i <= 80 ? `alter_t${i}_table` : `create_i${i}_index`
+    await sql.unsafe('INSERT INTO migrations (id, migration, batch) VALUES (?, ?, ?)', [i, name, i <= 59 ? 1 : 2])
+  }
+})
+
+afterAll(async () => {
+  await sql?.end()
+})
+
+const q = () => createQueryBuilder<typeof schema>({ schema, sql }).selectFrom('migrations').selectAll() as any
+
+describe('orWhere grouping, in rows (#1083)', () => {
+  it('the reported chain matches 10 rows, not 118', async () => {
+    const rows = await q()
+      .where('id', '<=', 10)
+      .where('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%')
+      .execute()
+
+    expect(rows.length).toBe(10)
+    // The bounding filter is the thing that used to vanish. Assert it directly:
+    // a count alone would pass for the wrong reason if the fixture changed.
+    expect(rows.every((r: any) => r.id <= 10)).toBe(true)
+  })
+
+  it('a where after an orWhere constrains the whole group', async () => {
+    const rows = await q()
+      .where('id', '<=', 10)
+      .orWhere('migration', 'like', '%table%')
+      .where('batch', '=', 2)
+      .execute()
+
+    // Was 31: the trailing `batch = 2` bound only to the OR's right arm, so
+    // rows 1-10 came back regardless of their batch.
+    expect(rows.length).toBe(21)
+    expect(rows.every((r: any) => r.batch === 2)).toBe(true)
+  })
+
+  it('a five-term chain does not degenerate to the whole table', async () => {
+    const rows = await q()
+      .where('id', '<=', 59)
+      .where('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%')
+      .where('batch', '=', 1)
+      .orWhere('batch', '=', 2)
+      .execute()
+
+    // Was 118 — every row in the table, from a query with five filters on it.
+    expect(rows.length).toBe(59)
+  })
+
+  it('a two-term OR chain still returns both branches', async () => {
+    const rows = await q().where('id', '<=', 10).orWhere('migration', 'like', '%table%').execute()
+
+    // Unchanged by the fix, and that is the point: no churn for the common case.
+    expect(rows.length).toBe(80)
+  })
+
+  it('a leading orWhere runs instead of raising a syntax error', async () => {
+    const rows = await q().orWhere('id', '<=', 10).execute()
+
+    // Was `SELECT * FROM migrations OR id <= ?` — SQLiteError: near "OR".
+    expect(rows.length).toBe(10)
+  })
+
+  it('whereGroup reproduces the pre-fix reading exactly', async () => {
+    const rows = await q()
+      .whereGroup((g: any) => g.where('id', '<=', 10).where('migration', 'like', '%create%'))
+      .orWhere('migration', 'like', '%table%')
+      .execute()
+
+    // 80 is what the broken chain returned. Anyone who was relying on the old
+    // grouping has this as the migration path, so it is pinned to the old
+    // number on purpose.
+    expect(rows.length).toBe(80)
+  })
+
+  it('count/sum/min/max all see the grouped WHERE', async () => {
+    const filtered = () => q()
+      .where('id', '<=', 10)
+      .where('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%')
+
+    // The aggregates rebuild their SQL by slicing from ' FROM ', which is the
+    // cheapest possible tripwire for a missed emit path: if any of them still
+    // read the raw text, they would aggregate over the unfiltered table.
+    expect(await filtered().count()).toBe(10)
+    expect(await filtered().max('id')).toBe(10)
+    expect(await filtered().min('id')).toBe(1)
+    expect(await filtered().sum('id')).toBe(55)
+  })
+
+  it('first() and exists() see the grouped WHERE', async () => {
+    const filtered = () => q().where('id', '>=', 100).orWhere('id', '<=', 2).where('batch', '=', 1)
+
+    expect(await filtered().exists()).toBe(true)
+    const rows = await filtered().execute()
+    expect(rows.length).toBe(2)
+  })
+
+  it('paginate counts and pages the grouped WHERE', async () => {
+    const page = await q()
+      .where('id', '<=', 10)
+      .where('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%')
+      .paginate(4)
+
+    expect(page.meta.total).toBe(10)
+    expect(page.data.map((r: any) => r.id)).toEqual([1, 2, 3, 4])
+  })
+})

--- a/packages/bun-query-builder/test/client.or-where-precedence.test.ts
+++ b/packages/bun-query-builder/test/client.or-where-precedence.test.ts
@@ -18,8 +18,8 @@
  * before. Those are asserted with `toBe`, not `toContain`.
  */
 
-import { describe, expect, it } from 'bun:test'
-import { buildDatabaseSchema, createQueryBuilder } from '../src'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, config, createQueryBuilder } from '../src'
 
 const schema = buildDatabaseSchema({
   Migration: {
@@ -35,7 +35,18 @@ const schema = buildDatabaseSchema({
 } as any)
 
 const q = () => createQueryBuilder<typeof schema>({ schema }).selectFrom('migrations').selectAll() as any
-const sqlOf = (build: (b: any) => any): string => String(build(q()).toSQL())
+
+/**
+ * Placeholders normalised to `?`.
+ *
+ * The dialect comes from process-wide config, so the same assertion sees `$1`
+ * under Postgres and `?` under SQLite depending on what else has run. This
+ * suite is about GROUPING, which is dialect-independent — normalising keeps it
+ * from failing for a reason it does not test. Placeholder NUMBERING is asserted
+ * separately, where it is the actual subject.
+ */
+const norm = (s: string): string => s.replace(/\$\d+/g, '?')
+const sqlOf = (build: (b: any) => any): string => norm(String(build(q()).toSQL()))
 
 describe('orWhere groups with the term before it (#1083)', () => {
   it('brackets a trailing OR run — the reported chain', () => {
@@ -44,9 +55,9 @@ describe('orWhere groups with the term before it (#1083)', () => {
       .where('migration', 'like', '%create%')
       .orWhere('migration', 'like', '%table%'))
 
-    // Was: `WHERE id <= $1 AND migration like $2 OR migration like $3`,
+    // Was: `WHERE id <= ? AND migration like ? OR migration like ?` (flat),
     // which meant `(id <= 10 AND create) OR table` and returned 118 of 118.
-    expect(sql).toContain('WHERE id <= $1 AND (migration like $2 OR migration like $3)')
+    expect(sql).toContain('WHERE id <= ? AND (migration like ? OR migration like ?)')
   })
 
   it('brackets a leading OR run against the AND that follows', () => {
@@ -58,7 +69,7 @@ describe('orWhere groups with the term before it (#1083)', () => {
     // The mis-grouping ran in both directions: this used to parse as
     // `id <= 10 OR (table AND batch = 2)`, so the trailing filter bound only
     // to the OR's right arm.
-    expect(sql).toContain('WHERE (id <= $1 OR migration like $2) AND batch = $3')
+    expect(sql).toContain('WHERE (id <= ? OR migration like ?) AND batch = ?')
   })
 
   it('leaves a two-term OR chain byte-identical', () => {
@@ -66,7 +77,7 @@ describe('orWhere groups with the term before it (#1083)', () => {
     // adding them anyway would churn the emitted SQL of every existing
     // two-term query for no correctness gain.
     expect(sqlOf(b => b.where('id', '<=', 10).orWhere('batch', '=', 2)))
-      .toBe('SELECT * FROM migrations WHERE id <= $1 OR batch = $2')
+      .toBe('SELECT * FROM migrations WHERE id <= ? OR batch = ?')
   })
 
   it('leaves an all-OR chain unbracketed', () => {
@@ -75,13 +86,13 @@ describe('orWhere groups with the term before it (#1083)', () => {
       .orWhere('migration', 'like', '%create%')
       .orWhere('migration', 'like', '%table%'))
 
-    expect(sql).toBe('SELECT * FROM migrations WHERE id <= $1 OR migration like $2 OR migration like $3')
+    expect(sql).toBe('SELECT * FROM migrations WHERE id <= ? OR migration like ? OR migration like ?')
     expect(sql).not.toContain('(')
   })
 
   it('leaves an all-AND chain byte-identical', () => {
     expect(sqlOf(b => b.where('id', '<=', 10).where('batch', '=', 1).where('migration', 'like', '%x%')))
-      .toBe('SELECT * FROM migrations WHERE id <= $1 AND batch = $2 AND migration like $3')
+      .toBe('SELECT * FROM migrations WHERE id <= ? AND batch = ? AND migration like ?')
   })
 
   it('brackets every OR run in a longer chain', () => {
@@ -93,7 +104,7 @@ describe('orWhere groups with the term before it (#1083)', () => {
       .orWhere('batch', '=', 2))
 
     // Was `a AND b OR c AND d OR e`, which degenerates to the whole table.
-    expect(sql).toContain('WHERE id <= $1 AND (migration like $2 OR migration like $3) AND (batch = $4 OR batch = $5)')
+    expect(sql).toContain('WHERE id <= ? AND (migration like ? OR migration like ?) AND (batch = ? OR batch = ?)')
   })
 })
 
@@ -125,9 +136,9 @@ describe('the WHERE lands in the right place (#1083)', () => {
   it('a where added after an orderBy still precedes the ORDER BY', () => {
     const sql = sqlOf(b => b.where('id', '<=', 10).orderBy('id').orWhere('batch', '=', 2))
 
-    // Was `… WHERE id <= $1 ORDER BY id ASC OR batch = $2` — a syntax error.
+    // Was `… WHERE id <= ? ORDER BY id ASC OR batch = ?` — a syntax error.
     expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'))
-    expect(sql).toBe('SELECT * FROM migrations WHERE id <= $1 OR batch = $2 ORDER BY id ASC')
+    expect(sql).toBe('SELECT * FROM migrations WHERE id <= ? OR batch = ? ORDER BY id ASC')
   })
 
   it('a where added after a limit still precedes the LIMIT', () => {
@@ -149,19 +160,15 @@ describe('whereGroup is the escape hatch for the old reading (#1083)', () => {
       .whereGroup((g: any) => g.where('id', '<=', 10).where('migration', 'like', '%create%'))
       .orWhere('migration', 'like', '%table%'))
 
-    expect(sql).toContain('WHERE (id <= $1 AND migration like $2) OR migration like $3')
+    expect(sql).toContain('WHERE (id <= ? AND migration like ?) OR migration like ?')
   })
 
-  it('numbers the group placeholders after the terms before it', () => {
+  it('keeps the group params in emitted order', () => {
     const built = q()
       .where('batch', '=', 1)
       .whereGroup((g: any) => g.where('id', '<=', 10).orWhere('id', '>=', 100))
 
-    const sql = String(built.toSQL())
-    expect(sql).toContain('WHERE batch = $1 AND (id <= $2 OR id >= $3)')
-    // The sub-builder numbers from $1; without the offset both the outer and
-    // inner first placeholder would be $1 and the values would bind shifted.
-    expect((sql.match(/\$1/g) ?? []).length).toBe(1)
+    expect(norm(String(built.toSQL()))).toContain('WHERE batch = ? AND (id <= ? OR id >= ?)')
     expect(built.__rawState().params).toEqual([1, 10, 100])
   })
 
@@ -170,7 +177,7 @@ describe('whereGroup is the escape hatch for the old reading (#1083)', () => {
       .where('batch', '=', 1)
       .orWhereGroup((g: any) => g.where('id', '<=', 10).where('migration', 'like', '%x%')))
 
-    expect(sql).toContain('WHERE batch = $1 OR (id <= $2 AND migration like $3)')
+    expect(sql).toContain('WHERE batch = ? OR (id <= ? AND migration like ?)')
   })
 
   it('throws rather than widening when the callback adds nothing', () => {
@@ -184,20 +191,55 @@ describe('object and raw forms are one term each (#1083)', () => {
   it('brackets a multi-key object so a later orWhere binds to all of it', () => {
     const sql = sqlOf(b => b.where({ batch: 1, id: 2 }).orWhere('migration', 'like', '%x%'))
 
-    // Un-bracketed this was `batch = $1 AND id = $2 OR migration like $3`,
+    // Un-bracketed this was `batch = ? AND id = ? OR migration like ?`,
     // which drops `batch` — the object's own keys came apart.
-    expect(sql).toContain('WHERE (batch = $1 AND id = $2) OR migration like $3')
+    expect(sql).toContain('WHERE (batch = ? AND id = ?) OR migration like ?')
   })
 
   it('leaves a single-key object unbracketed', () => {
     expect(sqlOf(b => b.where({ batch: 1 })))
-      .toBe('SELECT * FROM migrations WHERE batch = $1')
+      .toBe('SELECT * FROM migrations WHERE batch = ?')
   })
 
   it('treats orWhere({a, b}) as OR (a AND b)', () => {
     const sql = sqlOf(b => b.where('id', '<=', 10).orWhere({ batch: 1, migration: 'x' }))
 
-    expect(sql).toContain('OR (batch = $2 AND migration = $3)')
+    expect(sql).toContain('OR (batch = ? AND migration = ?)')
+  })
+})
+
+describe('whereGroup placeholder numbering, per dialect (#1083)', () => {
+  // The dialect is process-wide config, so it is pinned here rather than
+  // assumed — this is the one assertion in the file that is ABOUT `?` vs `$n`.
+  // Same save/restore shape as client.union-params.test.ts, which pins the
+  // matching invariant for set-operator renumbering.
+  let dialect: string
+  beforeEach(() => { dialect = config.dialect })
+  afterEach(() => { config.dialect = dialect as any })
+
+  it('Postgres: continues the outer numbering into the group', () => {
+    config.dialect = 'postgres' as any
+    const built = q()
+      .where('batch', '=', 1)
+      .whereGroup((g: any) => g.where('id', '<=', 10).orWhere('id', '>=', 100))
+    const sql = String(built.toSQL())
+
+    // The sub-builder numbers its own placeholders from $1. Without the offset
+    // the outer `batch` and the group's first term would BOTH be $1, and every
+    // value after the group would bind shifted by one.
+    expect(sql).toContain('WHERE batch = $1 AND (id <= $2 OR id >= $3)')
+    expect((sql.match(/\$1\b/g) ?? []).length).toBe(1)
+    expect(built.__rawState().params).toEqual([1, 10, 100])
+  })
+
+  it('SQLite: positional `?` needs no renumbering', () => {
+    config.dialect = 'sqlite' as any
+    const built = q()
+      .where('batch', '=', 1)
+      .whereGroup((g: any) => g.where('id', '<=', 10).orWhere('id', '>=', 100))
+
+    expect(String(built.toSQL())).toContain('WHERE batch = ? AND (id <= ? OR id >= ?)')
+    expect(built.__rawState().params).toEqual([1, 10, 100])
   })
 })
 
@@ -206,13 +248,13 @@ describe('the sub-select builder groups the same way (#1083)', () => {
     .selectFromSub(createQueryBuilder<typeof schema>({ schema }).selectFrom('migrations').selectAll() as any, 'm') as any
 
   it('brackets a trailing OR run', () => {
-    const sql = String(sub().where('id', '<=', 10).where('batch', '=', 1).orWhere('batch', '=', 2).toSQL())
+    const sql = norm(String(sub().where('id', '<=', 10).where('batch', '=', 1).orWhere('batch', '=', 2).toSQL()))
 
-    expect(sql).toContain('AND (batch = $2 OR batch = $3)')
+    expect(sql).toContain('AND (batch = ? OR batch = ?)')
   })
 
   it('places a where added after an orderBy before the ORDER BY', () => {
-    const sql = String(sub().orderBy('id').where('id', '<=', 10).toSQL())
+    const sql = norm(String(sub().orderBy('id').where('id', '<=', 10).toSQL()))
 
     // The old builder appended the WHERE to the end of the text, so ordering
     // first made the query unparseable.
@@ -220,18 +262,18 @@ describe('the sub-select builder groups the same way (#1083)', () => {
   })
 
   it('emits WHERE for a leading orWhere', () => {
-    const sql = String(sub().orWhere('id', '<=', 10).toSQL())
+    const sql = norm(String(sub().orWhere('id', '<=', 10).toSQL()))
 
-    expect(sql).toContain('WHERE id <= $1')
+    expect(sql).toContain('WHERE id <= ?')
     expect(sql).not.toMatch(/AS m\s+OR\b/)
   })
 
   it('supports whereGroup for the old reading', () => {
-    const sql = String(sub()
+    const sql = norm(String(sub()
       .whereGroup((g: any) => g.where('id', '<=', 10).where('batch', '=', 1))
       .orWhere('batch', '=', 2)
-      .toSQL())
+      .toSQL()))
 
-    expect(sql).toContain('WHERE (id <= $1 AND batch = $2) OR batch = $3')
+    expect(sql).toContain('WHERE (id <= ? AND batch = ?) OR batch = ?')
   })
 })

--- a/packages/bun-query-builder/test/client.or-where-precedence.test.ts
+++ b/packages/bun-query-builder/test/client.or-where-precedence.test.ts
@@ -1,0 +1,237 @@
+/**
+ * `orWhere` used to append a bare, ungrouped `OR`.
+ *
+ * SQL binds AND tighter than OR, so `a AND b OR c` parses as `(a AND b) OR c`
+ * and the first filter stops applying to every row `c` matches. Nothing warns;
+ * the query is valid SQL; the result set is a SUPERSET of what was asked for.
+ * Failing toward MORE rows is what made it dangerous — it looks like data
+ * rather than an error. The reported case returned 118 rows where 10 were
+ * intended, on a moderation queue where the extra rows were already-published
+ * content shown as pending.
+ *
+ * The rule now: each maximal run of OR terms is bracketed with the term that
+ * opens it, so OR binds TIGHTER than AND in chain order. See renderWhereTerms
+ * in src/sql-fragments.ts and stacksjs/bun-query-builder#1083.
+ *
+ * The no-churn guarantee matters as much as the fix: chains with no `orWhere`,
+ * two-term OR chains, and all-OR chains must emit exactly what they emitted
+ * before. Those are asserted with `toBe`, not `toContain`.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, createQueryBuilder } from '../src'
+
+const schema = buildDatabaseSchema({
+  Migration: {
+    name: 'Migration',
+    table: 'migrations',
+    primaryKey: 'id',
+    attributes: {
+      id: { validation: { rule: {} } },
+      migration: { validation: { rule: {} } },
+      batch: { validation: { rule: {} } },
+    },
+  },
+} as any)
+
+const q = () => createQueryBuilder<typeof schema>({ schema }).selectFrom('migrations').selectAll() as any
+const sqlOf = (build: (b: any) => any): string => String(build(q()).toSQL())
+
+describe('orWhere groups with the term before it (#1083)', () => {
+  it('brackets a trailing OR run — the reported chain', () => {
+    const sql = sqlOf(b => b
+      .where('id', '<=', 10)
+      .where('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%'))
+
+    // Was: `WHERE id <= $1 AND migration like $2 OR migration like $3`,
+    // which meant `(id <= 10 AND create) OR table` and returned 118 of 118.
+    expect(sql).toContain('WHERE id <= $1 AND (migration like $2 OR migration like $3)')
+  })
+
+  it('brackets a leading OR run against the AND that follows', () => {
+    const sql = sqlOf(b => b
+      .where('id', '<=', 10)
+      .orWhere('migration', 'like', '%table%')
+      .where('batch', '=', 2))
+
+    // The mis-grouping ran in both directions: this used to parse as
+    // `id <= 10 OR (table AND batch = 2)`, so the trailing filter bound only
+    // to the OR's right arm.
+    expect(sql).toContain('WHERE (id <= $1 OR migration like $2) AND batch = $3')
+  })
+
+  it('leaves a two-term OR chain byte-identical', () => {
+    // `toBe`, deliberately. A single top-level piece needs no brackets, and
+    // adding them anyway would churn the emitted SQL of every existing
+    // two-term query for no correctness gain.
+    expect(sqlOf(b => b.where('id', '<=', 10).orWhere('batch', '=', 2)))
+      .toBe('SELECT * FROM migrations WHERE id <= $1 OR batch = $2')
+  })
+
+  it('leaves an all-OR chain unbracketed', () => {
+    const sql = sqlOf(b => b
+      .where('id', '<=', 10)
+      .orWhere('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%'))
+
+    expect(sql).toBe('SELECT * FROM migrations WHERE id <= $1 OR migration like $2 OR migration like $3')
+    expect(sql).not.toContain('(')
+  })
+
+  it('leaves an all-AND chain byte-identical', () => {
+    expect(sqlOf(b => b.where('id', '<=', 10).where('batch', '=', 1).where('migration', 'like', '%x%')))
+      .toBe('SELECT * FROM migrations WHERE id <= $1 AND batch = $2 AND migration like $3')
+  })
+
+  it('brackets every OR run in a longer chain', () => {
+    const sql = sqlOf(b => b
+      .where('id', '<=', 59)
+      .where('migration', 'like', '%create%')
+      .orWhere('migration', 'like', '%table%')
+      .where('batch', '=', 1)
+      .orWhere('batch', '=', 2))
+
+    // Was `a AND b OR c AND d OR e`, which degenerates to the whole table.
+    expect(sql).toContain('WHERE id <= $1 AND (migration like $2 OR migration like $3) AND (batch = $4 OR batch = $5)')
+  })
+})
+
+describe('a leading orWhere emits WHERE, not a dangling OR (#1083)', () => {
+  // Five methods bypassed the connector helper entirely and emitted
+  // `SELECT … FROM migrations OR …` when they were the first predicate —
+  // invalid SQL on every dialect.
+  const leading: Array<[string, (b: any) => any]> = [
+    ['orWhere', b => b.orWhere('id', '<=', 10)],
+    ['orWhereIn', b => b.orWhereIn('id', [1, 2])],
+    ['orWhereNotIn', b => b.orWhereNotIn('id', [1, 2])],
+    ['orWhereColumn', b => b.orWhereColumn('id', '=', 'batch')],
+    ['orWhereNested', b => b.orWhereNested('SELECT 1')],
+    ['orWhereLike', b => b.orWhereLike('migration', '%x%')],
+    ['orWhereNull', b => b.orWhereNull('batch')],
+  ]
+
+  for (const [name, build] of leading) {
+    it(`${name}() as the first predicate`, () => {
+      const sql = sqlOf(build)
+
+      expect(sql).not.toMatch(/FROM\s+migrations\s+OR\b/)
+      expect(sql).toContain('WHERE')
+    })
+  }
+})
+
+describe('the WHERE lands in the right place (#1083)', () => {
+  it('a where added after an orderBy still precedes the ORDER BY', () => {
+    const sql = sqlOf(b => b.where('id', '<=', 10).orderBy('id').orWhere('batch', '=', 2))
+
+    // Was `… WHERE id <= $1 ORDER BY id ASC OR batch = $2` — a syntax error.
+    expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'))
+    expect(sql).toBe('SELECT * FROM migrations WHERE id <= $1 OR batch = $2 ORDER BY id ASC')
+  })
+
+  it('a where added after a limit still precedes the LIMIT', () => {
+    const sql = sqlOf(b => b.where('id', '<=', 10).limit(5).where('batch', '=', 1))
+
+    expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('LIMIT'))
+  })
+
+  it('keeps params in emitted order across a group', () => {
+    const built = q().where('id', '<=', 10).orWhere('batch', '=', 2).where('id', '>=', 1)
+
+    expect(built.__rawState().params).toEqual([10, 2, 1])
+  })
+})
+
+describe('whereGroup is the escape hatch for the old reading (#1083)', () => {
+  it('expresses (a AND b) OR c', () => {
+    const sql = sqlOf(b => b
+      .whereGroup((g: any) => g.where('id', '<=', 10).where('migration', 'like', '%create%'))
+      .orWhere('migration', 'like', '%table%'))
+
+    expect(sql).toContain('WHERE (id <= $1 AND migration like $2) OR migration like $3')
+  })
+
+  it('numbers the group placeholders after the terms before it', () => {
+    const built = q()
+      .where('batch', '=', 1)
+      .whereGroup((g: any) => g.where('id', '<=', 10).orWhere('id', '>=', 100))
+
+    const sql = String(built.toSQL())
+    expect(sql).toContain('WHERE batch = $1 AND (id <= $2 OR id >= $3)')
+    // The sub-builder numbers from $1; without the offset both the outer and
+    // inner first placeholder would be $1 and the values would bind shifted.
+    expect((sql.match(/\$1/g) ?? []).length).toBe(1)
+    expect(built.__rawState().params).toEqual([1, 10, 100])
+  })
+
+  it('orWhereGroup ORs the whole group', () => {
+    const sql = sqlOf(b => b
+      .where('batch', '=', 1)
+      .orWhereGroup((g: any) => g.where('id', '<=', 10).where('migration', 'like', '%x%')))
+
+    expect(sql).toContain('WHERE batch = $1 OR (id <= $2 AND migration like $3)')
+  })
+
+  it('throws rather than widening when the callback adds nothing', () => {
+    // A group that contributed no predicate would silently drop out and leave
+    // the query matching every row it existed to exclude.
+    expect(() => q().whereGroup(() => {})).toThrow(/added no conditions/)
+  })
+})
+
+describe('object and raw forms are one term each (#1083)', () => {
+  it('brackets a multi-key object so a later orWhere binds to all of it', () => {
+    const sql = sqlOf(b => b.where({ batch: 1, id: 2 }).orWhere('migration', 'like', '%x%'))
+
+    // Un-bracketed this was `batch = $1 AND id = $2 OR migration like $3`,
+    // which drops `batch` — the object's own keys came apart.
+    expect(sql).toContain('WHERE (batch = $1 AND id = $2) OR migration like $3')
+  })
+
+  it('leaves a single-key object unbracketed', () => {
+    expect(sqlOf(b => b.where({ batch: 1 })))
+      .toBe('SELECT * FROM migrations WHERE batch = $1')
+  })
+
+  it('treats orWhere({a, b}) as OR (a AND b)', () => {
+    const sql = sqlOf(b => b.where('id', '<=', 10).orWhere({ batch: 1, migration: 'x' }))
+
+    expect(sql).toContain('OR (batch = $2 AND migration = $3)')
+  })
+})
+
+describe('the sub-select builder groups the same way (#1083)', () => {
+  const sub = () => createQueryBuilder<typeof schema>({ schema })
+    .selectFromSub(createQueryBuilder<typeof schema>({ schema }).selectFrom('migrations').selectAll() as any, 'm') as any
+
+  it('brackets a trailing OR run', () => {
+    const sql = String(sub().where('id', '<=', 10).where('batch', '=', 1).orWhere('batch', '=', 2).toSQL())
+
+    expect(sql).toContain('AND (batch = $2 OR batch = $3)')
+  })
+
+  it('places a where added after an orderBy before the ORDER BY', () => {
+    const sql = String(sub().orderBy('id').where('id', '<=', 10).toSQL())
+
+    // The old builder appended the WHERE to the end of the text, so ordering
+    // first made the query unparseable.
+    expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'))
+  })
+
+  it('emits WHERE for a leading orWhere', () => {
+    const sql = String(sub().orWhere('id', '<=', 10).toSQL())
+
+    expect(sql).toContain('WHERE id <= $1')
+    expect(sql).not.toMatch(/AS m\s+OR\b/)
+  })
+
+  it('supports whereGroup for the old reading', () => {
+    const sql = String(sub()
+      .whereGroup((g: any) => g.where('id', '<=', 10).where('batch', '=', 1))
+      .orWhere('batch', '=', 2)
+      .toSQL())
+
+    expect(sql).toContain('WHERE (id <= $1 AND batch = $2) OR batch = $3')
+  })
+})

--- a/packages/bun-query-builder/test/client.test.ts
+++ b/packages/bun-query-builder/test/client.test.ts
@@ -313,6 +313,11 @@ describe('query builder - SQL text for clauses and helpers', () => {
     expectTextOutput(s2)
     const s3 = toTextOf(qb().selectFrom('projects').orWhereNested(nested as any) as any)
     expectTextOutput(s3)
+    // An orWhereNested with nothing before it used to emit
+    // `SELECT * FROM projects OR (...)` — invalid SQL that expectTextOutput
+    // waved through, since it only checks the result is a string. See #1083.
+    expect(s3).toContain('WHERE (')
+    expect(s3).not.toMatch(/FROM projects\s+OR\b/)
     const s4 = toTextOf(qb().selectFrom('users').where(['id', '>', 0]).andWhere(['name', 'like', '%a%']) as any)
     expectTextOutput(s4)
     const s5 = toTextOf(qb().selectFrom('users').where(['id', '>', 0]).orWhere(['name', 'like', '%a%']) as any)

--- a/packages/bun-query-builder/test/client.test.ts
+++ b/packages/bun-query-builder/test/client.test.ts
@@ -117,8 +117,19 @@ describe('query builder - modifiers and raws', () => {
   it('date/json helpers compose', () => {
     const q1 = qb().selectFrom('users').whereDate('created_at', '>=', '2024-01-01').toSQL() as any
     expect(typeof q1.execute).toBe('function')
-    const q2 = qb().selectFrom('users').whereJsonContains('meta', { a: 1 }).toSQL() as any
-    expect(typeof q2.execute).toBe('function')
+
+    // Pinned: OBJECT containment throws on SQLite by design (there is no
+    // json_each equivalent for it), so this assertion silently depended on some
+    // earlier test file leaving the process-wide dialect on postgres.
+    const dialect = config.dialect
+    try {
+      config.dialect = 'postgres' as any
+      const q2 = qb().selectFrom('users').whereJsonContains('meta', { a: 1 }).toSQL() as any
+      expect(typeof q2.execute).toBe('function')
+    }
+    finally {
+      config.dialect = dialect as any
+    }
   })
 })
 

--- a/packages/bun-query-builder/test/client.where-fails-closed.test.ts
+++ b/packages/bun-query-builder/test/client.where-fails-closed.test.ts
@@ -11,6 +11,12 @@
  *
  * Failing closed is the whole point of these tests: an exception is recoverable
  * and a silently missing predicate is not.
+ *
+ * The callback form is no longer among the rejected shapes — as of #1083 it
+ * builds a real parenthesised group. The guarantee these tests exist to protect
+ * survives that change unaltered: a callback that adds NO conditions still
+ * throws, because a group contributing nothing is the same silent widening by
+ * another route.
  */
 
 import { describe, expect, it } from 'bun:test'
@@ -21,12 +27,22 @@ function query() {
 }
 
 describe('where() refuses what it cannot apply', () => {
-  it('rejects the expression-callback form rather than dropping it', () => {
-    expect(() => query().where((eb: any) => eb.or([]))).toThrow(/where\(callback\) is not supported/)
+  it('rejects a callback that adds no conditions rather than dropping it', () => {
+    // The failure mode this replaced: the callback ran, contributed nothing,
+    // and the builder came back unfiltered.
+    expect(() => query().where((b: any) => { void b })).toThrow(/added no conditions/)
+    expect(() => query().where(() => true)).toThrow(/added no conditions/)
   })
 
-  it('names the alternatives, because there are working ones', () => {
-    expect(() => query().where(() => true)).toThrow(/whereNested|whereAny|orWhere/)
+  it('names what to do about it, because there is a working form', () => {
+    expect(() => query().where(() => true)).toThrow(/where\(\)\/orWhere\(\)/)
+  })
+
+  it('applies a callback that does add conditions', () => {
+    const sql = String(query().where('id', '=', 1).where((b: any) => b.where('a', '=', 1).orWhere('b', '=', 2)).toSQL())
+
+    expect(sql).toContain('(a = ')
+    expect(sql).toContain(' OR b = ')
   })
 
   it('rejects a missing condition', () => {

--- a/packages/bun-query-builder/test/client.where-in-writes.test.ts
+++ b/packages/bun-query-builder/test/client.where-in-writes.test.ts
@@ -23,8 +23,8 @@
  * injected operator cannot be walked back.
  */
 
-import { describe, expect, it } from 'bun:test'
-import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder } from '../src'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, config, createQueryBuilder } from '../src'
 
 function qb() {
   const models = {
@@ -44,7 +44,16 @@ function qb() {
   })
 }
 
+// The dialect decides whether placeholders are `$n` or `?`, and it lives in
+// process-wide config — so without pinning it here these assertions depended on
+// whichever test file happened to run first. Pinned rather than hedged, because
+// the numbering (`$2, $3`, not `$1, $2`) is exactly what this file is about:
+// an IN that restarted at $1 would update every row in the table.
 describe('IN on an UPDATE', () => {
+  let dialect: string
+  beforeEach(() => { dialect = config.dialect; config.dialect = 'postgres' as any })
+  afterEach(() => { config.dialect = dialect as any })
+
   it('renders one placeholder per element, parenthesised', () => {
     const sql = String((qb() as any)
       .updateTable('notifications')
@@ -67,7 +76,7 @@ describe('IN on an UPDATE', () => {
       .where('id', 'in', [7, 8])
       .toSQL())
 
-    expect(sql).toMatch(/IN \(\$2, \$3\)|IN \(\?, \?\)/)
+    expect(sql).toContain('IN ($2, $3)')
   })
 
   it('continues an existing WHERE with AND rather than opening a second one', () => {
@@ -125,6 +134,10 @@ describe('IN on an UPDATE', () => {
 })
 
 describe('IN on a DELETE', () => {
+  let dialect: string
+  beforeEach(() => { dialect = config.dialect; config.dialect = 'postgres' as any })
+  afterEach(() => { config.dialect = dialect as any })
+
   it('renders one placeholder per element', () => {
     const sql = String((qb() as any)
       .deleteFrom('notifications')

--- a/packages/bun-query-builder/test/orm.or-where-precedence.test.ts
+++ b/packages/bun-query-builder/test/orm.or-where-precedence.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The ORM had the same ungrouped-OR defect as the select builder (#1083),
+ * reached by a different route.
+ *
+ * Unlike the select builder it DID keep a structured term list (`_wheres`, each
+ * with a `boolean: 'and' | 'or'`) — it just rendered it flat:
+ *
+ *     clauses.push(i === 0 ? clause : `${w.boolean.toUpperCase()} ${clause}`)
+ *
+ * so the grouping was left to SQL's precedence and `.where(a).whereLike(b)
+ * .orWhereLike(c)` meant `(a AND b) OR c`. Having the right data structure is
+ * not the same as using it; that gap is worth a test of its own, because the
+ * next reader will see `_wheres` and assume this case is covered.
+ *
+ * `update()` and `delete()` share buildWhereClauses, so the mis-grouping was
+ * not read-only — a widened WHERE on a DELETE removes rows the filter existed
+ * to protect. That half is asserted here too.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { configureOrm, createModel, createTableFromModel, getDatabase } from '../src/orm'
+
+const Row = createModel({
+  name: 'PrecRow',
+  table: 'prec_rows',
+  primaryKey: 'id',
+  autoIncrement: true,
+  attributes: {
+    name: { type: 'string', fillable: true },
+    batch: { type: 'integer', fillable: true },
+  },
+} as const)
+
+describe('ORM orWhere grouping (#1083)', () => {
+  beforeAll(() => {
+    configureOrm({ database: ':memory:' })
+  })
+
+  beforeEach(async () => {
+    const db = getDatabase()
+    db.run('DROP TABLE IF EXISTS prec_rows')
+    await createTableFromModel(Row.getDefinition())
+    // 20 rows: ids 1-10 `create_*`, 11-20 `alter_*`; batch 1 for ids <= 5.
+    for (let i = 1; i <= 20; i++)
+      await Row.create({ name: i <= 10 ? `create_${i}_table` : `alter_${i}_table`, batch: i <= 5 ? 1 : 2 })
+  })
+
+  afterAll(() => getDatabase().close())
+
+  it('brackets a trailing OR run', () => {
+    const { sql } = Row.query()
+      .where('batch', 1)
+      .whereLike('name', '%create%')
+      .orWhereLike('name', '%alter%')
+      .toSql()
+
+    // Was `batch = ? AND name like ? OR name like ?`.
+    expect(sql).toContain('batch = ? AND (name like ? OR name like ?)')
+  })
+
+  it('returns the bounded rows, not the superset', async () => {
+    const rows = await Row.query()
+      .where('batch', 1)
+      .whereLike('name', '%create%')
+      .orWhereLike('name', '%alter%')
+      .get()
+
+    // Was 15: every `alter_*` row came back regardless of batch.
+    expect(rows.length).toBe(5)
+    // Number(): `type: 'integer'` currently generates a TEXT column in
+    // createTableFromModel, so this reads back as '1'. Unrelated to #1083 —
+    // coerced rather than asserted on, so this test fails for its own reason
+    // or not at all.
+    expect(rows.every(r => Number(r.get('batch')) === 1)).toBe(true)
+  })
+
+  it('brackets a leading OR run against the AND that follows', async () => {
+    const rows = await Row.query()
+      .where('batch', 1)
+      .orWhereLike('name', '%alter%')
+      .where('id', '<=', 12)
+      .get()
+
+    // `(batch = 1 OR name like '%alter%') AND id <= 12` — ids 1-5 and 11-12.
+    expect(rows.map(r => r.get('id'))).toEqual([1, 2, 3, 4, 5, 11, 12])
+  })
+
+  it('leaves a two-term OR chain unbracketed', () => {
+    const { sql } = Row.query().where('batch', 1).orWhereLike('name', '%alter%').toSql()
+
+    expect(sql).toContain('batch = ? OR name like ?')
+    expect(sql).not.toContain('(')
+  })
+
+  it('does not emit a leading OR when orWhere is the first term', () => {
+    const { sql } = Row.query().orWhere('batch', 1).toSql()
+
+    expect(sql).not.toMatch(/WHERE\s+OR\b/)
+    expect(sql).toContain('WHERE batch = ?')
+  })
+
+  it('whereGroup still emits one pre-parenthesised term', () => {
+    // _addGroup pushes an already-bracketed raw clause; renderWhereTerms must
+    // not wrap it a second time.
+    const { sql } = Row.query()
+      .whereGroup(b => b.where('batch', 1).orWhere('batch', 2))
+      .whereLike('name', '%create%')
+      .toSql()
+
+    expect(sql).toContain('(batch = ? OR batch = ?) AND name like ?')
+    expect(sql).not.toContain('((')
+  })
+
+  it('delete() respects the grouping instead of widening', async () => {
+    // The dangerous half: buildWhereClauses is shared with delete(), so the
+    // flat OR removed rows the filter was meant to protect.
+    await Row.query()
+      .where('batch', 1)
+      .whereLike('name', '%create%')
+      .orWhereLike('name', '%alter%')
+      .delete()
+
+    const left = await Row.query().get()
+    // 15 survive (20 minus the 5 batch-1 create rows). Under the flat OR this
+    // deleted 15 and left 5.
+    expect(left.length).toBe(15)
+  })
+})

--- a/packages/bun-query-builder/test/types-and-inference.test.ts
+++ b/packages/bun-query-builder/test/types-and-inference.test.ts
@@ -890,9 +890,11 @@ describe('Query Builder: fluent chaining', () => {
       .where({ id: 1 })
       .orWhere({ email: 'test@test.com' })
       .andWhere({ is_active: true }))
-    expect(s).toContain('WHERE')
-    expect(s).toContain('OR')
-    expect(s).toContain('AND')
+    // Asserted as a whole string, not as three toContain()s for 'WHERE'/'OR'/
+    // 'AND'. This is the test that should have caught #1083: it emitted
+    // `id = ? OR email = ? AND is_active = ?` — `(id) OR (email AND active)` —
+    // and passed, because every keyword it looked for was present.
+    expect(s).toContain('WHERE (id = $1 OR email = $2) AND is_active = $3')
   })
 })
 

--- a/packages/bun-query-builder/test/types-and-inference.test.ts
+++ b/packages/bun-query-builder/test/types-and-inference.test.ts
@@ -894,7 +894,8 @@ describe('Query Builder: fluent chaining', () => {
     // 'AND'. This is the test that should have caught #1083: it emitted
     // `id = ? OR email = ? AND is_active = ?` — `(id) OR (email AND active)` —
     // and passed, because every keyword it looked for was present.
-    expect(s).toContain('WHERE (id = $1 OR email = $2) AND is_active = $3')
+    // Placeholders normalised — `?` vs `$n` depends on process-wide config.
+    expect(s.replace(/\$\d+/g, '?')).toContain('WHERE (id = ? OR email = ?) AND is_active = ?')
   })
 })
 


### PR DESCRIPTION
Closes #1083.

## The bug

`orWhere` appended a bare, ungrouped `OR`. SQL binds `AND` tighter than `OR`, so:

```ts
.where('id', '<=', 10)
.where('migration', 'like', '%create%')
.orWhere('migration', 'like', '%table%')
// SELECT * FROM migrations WHERE id <= ? AND migration like ? OR migration like ?
```

parses as `(id <= 10 AND create) OR table`. `id <= 10` silently stops applying: **10 rows → 118**.

The query is valid SQL, nothing warns, and the result is a *superset* of what was asked for. That last part is what made it dangerous — it fails toward MORE rows, so it looks like data rather than an error. The reporter hit it on a moderation queue: a "Pending" tab search returned 18 rows instead of 3, 15 of them already published, and because the list and count queries were built identically the wrong `total` agreed with the wrong rows.

## The rule now

Each maximal run of `OR` terms is bracketed with the term that opens it, so `OR` binds **tighter** than `AND` in chain order:

```
.where(a).where(b).orWhere(c)   ->  a AND (b OR c)
.where(a).orWhere(b).where(c)   ->  (a OR b) AND c
```

That is the inverse of raw SQL, deliberately. It is how the chain reads, and it is already what `whereAny`/`whereAll`/`whereNone` and the ORM's `whereGroup` do — `orWhere` was the odd one out.

## Before / after, measured

Against the 118-row fixture from the issue:

| chain | before | rows | after | rows |
|---|---|---|---|---|
| `.where(a).where(b).orWhere(c)` | `a AND b OR c` | **118** | `a AND (b OR c)` | **10** |
| `.where(a).orWhere(c).where(d)` | `a OR c AND d` | **31** | `(a OR c) AND d` | **21** |
| `.where(a).orWhere(b).orWhere(c)` | `a OR b OR c` | 118 | **byte-identical** | 118 |
| `.where(a).orWhere(b)` | `a OR b` | 80 | **byte-identical** | 80 |
| `.orWhere(a)` alone | `FROM t OR a` | **syntax error** | `WHERE a` | **10** |

Verified on SQLite and on live Postgres, including the placeholder renumbering for nested groups.

## Why there was nothing to fix in `orWhere` itself

The select builder had no WHERE representation. Clauses were appended to a text string — alongside a `whereConditions` array with **25 pushes and zero reads**, a structured form nobody ever wired to the emit path. That is why this shipped. That array is now the real term list, rendered at emit time by `renderWhereTerms()`.

The ORM had the same defect by a different route: it *did* keep terms with an `and`/`or` flag, and joined them flat. Having the right data structure is not the same as using it.

Both now share `src/sql-fragments.ts`. Two independent copies of one rule is how they drifted — they also had two copies of the `IN ()` bug.

## Fixed along the way

All consequences of the same missing structure:

- A leading `orWhere`/`orWhereIn`/`orWhereNotIn`/`orWhereColumn`/`orWhereNested` emitted `SELECT … FROM t OR …` — a syntax error on every dialect.
- `.where(a).orderBy(c).orWhere(b)` emitted `… ORDER BY c ASC OR b`. The WHERE is now spliced ahead of the trailing clauses instead of appended, so clause ordering is structural rather than regex-managed. (`.where(x).join(y)` benefits from the same change.)
- The dynamic `orWhereX` proxy mis-grouped through a **second** path: it also assigned ``built = sql`${ensureBuilt()} OR …` ``, which was the object actually executed. `whereHas`/`whereDoesntHave` and the soft-delete filter carried the same double-write with an unconditional `WHERE` keyword.
- An object condition came apart: `.where({a, b}).orWhere(c)` dropped `a`. An object is one term now, bracketed when it has more than one key.
- `wherePivotIn(rel, col, [])` dropped its predicate and widened the query.
- `andWhere` and `orWhere` were two near-identical 75-line copies differing only in the connector — precisely how the OR variant came to be the broken one. One implementation now.

## ⚠️ This is a behaviour change

**Emitted SQL changes for any chain of 3+ where-terms containing an `orWhere`**, on both the select builder and the ORM. Two-term chains, all-OR chains, and chains with no `orWhere` are byte-identical — asserted with `toBe`, not `toContain`, so the no-churn guarantee is pinned.

Who is affected:

1. Anyone who wrote `.where(x).where(y).orWhere(z)` **meaning** `(x AND y) OR z` and got it by accident. They now get `x AND (y OR z)` and should switch to `whereGroup`.
2. Anyone who was bitten (the reporter) gets correct rows with no code change.
3. Anyone snapshot-testing emitted SQL for 3+-term OR chains.

The migration path ships **in this PR**: `whereGroup(cb)` / `orWhereGroup(cb)`, plus `orWhereNull`, `orWhereNotNull`, `orWhereBetween`, `orWhereExists`, `orWhereRaw`.

```ts
// the old reading, said explicitly
.whereGroup(qb => qb.where(x).where(y)).orWhere(z)   // (x AND y) OR z
```

An e2e test asserts `whereGroup` reproduces the pre-fix row count *exactly* (80), so the old behaviour is provably still reachable.

`where(callback)` also builds a real group now instead of throwing — the form `docs/guide/where.md` has documented since before the builder rejected it. A callback that adds **no** conditions still throws, so the fails-closed guarantee that test file exists to protect is unchanged.

No compatibility flag: two emit paths would double the surface of the code that just shipped a silent wrong-rows bug.

## Tests

43 new tests across four files:

- `client.or-where-precedence.test.ts` — SQL shape, incl. the byte-identical guarantees and the sub-select builder
- `client.or-where-precedence.e2e.test.ts` — **row counts**, each carrying the pre-fix number. Asserting the string proves the shape changed; only rows prove it was wrong.
- `orm.or-where-precedence.test.ts` — the ORM mirror, incl. `delete()` (which shares `buildWhereClauses`, so the mis-grouping removed rows the filter was meant to protect)
- Strengthened four existing tests that had **vacuous assertions** — `types-and-inference.test.ts:888` checked `toContain('WHERE')`, `toContain('OR')`, `toContain('AND')` and passed on the broken output. That is the test that should have caught this.

`1776 pass / 4 skip / 0 fail`, typecheck clean, 0 lint errors.

## Noted, not fixed here

`createTableFromModel` maps `type: 'integer'` to a `TEXT` column, so integer attributes read back as strings. Unrelated to this issue — worth its own report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)