### PR TITLE
fix(orm): give a declared column type the storage type it asks for

### DIFF
--- a/packages/bun-query-builder/src/column-types.ts
+++ b/packages/bun-query-builder/src/column-types.ts
@@ -1,0 +1,98 @@
+/**
+ * The one place a declared attribute type becomes a storage type.
+ *
+ * Two paths build SQLite columns from a model and they disagreed:
+ *
+ *  - the migration path (`SQLiteDriver.getColumnType`) understands the full
+ *    canonical set — integer, bigint, float, double, decimal, date, json, …
+ *  - `createTableFromModel` in orm.ts understood exactly two, `number` and
+ *    `boolean`, and sent everything else to the `TEXT` default.
+ *
+ * So `type: 'integer'` — the spelling used in this library's own docs and model
+ * examples — produced a TEXT column. Integers then stored and read back as
+ * strings, and under SQLite's text collation `'10' < '9'`, so `ORDER BY` and
+ * range filters on an integer attribute returned the wrong rows with no error
+ * anywhere. See stacksjs/bun-query-builder#1094.
+ *
+ * A shared mapping is the fix rather than a second copy of the switch, because
+ * a second copy is what produced the divergence in the first place.
+ *
+ * This module is a leaf: it imports only types, so either path can use it
+ * without a runtime cycle.
+ */
+
+import type { NormalizedColumnType } from './migrations'
+
+/**
+ * Whether a canonical type stores a number.
+ *
+ * Used to decide when the `*_id` naming heuristic may coerce a column to
+ * INTEGER. Declared text types must never be coerced by a name heuristic —
+ * external ids are frequently strings (tickers, wallet addresses, hashes).
+ */
+export function isNumericPlanType(type: string | undefined): boolean {
+  return type === 'integer' || type === 'bigint' || type === 'float' || type === 'double' || type === 'decimal'
+}
+
+/**
+ * Map a declared attribute type onto the canonical set.
+ *
+ * Accepts the spellings the model layer and the validation-rule reader already
+ * accept, so `type: 'int'`, `'bool'` and `'timestamp'` land where their long
+ * forms do. Returns `undefined` for anything unrecognised, which callers treat
+ * as "no opinion" rather than guessing.
+ */
+export function normalizeAttributeType(raw: unknown): NormalizedColumnType | undefined {
+  if (typeof raw !== 'string')
+    return undefined
+
+  switch (raw.toLowerCase()) {
+    case 'string': return 'string'
+    case 'text': return 'text'
+    case 'integer':
+    case 'int': return 'integer'
+    // `number` is an integer here, deliberately, and for the reason spelled out
+    // at the rule-based normalizer in migrations.ts: it is what nearly every
+    // count, coordinate, port and foreign key is declared as. Reading it as
+    // `decimal` was tried and reverted (cdd35a3, 3ba6dd2) because it reshaped
+    // every such column. Both paths have to agree on this or a model migrates
+    // into one column type and is created as another.
+    case 'number': return 'integer'
+    case 'bigint': return 'bigint'
+    case 'float': return 'float'
+    case 'double': return 'double'
+    case 'decimal': return 'decimal'
+    case 'boolean':
+    case 'bool': return 'boolean'
+    case 'date': return 'date'
+    case 'datetime':
+    case 'timestamp': return 'datetime'
+    case 'timestamptz':
+    case 'timestamp_tz': return 'timestamptz'
+    case 'json': return 'json'
+    case 'enum': return 'enum'
+    default: return undefined
+  }
+}
+
+/**
+ * The SQLite storage class for a canonical type.
+ *
+ * `enum` is TEXT here; the migration driver additionally emits a CHECK
+ * constraint, which needs the column name and a quoter and so stays with the
+ * driver.
+ */
+export function sqliteAffinityFor(type: NormalizedColumnType | undefined): 'TEXT' | 'INTEGER' | 'REAL' {
+  switch (type) {
+    case 'boolean': // SQLite stores booleans as 0/1
+    case 'integer':
+    case 'bigint':
+      return 'INTEGER'
+    case 'float':
+    case 'double':
+    case 'decimal':
+      return 'REAL'
+    default:
+      return 'TEXT'
+  }
+}

