### PR TITLE
fix(client): the cursor predicate is a where term, not a second WHERE (#1090)

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -186,6 +186,26 @@ function renderSelectColumn(col: unknown): string {
   )
 }
 
+/**
+ * Does this SQL have an `ORDER BY` of its own, at paren depth 0?
+ *
+ * Depth-aware because a subquery in the FROM list or an `IN (SELECT … ORDER BY
+ * …)` carries its own, and matching that one would reject a query whose outer
+ * SELECT is unordered.
+ */
+function hasTopLevelOrderBy(s: string): boolean {
+  const re = /\(|\)|\bORDER\s+BY\b/gi
+  let depth = 0
+  let m: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((m = re.exec(s))) {
+    if (m[0] === '(') { depth++ }
+    else if (m[0] === ')') { depth = Math.max(0, depth - 1) }
+    else if (depth === 0) { return true }
+  }
+  return false
+}
+
 // Pre-compiled regex patterns for performance
 const SQL_PATTERNS = {
   SELECT_STAR: /^SELECT\s+\*/i,
@@ -3297,9 +3317,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
      *
      * Splicing rather than appending also fixes `.where(a).orderBy(c).orWhere(b)`,
      * which used to emit `… ORDER BY c ASC OR b` and fail to parse.
+     *
+     * `extra` appends one more AND-term for this render only, without recording
+     * it. That is what cursorPaginate needs: its cursor predicate changes on
+     * every page, so pushing it onto `whereTerms` would accumulate one stale
+     * predicate per iteration.
      */
-    const currentSql = (): string => {
-      const body = renderWhereTerms(whereTerms)
+    const currentSql = (extra?: WhereTerm): string => {
+      const body = renderWhereTerms(extra ? [...whereTerms, extra] : whereTerms)
       if (!body)
         return text
       if (whereTail) {
@@ -5608,29 +5633,58 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         return { data: hasMore ? data.slice(0, perPage) : data, meta: { perPage, page: p, hasMore } }
       },
       async cursorPaginate(perPage: number, cursor?: any, column: string | string[] = 'id', direction: 'asc' | 'desc' = 'asc') {
-        let q = ensureBuilt()
+        if (!Number.isInteger(perPage) || perPage <= 0)
+          throw new TypeError(`[query-builder] cursorPaginate(perPage): expected positive integer, got ${perPage}`)
+
+        const cols = (Array.isArray(column) ? column : [column]).map(String)
+        for (const c of cols) validateIdentifier(c, 'cursorPaginate(column)')
+        const cmp = direction === 'asc' ? '>' : '<'
+        const dir = direction === 'asc' ? 'ASC' : 'DESC'
+        const params = [...whereParams]
+
+        // The cursor predicate is a WHERE TERM, not a second WHERE keyword.
+        // It used to be composed as `sql`${q} WHERE ...``, unconditionally — so
+        // any filter already on the builder produced `... WHERE a WHERE b`, a
+        // syntax error on every dialect. That is why `.where(x).chunkById(...)`
+        // never worked: page one has no cursor and succeeds, and the failure
+        // only lands on page two. See stacksjs/bun-query-builder#1090.
+        let predicate = ''
         if (cursor !== undefined && cursor !== null) {
           if (Array.isArray(column)) {
-            const cols = column.map(c => sql(String(c)))
-            const comp = direction === 'asc' ? sql`>` : sql`<`
-            const tupleCols = sql`(${sql(cols as any)})`
-            const tupleVals = sql`(${sql(cursor as any)})`
-            q = sql`${q} WHERE ${tupleCols} ${comp} ${tupleVals}`
+            const phs = (cursor as any[]).map((v) => { params.push(v); return getPlaceholder(params.length) })
+            predicate = `(${cols.join(', ')}) ${cmp} (${phs.join(', ')})`
           }
           else {
-            q = direction === 'asc'
-              ? sql`${q} WHERE ${sql(String(column))} > ${cursor}`
-              : sql`${q} WHERE ${sql(String(column))} < ${cursor}`
+            params.push(cursor)
+            predicate = `${cols[0]} ${cmp} ${getPlaceholder(params.length)}`
           }
         }
-        if (Array.isArray(column)) {
-          const orderParts = column.map(c => sql`${sql(String(c))} ${direction === 'asc' ? sql`ASC` : sql`DESC`}`)
-          const orderExpr = orderParts.reduce((acc, p, i) => (i === 0 ? p : sql`${acc}, ${p}`))
-          q = sql`${q} ORDER BY ${orderExpr} LIMIT ${perPage + 1}`
+
+        // Rendered through currentSql() so the predicate is spliced ahead of any
+        // trailing clause rather than appended past it, and so the builder's own
+        // WHERE terms come along.
+        const base = reorderSelectClauses(predicate ? currentSql({ conn: 'AND', sql: predicate }) : currentSql())
+        const order = cols.map(c => `${c} ${dir}`).join(', ')
+
+        // Cursor pagination OWNS the ordering — the cursor predicate `col > ?`
+        // only selects "the rows after this one" if the rows are sorted by that
+        // same column, so a different ORDER BY makes the cursor meaningless and
+        // silently skips or repeats rows.
+        //
+        // This case has always been broken: it emitted a second ORDER BY and
+        // failed to parse. It was invisible until now only because the
+        // duplicate-WHERE error above fired first. Refusing it says so, rather
+        // than dropping the caller's ordering without mentioning it.
+        if (hasTopLevelOrderBy(base)) {
+          throw new TypeError(
+            `[query-builder] cursorPaginate() cannot be combined with orderBy() — it orders by `
+            + `${order} itself, and a cursor is only meaningful in that order. `
+            + `Remove the orderBy(), or pass the column and direction to cursorPaginate().`,
+          )
         }
-        else {
-          q = sql`${q} ORDER BY ${sql(String(column))} ${direction === 'asc' ? sql`ASC` : sql`DESC`} LIMIT ${perPage + 1}`
-        }
+        const q = params.length > 0
+          ? _sql.unsafe(`${base} ORDER BY ${order} LIMIT ${perPage + 1}`, params)
+          : _sql.unsafe(`${base} ORDER BY ${order} LIMIT ${perPage + 1}`)
         const rows = await runWithHooks<any[]>(q, 'select', { signal: abortSignal, timeoutMs })
         // We fetch perPage+1 rows to detect whether more exist; the extra row
         // is only a "has more?" probe and is NOT delivered. The next cursor

--- a/packages/bun-query-builder/test/client.cursor-paginate.test.ts
+++ b/packages/bun-query-builder/test/client.cursor-paginate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression coverage for stacksjs/bun-query-builder#1090.
+ *
+ * `cursorPaginate` appended its cursor predicate with an unconditional `WHERE`
+ * keyword instead of continuing an existing one with `AND`. Any filter already
+ * on the builder produced two top-level `WHERE`s and a parse error — on every
+ * dialect, not just the SQLite wrapper.
+ *
+ * `chunkById` and `eachById` both delegate to it, so `.where(x).chunkById(...)`
+ * — the natural way to walk a filtered table in batches — had never worked.
+ *
+ * The timing is what kept this hidden: page one is fetched with no cursor, so
+ * no predicate is emitted and it succeeds. The failure only lands on page two.
+ * A fixture that fits in a single chunk passes, which is why the existing
+ * pagination tests never caught it. Every test here therefore either forces a
+ * non-null cursor or spans more than one chunk.
+ */
+
+import { SQL } from 'bun'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, createQueryBuilder } from '../src'
+
+const schema = buildDatabaseSchema({
+  Row: {
+    name: 'Row',
+    table: 'cp_rows',
+    primaryKey: 'id',
+    attributes: {
+      id: { validation: { rule: {} } },
+      b: { validation: { rule: {} } },
+      g: { validation: { rule: {} } },
+    },
+  },
+} as any)
+
+let sql: SQL
+
+beforeAll(async () => {
+  sql = new SQL('sqlite://:memory:')
+  await sql.unsafe('CREATE TABLE cp_rows (id INTEGER PRIMARY KEY, b INTEGER, g INTEGER)')
+  // ids 1-20; `b` alternates 1/0 so a filter halves the set; `g` groups by 5.
+  for (let i = 1; i <= 20; i++)
+    await sql.unsafe('INSERT INTO cp_rows VALUES (?, ?, ?)', [i, i % 2, Math.ceil(i / 5)])
+})
+
+afterAll(async () => {
+  await sql?.end()
+})
+
+const q = () => createQueryBuilder<typeof schema>({ schema, sql }).selectFrom('cp_rows').selectAll() as any
+
+describe('cursorPaginate continues an existing WHERE (#1090)', () => {
+  it('pages a filtered query instead of throwing', async () => {
+    const page = await q().where('b', '=', 1).cursorPaginate(3, 5, 'id')
+
+    // Was: SQLiteError: near "WHERE": syntax error.
+    expect(page.data.map((r: any) => r.id)).toEqual([7, 9, 11])
+    // The builder's own filter must still apply — a fix that merely stopped
+    // throwing by dropping the WHERE would return 6, 7, 8 here.
+    expect(page.data.every((r: any) => r.b === 1)).toBe(true)
+  })
+
+  it('pages an unfiltered query exactly as before', async () => {
+    const page = await q().cursorPaginate(3, 5, 'id')
+
+    expect(page.data.map((r: any) => r.id)).toEqual([6, 7, 8])
+  })
+
+  it('honours a descending cursor alongside a filter', async () => {
+    const page = await q().where('b', '=', 1).cursorPaginate(3, 15, 'id', 'desc')
+
+    expect(page.data.map((r: any) => r.id)).toEqual([13, 11, 9])
+  })
+
+  it('honours a composite cursor alongside a filter', async () => {
+    const page = await q().where('b', '=', 1).cursorPaginate(3, [2, 7], ['g', 'id'])
+
+    expect(page.data.map((r: any) => r.id)).toEqual([9, 11, 13])
+  })
+
+  it('carries a grouped OR filter into the cursor query', async () => {
+    // Guards the interaction with #1083: the builder's WHERE is rendered from
+    // the term list, so the cursor predicate has to be ANDed against the whole
+    // group rather than against its last term.
+    const page = await q().where('id', '<=', 4).orWhere('id', '>=', 18).cursorPaginate(10, 1, 'id')
+
+    expect(page.data.map((r: any) => r.id)).toEqual([2, 3, 4, 18, 19, 20])
+  })
+})
+
+describe('chunkById/eachById over a filtered query (#1090)', () => {
+  it('chunkById walks every matching row', async () => {
+    const seen: number[] = []
+    await q().where('b', '=', 1).chunkById(3, 'id', (rows: any[]) => {
+      seen.push(...rows.map(r => r.id))
+    })
+
+    // Was: threw on the second chunk. Note this spans four chunks — a fixture
+    // that fitted in one would have passed against the bug.
+    expect(seen).toEqual([1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
+  })
+
+  it('eachById visits every matching row', async () => {
+    const seen: number[] = []
+    await q().where('b', '=', 1).eachById(3, 'id', (row: any) => {
+      seen.push(row.id)
+    })
+
+    expect(seen).toEqual([1, 3, 5, 7, 9, 11, 13, 15, 17, 19])
+  })
+
+  it('chunkById is unchanged on an unfiltered query', async () => {
+    const seen: number[] = []
+    await q().chunkById(3, 'id', (rows: any[]) => {
+      seen.push(...rows.map(r => r.id))
+    })
+
+    expect(seen).toEqual(Array.from({ length: 20 }, (_, i) => i + 1))
+  })
+})
+
+describe('cursorPaginate argument validation (#1090)', () => {
+  it('refuses to be combined with orderBy', async () => {
+    // A cursor predicate `col > ?` only means "the rows after this one" if the
+    // result is sorted by that column, so a second ordering makes the cursor
+    // meaningless. This always emitted a duplicate ORDER BY and failed to
+    // parse; it was invisible because the duplicate-WHERE error fired first.
+    await expect(q().where('b', '=', 1).orderBy('id').cursorPaginate(3, 5, 'id'))
+      .rejects.toThrow(/cannot be combined with orderBy/)
+  })
+
+  it('refuses a non-positive page size', async () => {
+    await expect(q().cursorPaginate(0, 1, 'id')).rejects.toThrow(/expected positive integer/)
+  })
+
+  it('refuses a column that is not an identifier', async () => {
+    await expect(q().cursorPaginate(3, 1, 'id; DROP TABLE cp_rows')).rejects.toThrow(/Invalid identifier/)
+    // And the table is still there.
+    expect((await sql.unsafe('SELECT count(*) as c FROM cp_rows'))[0].c).toBe(20)
+  })
+})


### PR DESCRIPTION
Closes #1090.

## The bug

`cursorPaginate` composed its cursor predicate with an unconditional `WHERE` keyword:

```ts
q = sql`${q} WHERE ${sql(String(column))} > ${cursor}`
```

So any filter already on the builder produced two top-level `WHERE`s:

```ts
await db.selectFrom('t').selectAll().where('b', '=', 1).cursorPaginate(3, 5, 'id')
// SQLiteError: near "WHERE": syntax error
```

`chunkById` and `eachById` both delegate to `cursorPaginate`, so `.where(x).chunkById(...)` — the natural way to walk a filtered table in batches — had never worked. This is not the SQLite-wrapper class of bug; it reproduces on **every dialect**.

## Why nothing caught it

Page one is fetched with `cursor === undefined`, so no predicate is emitted and it succeeds. The failure only lands on **page two**. A test fixture that fits in a single chunk passes against the bug — which is exactly what the existing pagination tests do.

Every test added here either forces a non-null cursor or spans more than one chunk. The `chunkById` case deliberately spans four.

## The fix

The predicate is now a WHERE **term**, rendered through `currentSql()` (the term-list renderer from #1083), so it is ANDed onto whatever the builder already has and spliced ahead of the trailing clauses rather than appended past them.

`currentSql()` gained an optional extra term for this. The cursor changes on every page, so pushing it onto `whereTerms` would accumulate one stale predicate per iteration — the extra term applies to a single render and is not recorded.

A test pins the interaction with #1083's grouping: `.where(a).orWhere(b).cursorPaginate(...)` must AND the cursor against the whole OR-group, not against its last term.

## ⚠️ One extra defect fixed, because it was in the same lines

**`cursorPaginate` combined with `orderBy` emitted a second `ORDER BY`** and failed to parse. It was invisible until now because the duplicate-`WHERE` error fired first — fixing that one revealed this one, and shipping the fix without handling it would have looked like this PR caused it.

Cursor pagination owns the ordering by necessity: `col > ?` only means "the rows after this one" if the rows are sorted by that column, so a second ordering makes the cursor meaningless — it silently skips or repeats rows. It now throws:

```
[query-builder] cursorPaginate() cannot be combined with orderBy() — it orders by id ASC
itself, and a cursor is only meaningful in that order. Remove the orderBy(), or pass the
column and direction to cursorPaginate().
```

**No working code changes**: that combination already crashed with a driver syntax error. This replaces an opaque `near "ORDER": syntax error` with an explanation. The check is paren-depth aware, so a subquery's own `ORDER BY` doesn't trip it.

## Also tightened while rewriting

`perPage` is validated as a positive integer, and the cursor column goes through `validateIdentifier` — neither of which it did before. `cursorPaginate(3, 1, 'id; DROP TABLE t')` was previously interpolated; a test now asserts it is rejected and the table survives.

## Verification

| case | before | after |
|---|---|---|
| `.where(b=1).cursorPaginate(3, 5, 'id')` | `near "WHERE": syntax error` | `[7, 9, 11]` |
| `.where(b=1).chunkById(3, 'id', …)` | throws on chunk 2 | `[1,3,5,7,9,11,13,15,17,19]` |
| `.where(b=1).cursorPaginate(3, 15, 'id', 'desc')` | throws | `[13, 11, 9]` |
| `.where(b=1).cursorPaginate(3, [2,7], ['g','id'])` | throws | `[9, 11, 13]` |
| `.cursorPaginate(3, 5, 'id')` (no filter) | `[6, 7, 8]` | **unchanged** |

Run against both SQLite and a live Postgres — identical results on each.

`1789 pass / 4 skip / 0 fail`, typecheck clean, 0 lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)