### PR TITLE
fix(orm): make createModel models findable, so relations read the declared table

### DIFF
--- a/packages/bun-query-builder/src/model.ts
+++ b/packages/bun-query-builder/src/model.ts
@@ -41,7 +41,7 @@
  */
 
 import { createBrowserModel, isBrowser, type BrowserModelDefinition } from './browser'
-import { createModel, type ModelDefinition as OrmModelDefinition } from './orm'
+import { clearLocalModels, createModel, type ModelDefinition as OrmModelDefinition } from './orm'
 
 // Re-export the browser model types for convenience
 export type { BrowserModelDefinition as ModelDefinition }
@@ -119,9 +119,14 @@ export function hasModel(name: string): boolean {
 
 /**
  * Clear all registered models. Primarily useful for testing.
+ *
+ * Also drops the models `createModel` registered internally, and the memoized
+ * relation resolutions derived from them. Leaving either behind lets a stale
+ * resolution from one test file decide a relation's table in the next.
  */
 export function clearModelRegistry(): void {
   modelRegistry.clear()
+  clearLocalModels()
 }
 
 /**

--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -99,6 +99,47 @@ function assertValidOrderByColumn(name: unknown, context: string): asserts name 
 // Lazy reference to model registry to avoid circular dependency
 // eslint-disable-next-line pickier/no-unused-vars
 let _getModel: ((name: string) => any) | null = null
+
+/**
+ * Models built by `createModel`, keyed by definition name.
+ *
+ * `defineModel` publishes into model.ts's global registry; `createModel` never
+ * did. So every lookup below missed a `createModel` model, and each caller fell
+ * back to its own guess:
+ *
+ *  - relation resolution guessed the table from the MODEL NAME, ignoring a
+ *    declared `table`. Where no table existed at the guessed name that was a
+ *    "no such table" crash; where one did — a plausible accident, since the
+ *    guess is the conventional name — the relation silently read the WRONG
+ *    TABLE and returned wrong rows.
+ *  - eager-load hydration fell back to the PARENT's definition, so the related
+ *    rows were shaped by the wrong model. An attribute marked `hidden: true` on
+ *    the related model was serialized into a `with()` payload even though a
+ *    direct query on that same model redacts it.
+ *
+ * See stacksjs/bun-query-builder#1093.
+ *
+ * Kept module-local rather than written into the public registry so that
+ * `getAllModels()` / `getModelRegistry()` / `hasModel()` keep reporting exactly
+ * what `defineModel` put there, and so two models sharing a name cannot clobber
+ * each other's public entry.
+ */
+const localModels = new Map<string, any>()
+
+function registerLocalModel(name: string, model: any): void {
+  localModels.set(name, model)
+  // Relation resolution is memoized per model+relation pair. A resolution
+  // computed before this model was registered guessed its table, so the memo
+  // has to go or registration order silently decides the answer.
+  relationCache.clear()
+}
+
+/** Drops the `createModel` models. Paired with `clearModelRegistry()`. */
+export function clearLocalModels(): void {
+  localModels.clear()
+  relationCache.clear()
+}
+
 function getModelFromRegistry(name: string): any {
   if (!_getModel) {
     try {
@@ -108,7 +149,9 @@ function getModelFromRegistry(name: string): any {
       _getModel = () => undefined
     }
   }
-  return _getModel!(name)
+  // The public registry wins, so a `defineModel` facade still shadows the plain
+  // model it wraps.
+  return _getModel!(name) ?? localModels.get(name)
 }
 
 // Binding helper type for SQL queries
@@ -3438,7 +3481,12 @@ function createModelInternal<const TDef extends ModelDefinition>(definition: TDe
 
 /** Create a model class from a definition with full type inference. */
 export function createModel<const TDef extends ModelDefinition>(definition: TDef): ModelStatic<TDef> {
-  return createModelInternal(definition)
+  const model = createModelInternal(definition)
+  // Make the model findable by name, so a relation pointing at it reads its
+  // declared `table` instead of guessing one. See #1093 and localModels above.
+  if (definition?.name)
+    registerLocalModel(definition.name, model)
+  return model
 }
 
 export async function createTableFromModel(definition: ModelDefinition): Promise<void> {

--- a/packages/bun-query-builder/test/orm.relation-declared-table.test.ts
+++ b/packages/bun-query-builder/test/orm.relation-declared-table.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Relations must read the related model's declared `table`.
+ * stacksjs/bun-query-builder#1093.
+ *
+ * `defineModel` publishes into the global model registry; `createModel` did
+ * not. Every relation lookup went through that registry, so a `createModel`
+ * model was invisible and each caller fell back to its own guess.
+ *
+ * Two distinct failures came out of that one gap, and the milder one is the
+ * only one the issue reported:
+ *
+ *  1. The table was guessed from the MODEL NAME, ignoring `table`. With no
+ *     table at the guessed name that is a loud "no such table" crash. With one
+ *     there — and the guess is the *conventional* name, so this is a plausible
+ *     accident — the relation silently reads the wrong table and returns wrong
+ *     rows.
+ *  2. Eager-load hydration fell back to the PARENT's definition, so related
+ *     rows were shaped by the wrong model. An attribute marked `hidden: true`
+ *     on the related model was serialized into a `with()` payload even though a
+ *     direct query on that same model redacts it.
+ *
+ * The second is worse in one specific way: it does not require an unusual table
+ * name. It hits models whose naming is entirely conventional, so nothing ever
+ * warns those users that a relation is being resolved by guesswork.
+ */
+
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { clearModelRegistry, configureOrm, createModel, getAllModels, hasModel } from '../src'
+
+let db: Database
+
+beforeEach(() => {
+  clearModelRegistry()
+  db = new Database(':memory:', { create: true })
+  configureOrm({ database: db })
+})
+
+afterEach(() => {
+  clearModelRegistry()
+})
+
+describe('relations resolve the declared table (#1093)', () => {
+  it('reads the declared table, not a table sitting at the guessed name', async () => {
+    db.run('CREATE TABLE wg_owners (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)')
+    db.run('CREATE TABLE wg_custom_widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, owner_id INTEGER, label TEXT)')
+    // The decoy: a real table at the name the resolver would guess from
+    // `Widget`. Without the fix the relation reads THIS one and returns rows
+    // that look perfectly valid.
+    db.run('CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, owner_id INTEGER, label TEXT)')
+    db.run(`INSERT INTO wg_owners (id, name) VALUES (1, 'owner-1')`)
+    db.run(`INSERT INTO wg_custom_widgets (id, owner_id, label) VALUES (1, 1, 'REAL')`)
+    db.run(`INSERT INTO widgets (id, owner_id, label) VALUES (1, 1, 'DECOY')`)
+
+    createModel({
+      name: 'Widget',
+      table: 'wg_custom_widgets',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: {
+        owner_id: { type: 'integer', fillable: true },
+        label: { type: 'string', fillable: true },
+      },
+    } as any)
+
+    const Owner = createModel({
+      name: 'Owner',
+      table: 'wg_owners',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true } },
+      hasMany: ['Widget'],
+    } as any)
+
+    const rows: any = await (Owner as any).query().with('widget').get()
+    const row = typeof rows?.[0]?.toJSON === 'function' ? rows[0].toJSON() : rows?.[0]
+    const related = row?.widget
+
+    expect(Array.isArray(related)).toBe(true)
+    expect(related.map((r: any) => r.label)).toEqual(['REAL'])
+  })
+
+  it('hides the RELATED model\'s hidden attributes in a with() payload', async () => {
+    // Note the table name here IS the conventional guess for `Hidsecret`, so
+    // the table-resolution half of #1093 cannot fire. This isolates hydration:
+    // the only thing that can leak the column is being shaped by the parent's
+    // definition instead of the related model's.
+    db.run('CREATE TABLE hid_owners (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)')
+    db.run('CREATE TABLE hidsecrets (id INTEGER PRIMARY KEY AUTOINCREMENT, hidowner_id INTEGER, label TEXT, token TEXT)')
+    db.run(`INSERT INTO hid_owners (id, name) VALUES (1, 'owner-1')`)
+    db.run(`INSERT INTO hidsecrets (id, hidowner_id, label, token) VALUES (1, 1, 'ok', 'SUPER-SECRET')`)
+
+    const Secret = createModel({
+      name: 'Hidsecret',
+      table: 'hidsecrets',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: {
+        hidowner_id: { type: 'integer', fillable: true },
+        label: { type: 'string', fillable: true },
+        token: { type: 'string', fillable: true, hidden: true },
+      },
+    } as any)
+
+    const Owner = createModel({
+      name: 'Hidowner',
+      table: 'hid_owners',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true } },
+      hasMany: ['Hidsecret'],
+    } as any)
+
+    // Baseline: a direct query on the related model redacts it.
+    const direct: any = await (Secret as any).query().get()
+    const directRow = typeof direct?.[0]?.toJSON === 'function' ? direct[0].toJSON() : direct?.[0]
+    expect(directRow).not.toHaveProperty('token')
+
+    // The eager-loaded payload must agree with it.
+    const rows: any = await (Owner as any).query().with('hidsecret').get()
+    const row = typeof rows?.[0]?.toJSON === 'function' ? rows[0].toJSON() : rows?.[0]
+    const related = row?.hidsecret
+
+    expect(Array.isArray(related)).toBe(true)
+    expect(related[0]).not.toHaveProperty('token')
+    expect(JSON.stringify(related)).not.toContain('SUPER-SECRET')
+  })
+})
+
+describe('createModel registration is internal (#1093)', () => {
+  it('does not add createModel models to the public registry', () => {
+    createModel({
+      name: 'PrivateOnly',
+      table: 'private_only',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true } },
+    } as any)
+
+    // The relation resolver can find it, but the public surface is unchanged —
+    // `getAllModels()`/`hasModel()` keep reporting exactly what `defineModel`
+    // put there, so nothing downstream starts seeing new entries.
+    expect(hasModel('PrivateOnly')).toBe(false)
+    expect(getAllModels().some((m: any) => m?.getName?.() === 'PrivateOnly')).toBe(false)
+  })
+
+  it('clearModelRegistry() drops them, so resolutions do not leak across tests', async () => {
+    db.run('CREATE TABLE lk_owners (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)')
+    db.run('CREATE TABLE lk_declared (id INTEGER PRIMARY KEY AUTOINCREMENT, lkowner_id INTEGER)')
+    db.run(`INSERT INTO lk_owners (id, name) VALUES (1, 'a')`)
+
+    createModel({
+      name: 'Lkchild',
+      table: 'lk_declared',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { lkowner_id: { type: 'integer', fillable: true } },
+    } as any)
+
+    const Owner = createModel({
+      name: 'Lkowner',
+      table: 'lk_owners',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true } },
+      hasMany: ['Lkchild'],
+    } as any)
+
+    // Warms the memoized relation resolution.
+    await (Owner as any).query().with('lkchild').get()
+
+    clearModelRegistry()
+
+    // With the registration and the memo both dropped, the child is unknown
+    // again and the resolver falls back to the guessed table, which does not
+    // exist. A silent success here would mean a stale resolution survived.
+    const Owner2 = createModel({
+      name: 'Lkowner',
+      table: 'lk_owners',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true } },
+      hasMany: ['Lkchild'],
+    } as any)
+
+    await expect((Owner2 as any).query().with('lkchild').get()).rejects.toThrow(/lkchilds/)
+  })
+})