--- a/packages/bun-query-builder/src/drivers/sqlite.ts
+++ b/packages/bun-query-builder/src/drivers/sqlite.ts
@@ -1,15 +1,18 @@
 import type { ColumnPlan, IndexPlan, RebuildTableSpec, TablePlan } from '../migrations'
 import type { DateBucketGrain } from './postgres'
+import { isNumericPlanType, sqliteAffinityFor } from '../column-types'
 import { qualifiedIndexName } from './index-name'
 
 /**
  * Whether a plan type belongs to the numeric family. Used by the `_id`
  * safety net (numeric ids must store as INTEGER on SQLite) — non-numeric
  * declared types must never be coerced by the name heuristic.
+ *
+ * Defined in column-types.ts now, so the ORM's create-table path applies the
+ * same rule from the same source. Re-exported because this is where callers
+ * already import it from.
  */
-export function isNumericPlanType(type: string | undefined): boolean {
-  return type === 'integer' || type === 'bigint' || type === 'float' || type === 'double' || type === 'decimal'
-}
+export { isNumericPlanType }
 
 export interface DialectDriver {
   createEnumType: (enumTypeName: string, values: string[]) => string
@@ -53,27 +56,18 @@ export class SQLiteDriver implements DialectDriver {
       return 'INTEGER'
     }
 
-    switch (column.type) {
-      case 'string': return 'TEXT'
-      case 'text': return 'TEXT'
-      case 'boolean': return 'INTEGER' // SQLite uses INTEGER for booleans (0/1)
-      case 'integer': return 'INTEGER'
-      case 'bigint': return 'INTEGER'
-      case 'float': return 'REAL'
-      case 'double': return 'REAL'
-      case 'decimal': return 'REAL'
-      case 'date': return 'TEXT'
-      case 'datetime': return 'TEXT'
-      case 'timestamptz': return 'TEXT'
-      case 'json': return 'TEXT'
-      case 'enum':
-        if (column.enumValues && column.enumValues.length > 0) {
-          const enumValues = column.enumValues.map(v => `'${v.replace(/'/g, '\'\'')}'`).join(', ')
-          return `TEXT CHECK (${this.quoteIdentifier(column.name)} IN (${enumValues}))`
-        }
-        return 'TEXT'
-      default: return 'TEXT'
+    // An enum is TEXT plus a CHECK, which needs the column name and a quoter,
+    // so it stays here. Every other type comes from the shared mapping — this
+    // path and the ORM's create-table path drifting apart is #1094.
+    if (column.type === 'enum') {
+      if (column.enumValues && column.enumValues.length > 0) {
+        const enumValues = column.enumValues.map(v => `'${v.replace(/'/g, '\'\'')}'`).join(', ')
+        return `TEXT CHECK (${this.quoteIdentifier(column.name)} IN (${enumValues}))`
+      }
+      return 'TEXT'
     }
+
+    return sqliteAffinityFor(column.type)
   }
 
   private getPrimaryKeyType(column: ColumnPlan): string {

--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -28,6 +28,7 @@ import { Database, type SQLQueryBindings } from 'bun:sqlite'
 import type { FactoryFaker } from './faker-compat'
 import type { SupportedDialect } from './types'
 import type { RelationCardinality } from './type-inference'
+import { isNumericPlanType, normalizeAttributeType, sqliteAffinityFor } from './column-types'
 import { config, isMysqlLike } from './config'
 import type { DriverConnection } from './db'
 import { getOrCreateBunSql } from './db'
@@ -3465,11 +3466,20 @@ export async function createTableFromModel(definition: ModelDefinition): Promise
     const name = toSnakeCase(attrName)
     if (emitted.has(name)) continue
     emitted.add(name)
-    let colType = 'TEXT'
-    if (attr.type === 'number') colType = 'INTEGER'
-    else if (attr.type === 'boolean') colType = 'INTEGER'
-    // Safety net: foreign key columns must always be INTEGER
-    if (name.endsWith('_id')) colType = 'INTEGER'
+    // Same mapping the migration path uses. This understood only `number` and
+    // `boolean` and sent everything else to TEXT, so `type: 'integer'` — the
+    // spelling in this library's own docs — created a TEXT column and integers
+    // read back as strings. See #1094 and column-types.ts.
+    const declaredType = normalizeAttributeType(attr.type)
+    let colType: string = sqliteAffinityFor(declaredType)
+    // Safety net: a numeric foreign-key column stores as INTEGER, so float
+    // storage cannot corrupt an id (11.0 for 11). Conditional on the declared
+    // type, matching SQLiteDriver.getColumnType: external ids are frequently
+    // strings (tickers, wallet addresses, hashes) and a declared text type has
+    // to win over a name heuristic. An attribute that declares no type at all
+    // keeps the old INTEGER default rather than silently changing shape.
+    if (name.endsWith('_id') && (declaredType === undefined || isNumericPlanType(declaredType)))
+      colType = 'INTEGER'
     let colDef = `${name} ${colType}`
     if (attr.unique) colDef += ' UNIQUE'
     // Inline FK constraints for SQLite CREATE TABLE

--- a/packages/bun-query-builder/test/orm.create-table-column-types.test.ts
+++ b/packages/bun-query-builder/test/orm.create-table-column-types.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `createTableFromModel` must give a declared attribute type the same storage
+ * type the migration path would. stacksjs/bun-query-builder#1094.
+ *
+ * It understood exactly two spellings — `number` and `boolean` — and sent
+ * everything else to the `TEXT` default. So `type: 'integer'`, the spelling
+ * used in this library's own docs and model examples, produced a TEXT column.
+ *
+ * Nothing errors when that happens. Integers store and read back as strings,
+ * and under SQLite's text collation `'10' < '9'`, so `ORDER BY` and range
+ * filters on an integer attribute return the wrong rows quietly. `WHERE n > 9`
+ * returned zero rows where one was correct.
+ *
+ * The cross-path test below is the one that keeps this fixed: the bug was not
+ * a wrong entry in a table, it was two tables that disagreed, so asserting the
+ * ORM's output alone would let them drift apart again.
+ */
+
+import type { ColumnPlan } from '../src/migrations'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { clearModelRegistry, configureOrm, createModel, createTableFromModel } from '../src'
+import { normalizeAttributeType, sqliteAffinityFor } from '../src/column-types'
+import { SQLiteDriver } from '../src/drivers/sqlite'
+
+let db: Database
+
+beforeEach(() => {
+  clearModelRegistry()
+  db = new Database(':memory:', { create: true })
+  configureOrm({ database: db })
+})
+
+afterEach(() => {
+  clearModelRegistry()
+})
+
+/** Column name -> declared SQLite type, from the table the ORM actually built. */
+async function columnTypesFor(attributes: Record<string, any>): Promise<Record<string, string>> {
+  const M = createModel({
+    name: 'Ctrow',
+    table: 'ct_rows',
+    primaryKey: 'id',
+    autoIncrement: true,
+    attributes,
+  } as any)
+
+  await createTableFromModel((M as any).getDefinition())
+
+  const out: Record<string, string> = {}
+  for (const c of db.query('PRAGMA table_info(ct_rows)').all() as any[]) {
+    if (c.name !== 'id')
+      out[c.name] = String(c.type)
+  }
+  return out
+}
+
+describe('createTableFromModel column types (#1094)', () => {
+  it('maps every declared type to its storage type', async () => {
+    const types = await columnTypesFor({
+      a_string: { type: 'string', fillable: true },
+      a_text: { type: 'text', fillable: true },
+      a_integer: { type: 'integer', fillable: true },
+      a_int: { type: 'int', fillable: true },
+      a_number: { type: 'number', fillable: true },
+      a_bigint: { type: 'bigint', fillable: true },
+      a_float: { type: 'float', fillable: true },
+      a_double: { type: 'double', fillable: true },
+      a_decimal: { type: 'decimal', fillable: true },
+      a_boolean: { type: 'boolean', fillable: true },
+      a_bool: { type: 'bool', fillable: true },
+      a_date: { type: 'date', fillable: true },
+      a_datetime: { type: 'datetime', fillable: true },
+      a_json: { type: 'json', fillable: true },
+    })
+
+    expect(types).toEqual({
+      a_string: 'TEXT',
+      a_text: 'TEXT',
+      a_integer: 'INTEGER',
+      a_int: 'INTEGER',
+      // `number` is an integer by long-standing decision — see column-types.ts.
+      a_number: 'INTEGER',
+      a_bigint: 'INTEGER',
+      a_float: 'REAL',
+      a_double: 'REAL',
+      a_decimal: 'REAL',
+      a_boolean: 'INTEGER',
+      a_bool: 'INTEGER',
+      a_date: 'TEXT',
+      a_datetime: 'TEXT',
+      a_json: 'TEXT',
+    })
+  })
+
+  it('agrees with the migration driver for every canonical type', () => {
+    // The anti-drift check. #1094 was two mappings disagreeing, so pinning only
+    // one of them would let the next divergence through.
+    const driver = new SQLiteDriver()
+    const canonical = [
+      'string',
+      'text',
+      'boolean',
+      'integer',
+      'bigint',
+      'float',
+      'double',
+      'decimal',
+      'date',
+      'datetime',
+      'timestamptz',
+      'json',
+    ] as const
+
+    for (const type of canonical) {
+      const plan: ColumnPlan = {
+        name: 'c',
+        type,
+        isPrimaryKey: false,
+        isUnique: false,
+        isNullable: true,
+        hasDefault: false,
+      }
+      // `addColumn` renders `"c" <TYPE> ...`; take the type it chose.
+      const rendered = driver.addColumn('t', plan)
+      const driverType = rendered.match(/"c"\s+(TEXT|INTEGER|REAL)/)?.[1]
+
+      expect(driverType, `driver type for ${type}`).toBeDefined()
+      expect(sqliteAffinityFor(type), `shared mapping disagrees with driver for '${type}'`).toBe(driverType as any)
+    }
+  })
+
+  it('stores an integer attribute as a number, so comparisons are numeric', async () => {
+    const M = createModel({
+      name: 'Ctnum',
+      table: 'ct_nums',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true }, n: { type: 'integer', fillable: true } },
+    } as any)
+    await createTableFromModel((M as any).getDefinition())
+
+    await (M as any).create({ name: 'nine', n: 9 })
+    await (M as any).create({ name: 'ten', n: 10 })
+
+    // Under TEXT affinity this returned [] — '10' sorts before '9'.
+    const gt = db.query('SELECT name FROM ct_nums WHERE n > 9').all() as any[]
+    expect(gt.map(r => r.name)).toEqual(['ten'])
+
+    const [{ t }] = db.query('SELECT typeof(n) t FROM ct_nums LIMIT 1').all() as any[]
+    expect(t).toBe('integer')
+  })
+
+  describe('the *_id naming heuristic', () => {
+    it('keeps a numeric id as INTEGER', async () => {
+      const types = await columnTypesFor({ owner_id: { type: 'integer', fillable: true } })
+      expect(types.owner_id).toBe('INTEGER')
+    })
+
+    it('does not coerce an id that is declared text', async () => {
+      // External ids are frequently strings — tickers, wallet addresses,
+      // hashes. A declared type has to beat a name heuristic, and the
+      // migration path already worked this way.
+      const types = await columnTypesFor({ ticker_id: { type: 'string', fillable: true } })
+      expect(types.ticker_id).toBe('TEXT')
+    })
+
+    it('still defaults an id with no declared type to INTEGER', async () => {
+      const types = await columnTypesFor({ legacy_id: { fillable: true } })
+      expect(types.legacy_id).toBe('INTEGER')
+    })
+  })
+})
+
+describe('normalizeAttributeType (#1094)', () => {
+  it('accepts the short spellings alongside the long ones', () => {
+    expect(normalizeAttributeType('int')).toBe('integer')
+    expect(normalizeAttributeType('bool')).toBe('boolean')
+    expect(normalizeAttributeType('timestamp')).toBe('datetime')
+    expect(normalizeAttributeType('INTEGER')).toBe('integer')
+  })
+
+  it('returns undefined for anything it does not recognise', () => {
+    // Callers treat this as "no opinion" and fall back, rather than guessing.
+    expect(normalizeAttributeType('wat')).toBeUndefined()
+    expect(normalizeAttributeType(undefined)).toBeUndefined()
+    expect(normalizeAttributeType(42)).toBeUndefined()
+  })
+})

