### PR TITLE
fix(ci): address the pantry action by its real owner, not a rename redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry
-        uses: home-lang/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@main
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry
-        uses: home-lang/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@main
 
       - name: Install Dependencies
         run: bun install --ignore-scripts


### PR DESCRIPTION
Both workflows reference `home-lang/pantry/packages/action@main`:

- `.github/workflows/ci.yml:124`
- `.github/workflows/release.yml:23`

`home-lang/pantry` **does not exist**. The reference resolves only through GitHub's rename redirect:

```
$ gh api repos/home-lang/pantry --jq .full_name
pantry-pm/pantry
```

Meanwhile the `home-lang` org is live, with 7 repos (`home`, `home-os`, `pantry-registry`, …) and no `pantry` among them. A GitHub rename redirect survives only while the old name stays free at the old location, so this indirection is load-bearing for both CI and the release path.

That matters more on the release side: the pantry step runs at `release.yml:23`, ahead of the publish steps, in a job holding `id-token: write` (`:14`), `NPM_TOKEN` (`:42`) and `GITHUB_TOKEN` (`:57`).

This PR points both workflows at `pantry-pm/pantry` directly — where they already resolve to. Same action, same ref, one less indirection. No behavior change; this PR's own CI exercises it, since `publish-commit` runs the step from the PR head.

## What this deliberately does *not* do

It leaves the `@main` ref alone. That is a separate decision with a real trade-off and it is yours, not mine:

- **`@main` (today)** — upstream fixes arrive immediately; upstream breakage does too, unreviewed. This is what reddened `main` on Aug 14, when an SDK change promoted `sqlite: latest` from silently-skipped to fatally-unresolvable with no commit on our side (fixed in 0671de8 by moving `deps.yaml` to ranges).
- **Pin to a tag** — `v0.11.29` is current; tags are published, so this is available today.
- **Pin to a SHA** — safest, needs a bot or a human to bump.

Two things worth knowing before choosing:

1. `pantry-pm/pantry@main` moved **this morning** (`19255bff7301`, 11:04Z). The ref is genuinely live, not dormant.
2. Pinning `uses:` alone is only half the job — the action also resolves a pantry **binary** version, so pinning one and not the other leaves the part that actually runs `publish:commit` still floating.

Happy to do whichever you prefer as a follow-up. It is also worth checking whether buddy-bot is configured to bump action refs, since that determines whether SHA pinning is sustainable here or turns into manual work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)