### PR DESCRIPTION
Closes #1093.

## Root cause

`defineModel` registers into the global model registry (`model.ts:193`). **`createModel` never did** — there is not one `registerModel` call in `orm.ts`. Every relation lookup goes through `getModelFromRegistry`, so a `createModel` model was invisible to it and each caller fell back to its own guess.

That is also why CI never caught it: the repo's own passing Postgres integration test builds its models with `defineModel`.

Note the line the issue points at was never the bug — `relatedModel?.getTable?.() || toTableName(name)` has been correct since March. The `||` fallback was firing because the left side was always `undefined`.

## Two failures, not one

**1. Wrong table.** The table was guessed from the model name, ignoring `table`. Where no table exists at the guessed name, that is the loud "no such table" crash the issue reports. Where one *does* — and the guess is the conventional name, so this is a plausible accident — the relation silently reads the wrong table:

```
with("widget") -> [{ id: 1, owner_id: 1, label: "DECOY" }]     # before
with("widget") -> [{ id: 1, owner_id: 1, label: "REAL"  }]     # after
```

**2. A `hidden` column leaks through `with()`.** Eager-load hydration fell back to the *parent's* definition (`orm.ts` ×4, `|| this._definition`), so related rows were shaped by the wrong model:

| | direct query | via `with()` |
|---|---|---|
| before | `token` redacted | **`token: "SUPER-SECRET"` returned** |
| after | redacted | redacted |