--- a/packages/bun-query-builder/test/orm.or-where-precedence.test.ts
+++ b/packages/bun-query-builder/test/orm.or-where-precedence.test.ts
@@ -67,11 +67,9 @@ describe('ORM orWhere grouping (#1083)', () => {
 
     // Was 15: every `alter_*` row came back regardless of batch.
     expect(rows.length).toBe(5)
-    // Number(): `type: 'integer'` currently generates a TEXT column in
-    // createTableFromModel, so this reads back as '1'. Unrelated to #1083 —
-    // coerced rather than asserted on, so this test fails for its own reason
-    // or not at all.
-    expect(rows.every(r => Number(r.get('batch')) === 1)).toBe(true)
+    // `type: 'integer'` produces an INTEGER column since #1094, so this reads
+    // back as a number and can be asserted directly rather than coerced.
+    expect(rows.every(r => r.get('batch') === 1)).toBe(true)
   })
 
   it('brackets a leading OR run against the AND that follows', async () => {


### PR DESCRIPTION
Closes #1094.

`createTableFromModel` understood exactly two attribute types — `number` and `boolean` — and sent everything else to its `TEXT` default. So `type: 'integer'`, the spelling used in this library's own docs and model examples, produced a **TEXT** column.

## Why it is worse than a wrong column type

Nothing errors. Integers store and read back as strings, and under SQLite's text collation `'10' < '9'`:

```
WHERE n > 9   ->  []          # rows n=9 and n=10 exist; "ten" is correct
typeof(n)     ->  'text'
```

Range filters and `ORDER BY` on an integer attribute return the wrong rows, quietly. Measured through the ORM, before → after:

| declared | before | after |
|---|---|---|
| `integer` | TEXT | **INTEGER** |
| `bigint` | TEXT | **INTEGER** |
| `float` | TEXT | **REAL** |
| `decimal` | TEXT | **REAL** |
| `number`, `boolean` | INTEGER | INTEGER |
| `string`, `text`, `date`, `datetime`, `json` | TEXT | TEXT |
| `ticker_id` declared `string` | **INTEGER** | **TEXT** |

## The actual defect is a disagreement, not an entry

The migration path (`SQLiteDriver.getColumnType`) already handled every one of these correctly. So a model **migrated into one column type and was created as another** — two mappings for one question.

Fixing only the ORM's table would leave that shape in place, so both paths now read one mapping in `column-types.ts`, and the driver delegates to it, keeping only the enum `CHECK` — which needs a column name and a quoter — of its own. There is a test asserting the two agree for every canonical type; that is the one that keeps this fixed.

## The `*_id` heuristic

Also made conditional on the declared type being numeric, which is what the migration path already did (`drivers/sqlite.ts`, pinned by `test/sqlite-string-id-columns.test.ts`). A declared **string** id — tickers, wallet addresses, hashes — was being coerced to INTEGER, so `'007'` stored as `7`.

An attribute that declares no type at all keeps the old INTEGER default, so nothing relying on the bare heuristic changes shape.

## A test was already papering over this

`test/orm.or-where-precedence.test.ts:70` carried a `Number()` coercion with a comment naming this exact bug:

> `Number()`: `type: 'integer'` currently generates a TEXT column in createTableFromModel, so this reads back as '1'.

It asserts directly now.

## Checks

- typecheck clean; pickier reports one pre-existing `brace-style` warning at `orm.ts:422` (`:421` on main — moved by one import line)
- `bun test` — 1962 pass, 4 skip, 2 fail

**Both failures reproduce on clean `main`** with none of these changes present; I checked before attributing them:

- `CLI > version prints package version` — stale local `bin/qbx`, a gitignored binary rebuilt by CI
- `migration locking (#1067) > serialises concurrent runs` — passes in isolation, fails only in the full suite, timing-sensitive. Pre-existing and worth its own look; CI has been green on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)