### PR TITLE
fix(ci): renovate rejects unknown keys, so the disable never took effect (#1082)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabled": false,
-  "_comment": [
+  "description": [
     "Renovate is off: buddy-bot owns dependency updates here (see CLAUDE.md).",
     "",
     "Both bots were live on the same manifests, which does not merely duplicate",
@@ -19,6 +19,11 @@
     "with no config as un-onboarded and opens a fresh 'Configure Renovate' PR.",
     "Disabling in-repo is the only way to stay quiet. For belt and braces,",
     "deselect this repository in the Renovate GitHub App installation settings.",
+    "",
+    "These notes live in `description`, not `_comment`: JSON has no comment",
+    "syntax, and renovate REJECTS unknown top-level keys rather than ignoring",
+    "them — an invalid config made it file an 'Action Required' issue (#1082).",
+    "`description` is the documented field for exactly this.",
     "",
     "GitHub Actions bumps are handled by .github/dependabot.yml, because",
     "buddy-bot generates workflow files but does not bump `uses:` pins."


### PR DESCRIPTION
Closes #1082.

When renovate was disabled in #1080, the block explaining *why* was written as a `_comment` key. JSON has no comment syntax, and `_comment` is not a renovate option.

Renovate does not ignore unknown top-level keys — it treats the whole file as invalid, stops processing, and opens an **"Action Required: Fix Renovate Configuration"** issue:

> Location: `.github/renovate.json`
> Error type: The renovate configuration file contains some invalid settings
> Message: Invalid configuration option: _comment

So the config meant to quietly disable renovate became a standing complaint instead. (`enabled: false` never applied either, since the file was rejected wholesale — the queue stayed quiet only because renovate halts on an invalid config, which is not the same thing as being off.)

`description` is the documented field for annotating a renovate config, and it accepts an array of strings. Same text, in a key the schema actually accepts.

Verified the file parses and carries exactly three top-level keys: `$schema`, `enabled`, `description`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)