### PR TITLE
fix(ci): pantry cannot resolve `latest`, so ask for ranges instead

### DIFF
--- a/deps.yaml
+++ b/deps.yaml
@@ -1,5 +1,21 @@
+# Ranges, never `latest`.
+#
+# pantry's installer SDK resolves `latest` from a hardcoded per-domain switch
+# (nodejs.org, ziglang.org, ...) that ends in a bare throw. A domain the SDK
+# supports but has no case for cannot resolve `latest` at all — it fails with
+# `Cannot resolve latest version for <domain>`. A range takes a different path
+# that reads the package's published version list, so it always resolves.
+#
+# That is not hypothetical: `sqlite: latest` was fine only because the SDK did
+# not support sqlite.org and skipped it with a warning. Adding it upstream
+# promoted it from skipped to installed and reddened main. `bun` never broke
+# here precisely because it was already a range.
+#
+# mysql and postgres are still skipped as unsupported, so their spec is inert
+# today — they are ranges so that being added upstream is a no-op, not an
+# outage.
 dependencies:
   bun: ^1.3.14
-  mysql: latest
-  postgres: latest
-  sqlite: latest
+  mysql: ^8.0.45
+  postgres: ^18.0.0
+  sqlite: ^3.52.0


### PR DESCRIPTION
## What broke

`main` is red at the `Setup Pantry` step:

```
Required system package sqlite@latest failed to install:
  Cannot resolve latest version for sqlite.org
```

No commit here explains it. The identical tree (`6210b19`) was green at 11:07Z and red by 12:21Z, and a re-run failed the same way, so it is not a flake. `.github/workflows/ci.yml` uses `home-lang/pantry/packages/action@main` — unpinned — so upstream changes land in our CI unreviewed.

It is **not** the three PRs merged just before it. `e568f9a` still had `actions/cache@v5.1.0` and failed identically.

## Why

pantry's installer SDK resolves `latest` from a hardcoded per-domain switch (`nodejs.org`, `ziglang.org`, …) ending in a bare `throw`. A domain the SDK *supports* but has no case for cannot resolve `latest` at all.

Its supported set grew between versions:

| version | supported domains |
|---|---|
| 0.11.21 | `mail-os/mail`, `ziglang.org`, `bun.sh`, `nodejs.org` |
| 0.11.26 | …plus **`sqlite.org`** |

Adding `sqlite.org` promoted it from *unsupported → warn and skip* to *supported → try to install*, landing it on the throw. `bun` never broke because it was already a range.

## Verified

Against 0.11.26, the exact version CI runs:

| spec | result |
|---|---|
| `sqlite.org@latest` | ✗ `Cannot resolve latest version for sqlite.org` |
| `sqlite.org@3.52.0` | ✓ installs |
| `sqlite.org@^3.52.0` | ✓ installs (resolves 3.53.4) |

And `resolve-deps` on the new file resolves all four: `bun`, `mysql 8.0.45`, `postgres 18.6`, `sqlite 3.53.4`.

## On mysql/postgres

Still unsupported by the SDK, so they are skipped with a warning and their spec is inert *today*. They move to ranges so that being added upstream is a no-op instead of a repeat of this outage. If you would rather keep this diff to sqlite alone, dropping those two lines is safe.

## Worth considering separately

`action@main` is why this arrived unannounced. Pinning it to a tag or SHA would make upstream changes something we adopt deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)