### PR TITLE
fix(client): whereJsonContains binds the document, not its JSON text (#1091)

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -4944,12 +4944,27 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         const dialect = config.dialect
         const idx = whereParams.length + 1
         if (dialect === 'postgres') {
+          // Bind the document itself, NOT `JSON.stringify(document)`. Bun's
+          // driver already JSON-encodes a value bound to a jsonb parameter, so
+          // stringifying first encoded it twice and Postgres received the jsonb
+          // *string* `"[\"bun\"]"` where the array `["bun"]` was meant. A jsonb
+          // string never `@>`-contains anything, so the predicate was vacuously
+          // false and every call returned zero rows, silently. See #1091.
+          //
+          // That encoding covers objects, arrays and strings. Numbers and
+          // booleans are bound as int4/bool instead, which `@>` has no operator
+          // for (`operator does not exist: jsonb @> integer`), so those are
+          // lifted to a jsonb scalar with to_jsonb().
+          const needsJsonbLift = typeof json === 'number' || typeof json === 'boolean'
+          const operand = needsJsonbLift
+            ? `to_jsonb(${getPlaceholder(idx)})`
+            : getPlaceholder(idx)
           // operator (`@>`, default) or function (`jsonb_contains`) per config.
           if (config.sql?.jsonContainsMode === 'function')
-            pushWhere('AND', `jsonb_contains(${column}, ${getPlaceholder(idx)})`)
+            pushWhere('AND', `jsonb_contains(${column}, ${operand})`)
           else
-            pushWhere('AND', `${column} @> ${getPlaceholder(idx)}`)
-          whereParams.push(JSON.stringify(json))
+            pushWhere('AND', `${column} @> ${operand}`)
+          whereParams.push(json)
         }
         else if (isMysqlLike(dialect)) {
           pushWhere('AND', `JSON_CONTAINS(${column}, ${getPlaceholder(idx)})`)

--- a/packages/bun-query-builder/test/client.json-contains.pg.test.ts
+++ b/packages/bun-query-builder/test/client.json-contains.pg.test.ts
@@ -1,0 +1,121 @@
+/**
+ * whereJsonContains against a live Postgres — stacksjs/bun-query-builder#1091.
+ *
+ * The bug: `whereJsonContains` pushed `JSON.stringify(json)`, but Bun's driver
+ * already JSON-encodes a value bound to a jsonb parameter. The document was
+ * therefore encoded twice and Postgres received the jsonb *string*
+ * `"[\"bun\"]"` where the array `["bun"]` was meant. A jsonb string never
+ * `@>`-contains anything, so the predicate was vacuously false and every call
+ * returned zero rows, for every input, silently.
+ *
+ * This has to execute. The emitted SQL was correct throughout (`tags @> $1`) —
+ * only the bound parameter was wrong, and `toSQL()` does not expose parameters,
+ * so no SQL-text assertion can observe the difference. The existing #1026 suite
+ * asserted the text and stayed green across the entire lifetime of this bug.
+ *
+ * Note also that every negative case ("no row should match") passed while the
+ * bug was live, because the answer was always zero rows. Only positive cases —
+ * containment that genuinely holds — can fail here, so every case below asserts
+ * a row comes back except where it explicitly checks a non-match.
+ *
+ * Runs in a subprocess: `config.dialect` is global and other test files pin it
+ * to sqlite, which would mask the network-driver path entirely.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'bun:test'
+import { PG_URL, probePostgres } from './pg'
+
+const pgAvailable = await probePostgres()
+
+describe.skipIf(!pgAvailable)('whereJsonContains against live Postgres (#1091)', () => {
+  it('matches rows for documents and scalars, in both containment modes', () => {
+    const srcEntry = resolve(import.meta.dir, '../src/index.ts')
+    const dir = mkdtempSync(join(tmpdir(), 'qb-jc1091-'))
+    const scriptPath = join(dir, 'probe.ts')
+
+    writeFileSync(scriptPath, `
+import { SQL } from 'bun'
+import { setConfig, resetConnection, createQueryBuilder, buildDatabaseSchema, buildSchemaMeta } from ${JSON.stringify(srcEntry)}
+
+const URL = ${JSON.stringify(PG_URL)}
+const failures = []
+const check = (label, got, want) => {
+  const g = JSON.stringify(got), w = JSON.stringify(want)
+  if (g !== w) failures.push(label + ': got ' + g + ', want ' + w)
+}
+
+const raw = new SQL(URL)
+await raw.unsafe('DROP TABLE IF EXISTS _qb_jsoncontains')
+await raw.unsafe('CREATE TABLE _qb_jsoncontains (id int primary key, tags jsonb, meta jsonb)')
+await raw.unsafe(\`INSERT INTO _qb_jsoncontains VALUES
+  (1, '["bun","sql",1,true]', '{"published":true,"tier":"pro"}'),
+  (2, '["node"]',             '{"published":false}')\`)
+await raw.end()
+
+setConfig({ dialect: 'postgres', database: { url: URL } })
+resetConnection()
+
+const models = { _qb_jsoncontains: { columns: {
+  id: { type: 'integer', isPrimaryKey: true }, tags: { type: 'json' }, meta: { type: 'json' },
+} } }
+const db = createQueryBuilder({
+  schema: buildDatabaseSchema(models),
+  meta: buildSchemaMeta(models),
+  autoMigration: { enabled: false },
+})
+
+const ids = async (column, operand) => {
+  const rows = await db.selectFrom('_qb_jsoncontains').select('id')
+    .whereJsonContains(column, operand).orderBy('id', 'asc').get()
+  return rows.map(r => Number(r.id))
+}
+
+// Documents. Each of these returned [] while #1091 was live.
+check('array', await ids('tags', ['bun']), [1])
+check('array multi-element', await ids('tags', ['bun', 'sql']), [1])
+check('object', await ids('meta', { published: true }), [1])
+check('object multi-key', await ids('meta', { published: true, tier: 'pro' }), [1])
+check('string', await ids('tags', 'bun'), [1])
+
+// Scalars. Bound as int4/bool, so these need the to_jsonb lift or Postgres
+// rejects the statement outright rather than returning nothing.
+check('number', await ids('tags', 1), [1])
+check('boolean', await ids('tags', true), [1])
+
+// Non-matches still do not match — the fix must not widen the predicate.
+check('array non-match', await ids('tags', ['nope']), [])
+check('object non-match', await ids('meta', { published: 'nope' }), [])
+check('string non-match', await ids('tags', 'zzz'), [])
+check('number non-match', await ids('tags', 99), [])
+
+// jsonb_contains() is the same containment through the function form.
+setConfig({ sql: { jsonContainsMode: 'function' } })
+check('function mode array', await ids('tags', ['bun']), [1])
+check('function mode number', await ids('tags', 1), [1])
+check('function mode non-match', await ids('tags', ['nope']), [])
+
+const cleanup = new SQL(URL)
+await cleanup.unsafe('DROP TABLE IF EXISTS _qb_jsoncontains')
+await cleanup.end()
+
+if (failures.length) {
+  console.error('FAILURES:\\n' + failures.join('\\n'))
+  process.exit(1)
+}
+console.log('OK')
+`)
+
+    const proc = Bun.spawnSync({ cmd: ['bun', scriptPath], stdout: 'pipe', stderr: 'pipe', cwd: process.cwd(), env: { ...process.env } })
+    const dec = new TextDecoder()
+    const out = dec.decode(proc.stdout).trim()
+    const err = dec.decode(proc.stderr).trim()
+    rmSync(dir, { recursive: true, force: true })
+
+    expect(proc.exitCode, `whereJsonContains pg probe failed.\nstdout: ${out}\nstderr: ${err}`).toBe(0)
+    expect(out).toContain('OK')
+  })
+})

--- a/packages/bun-query-builder/test/client.json-contains.test.ts
+++ b/packages/bun-query-builder/test/client.json-contains.test.ts
@@ -67,4 +67,37 @@ describe('whereJsonContains dialect handling (#1026)', () => {
   // (`whereJsonContains('tags', ['bun'])` against a seeded table returns the
   // matching row); an in-suite execution test is omitted because the shared
   // lazy-connection state across test files makes it flaky.
+
+  /**
+   * #1091. Postgres binds a number as int4 and a boolean as bool, neither of
+   * which `@>` accepts (`operator does not exist: jsonb @> integer`), so a
+   * scalar operand is lifted to a jsonb scalar. Documents are bound directly
+   * and must NOT be lifted — the driver already encodes those as jsonb.
+   *
+   * These assert the SQL shape only. The bug this guards against lived
+   * entirely in the bound parameter, which `toSQL()` does not expose, so the
+   * real guard is the execution test in client.json-contains.pg.test.ts.
+   */
+  it('Postgres: lifts a number or boolean operand with to_jsonb (#1091)', () => {
+    config.dialect = 'postgres' as any
+    config.sql = { ...config.sql, jsonContainsMode: 'operator' }
+    const num = String((qb() as any).selectFrom('posts').whereJsonContains('tags', 1).toSQL())
+    expect(num).toContain('tags @> to_jsonb($1)')
+    const bool = String((qb() as any).selectFrom('posts').whereJsonContains('tags', true).toSQL())
+    expect(bool).toContain('tags @> to_jsonb($1)')
+
+    config.sql = { ...config.sql, jsonContainsMode: 'function' }
+    const fn = String((qb() as any).selectFrom('posts').whereJsonContains('tags', 1).toSQL())
+    expect(fn).toContain('jsonb_contains(tags, to_jsonb($1))')
+  })
+
+  it('Postgres: binds a document operand directly, without to_jsonb (#1091)', () => {
+    config.dialect = 'postgres' as any
+    config.sql = { ...config.sql, jsonContainsMode: 'operator' }
+    for (const operand of [['bun'], { published: true }, 'bun']) {
+      const s = String((qb() as any).selectFrom('posts').whereJsonContains('tags', operand).toSQL())
+      expect(s).toContain('tags @> $1')
+      expect(s).not.toContain('to_jsonb')
+    }
+  })
 })