This second one is the more serious of the pair, for a reason that is easy to miss: **it does not require an unusual table name.** The model in that test is called `Hidsecret` with table `hidsecrets` — exactly the conventional guess — so the table half cannot fire and the user never sees a "no such table" warning. Anyone whose naming is ordinary gets no signal that their relations are being resolved by guesswork.

## The fix

Register `createModel` models in a module-local map that `getModelFromRegistry` consults *after* the public registry. That is the single chokepoint all the lookups already share — four table resolutions and four hydration fallbacks — so both failures close with one change.

**Deliberately not in the public registry.** `getAllModels()`, `getModelRegistry()` and `hasModel()` keep reporting exactly what `defineModel` put there, so nothing downstream starts seeing new entries and two models sharing a name cannot clobber each other's public entry. There is a test pinning that surface as unchanged — it passes before and after, which is the point.

Also drops the memoized relation resolutions when a model registers and when `clearModelRegistry()` runs. That memo is keyed per model+relation pair and was never invalidated, so a resolution computed before a model existed kept its guessed table — making the answer depend on registration order and leaking stale resolutions across test files.

## Tests

`test/orm.relation-declared-table.test.ts` — 4 tests. Three fail without the src change; the fourth is the public-surface invariant that must pass both ways.

The decoy table matters: a test that only asserts "no crash" would have passed while the relation returned the wrong rows.

## Checks

- `bun test` — 1959 pass, 4 skip, 1 fail; typecheck clean
- pickier reports one `brace-style` warning at `orm.ts:464`, which is **pre-existing** — it sits at `:421` on `main` and moved only because this PR adds 43 lines above it. Untouched.

The one test failure is `CLI > version prints package version`, unrelated and local-only: `bin/qbx` is a gitignored binary compiled at build time and a stale local copy reports an old version. CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)