### PR TITLE
fix(client): write the cache-key delimiter as \0, not a raw NUL byte

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -5904,7 +5904,7 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
         // `where id = $1` with [1] and with [2] would otherwise share one
         // cache entry and the second query would return the first's rows.
         const cacheKey = useCache
-          ? `${String(finalQuery)} ${JSON.stringify(whereParams)}`
+          ? `${String(finalQuery)}\0${JSON.stringify(whereParams)}`
           : ''
         if (useCache) {
           const cached = queryCache.get(cacheKey)

--- a/packages/bun-query-builder/test/source-hygiene.test.ts
+++ b/packages/bun-query-builder/test/source-hygiene.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Mechanical checks on the source itself.
+ *
+ * `src/client.ts` carried a literal NUL byte (0x00) for two months, written as
+ * the raw control character instead of the `\0` escape, as the delimiter in a
+ * cache key:
+ *
+ *     const cacheKey = `${String(finalQuery)}<0x00>${JSON.stringify(params)}`
+ *
+ * The runtime string was correct, so nothing failed and nothing caught it. What
+ * it broke was every tool that reads the file. A single NUL makes grep classify
+ * the whole file as binary, and grep then reports "binary file matches" instead
+ * of matching lines — ripgrep, VS Code search and agent search tools inherit
+ * the same behaviour. The repo's largest and most-edited file, 8000+ lines,
+ * silently returned nothing for ordinary searches:
+ *
+ *     $ grep -c "async paginate" src/client.ts
+ *     0                                   # exit 1, while `grep -a` finds it
+ *
+ * A search that returns nothing is indistinguishable from a symbol that does
+ * not exist, so this actively misleads anyone — human or otherwise — trying to
+ * find code in it.
+ *
+ * The escape and the raw byte produce byte-identical transpiler output, so
+ * there is never a reason to commit the raw byte.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { extname, join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+
+const SRC_DIR = resolve(import.meta.dir, '../src')
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...sourceFiles(full))
+      continue
+    }
+    if (statSync(full).isFile() && (extname(full) === '.ts' || extname(full) === '.tsx'))
+      out.push(full)
+  }
+  return out
+}
+
+describe('source hygiene', () => {
+  it('no source file contains a raw control character that makes it read as binary', () => {
+    const offenders: string[] = []
+
+    for (const file of sourceFiles(SRC_DIR)) {
+      const text = readFileSync(file, 'utf8')
+      for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i)
+        // Everything below 0x20 except tab (9), newline (10) and carriage
+        // return (13). NUL is the one that triggers the binary heuristic, but
+        // no other C0 control belongs in a source file either.
+        if (code < 0x20 && code !== 9 && code !== 10 && code !== 13) {
+          const line = text.slice(0, i).split('\n').length
+          offenders.push(
+            `${relative(SRC_DIR, file)}:${line} contains U+${code.toString(16).padStart(4, '0').toUpperCase()} — `
+            + `write it as an escape (\\0, \\u0001, …) instead of the raw byte`,
+          )
+          break
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  /**
+   * Guards the specific delimiter rather than only the byte: swapping it for a
+   * printable character would reintroduce the collision d7c3a16 fixed, where a
+   * SQL tail and a parameter head could run together into the same cache key.
+   */
+  it('the query cache key still separates SQL from params with a NUL', () => {
+    const client = readFileSync(join(SRC_DIR, 'client.ts'), 'utf8')
+    expect(client).toContain('`${String(finalQuery)}\\0${JSON.stringify(whereParams)}`')
+  })
+})


### PR DESCRIPTION
`src/client.ts` carries a literal NUL byte (0x00) as the delimiter in a query cache key, written as the raw control character instead of the `\0` escape. From d7c3a16 (June).

```ts
const cacheKey = useCache
  ? `${String(finalQuery)}<0x00>${JSON.stringify(whereParams)}`
  : ''
```

## Why it matters

The runtime string is correct, so nothing ever failed. What it breaks is every tool that *reads* the file. A single NUL makes grep classify the whole file as binary and print `binary file matches` instead of matching lines — ripgrep, VS Code search and agent search tools inherit the same heuristic.

The repo's largest and most-edited source file, 8000+ lines, silently returns nothing for ordinary searches:

```
$ grep -c "async paginate" src/client.ts
0                          # exit 1 — while `grep -a` finds it at line 5596
```

A search that returns nothing is indistinguishable from a symbol that does not exist. This is not hypothetical: it produced a wrong conclusion about missing code during this week's triage (I briefly concluded `whereJsonContains` had been deleted from the source), and three queued backlog items require searching this file.

## Why it is safe

The escape and the raw byte are equivalent, verified rather than assumed:

- both sources transpile to **byte-identical** output (180277 bytes)
- the runtime cache-key string is unchanged
- it still contains **exactly one NUL character**, so the delimiter keeps the property d7c3a16 chose it for — a SQL tail and a parameter head cannot run together into the same key

`dist/` never contained the raw byte, and the key is never persisted across a boundary.

## Guard

Adds `test/source-hygiene.test.ts`, which scans `src/` for C0 control characters other than tab, newline and carriage return. Confirmed it fails against the pre-fix file:

```
guard against pre-fix main: WOULD FAIL -> line 5907 U+0000
```

It also pins the delimiter itself, because swapping it for a printable character would silently reintroduce the collision d7c3a16 fixed — `client.caching.test.ts:227` covers that behaviour, but nothing covered the delimiter's identity.

## Checks

- `bun test` — 1957 pass, 4 skip, 1 fail; typecheck and pickier clean

The one failure is `CLI > version prints package version`, which is unrelated and local-only: `bin/qbx` is a gitignored binary compiled at build time, and a stale local copy reports an old version. CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)