### PR DESCRIPTION
Closes #1091.

`whereJsonContains` pushed `JSON.stringify(json)`, but Bun's driver already JSON-encodes a value bound to a jsonb parameter. The document was encoded twice, so Postgres received the jsonb *string* `"[\"bun\"]"` where the array `["bun"]` was meant. A jsonb string never `@>`-contains anything, so the predicate was vacuously false and the query returned **zero rows for every input, with no error**.

## Verified against live Postgres 17

Same script through the query builder, before and after:

| operand | column | before | after |
|---|---|---|---|
| `['bun']` | tags | `[]` ✗ | `[1]` ✓ |
| `['bun','sql']` | tags | `[]` ✗ | `[1]` ✓ |
| `{ published: true }` | meta | `[]` ✗ | `[1]` ✓ |
| `{ published: true, tier: 'pro' }` | meta | `[]` ✗ | `[1]` ✓ |
| `'bun'` | tags | `[]` ✗ | `[1]` ✓ |
| `1` | tags | `[]` ✗ | `[1]` ✓ |
| `true` | tags | `[]` ✗ | `[1]` ✓ |
| non-matches (4 cases) | — | `[]` ✓ | `[]` ✓ |
| `jsonb_contains` mode (3 cases) | — | `[]` ✗ | ✓ |

9 failed before, 0 after.

## On scalars

Binding the value directly fixes objects, arrays and strings. Numbers and booleans are bound as `int4`/`bool` rather than jsonb, and `@>` has no operator for those — a naive fix turns them from *silently wrong* into `operator does not exist: jsonb @> integer`. They are lifted with `to_jsonb()` instead, so `whereJsonContains('tags', 1)` now actually works.

I checked the alternatives on the live server rather than guessing: `$1::jsonb` with the stringified form fails on every shape (the driver encodes the string again), and `to_jsonb($1)` fails on documents (`could not determine polymorphic type`). Only the split above handles all seven shapes.

## Scope

MySQL is untouched — `JSON_CONTAINS` takes its candidate as JSON text, so the stringified form is correct there. SQLite binds scalars through `json_each` and never saw this. #1091 explicitly advised against changing all three together.

## On the tests

The emitted SQL was correct throughout (`tags @> $1`); only the bound parameter was wrong, and `toSQL()` does not expose parameters. **No SQL-text assertion can observe this bug** — which is why the existing #1026 suite asserted the text and stayed green for its entire lifetime. So the real guard here executes against a live Postgres, gated on availability and run in a subprocess (`config.dialect` is global and other files pin it to sqlite).

Worth noting: every *negative* case passed while the bug was live, because the answer was always zero rows. Only containment that genuinely holds can fail, so the new cases assert rows come back.

Both new tests were confirmed to fail without the src change.

## Checks

- CI: lint, typecheck, test, publish-commit — all green
- Locally: `bun test` — 1955 pass, 4 skip, 1 fail; typecheck and pickier clean

The one local failure is `CLI > version prints package version` (expects `0.2.41`, gets `0.1.37`), and it is **unrelated to this change** — a stale `bin/qbx`. That binary is gitignored and compiled at build time; mine dates from June, when the package was at `0.1.37`. CI rebuilds it, which is why the test passes there. Nothing to fix in the repo.

The live-Postgres guard was confirmed to actually execute on the runner rather than skip:

```
(pass) whereJsonContains against live Postgres (#1091) > matches rows for
       documents and scalars, in both containment modes [153.61ms]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
