### PR TITLE
fix(client): an empty insert is a no-op, not a stand-in query

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -6657,6 +6657,50 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
       let built: any
       let sqlText = ''
       const params: any[] = []
+      // Set when `values()` is handed an empty batch. There is no statement to
+      // run in that case, so every terminal below answers from here instead of
+      // executing a stand-in query. See #1097.
+      let noRows = false
+
+      /**
+       * What the dialect returns for an insert that affected no rows.
+       *
+       * Postgres gives `[]` for an insert without RETURNING, so an empty batch
+       * is indistinguishable from a real one that inserted nothing — which is
+       * the point. The bun:sqlite wrapper reports `{ changes, lastInsertRowid }`
+       * instead, so it gets zeros.
+       */
+      const emptyInsertResult = (): any => (isPostgres ? [] : { changes: 0, lastInsertRowid: 0 })
+
+      /**
+       * The `.returning(...)` / `.returningAll()` surface for an empty batch.
+       *
+       * Mirrors the real one's method set so `.returning('id').first()` still
+       * resolves rather than throwing "first is not a function". No rows were
+       * inserted, so the row accessors answer empty and the *OrFail pair throws
+       * the same message they throw when a real RETURNING comes back empty.
+       */
+      const emptyReturningBuilder = (): any => {
+        const noRow = async (): Promise<any> => undefined
+        const noRowOrFail = async (): Promise<any> => {
+          throw new Error('Insert with RETURNING returned no rows')
+        }
+        return {
+          where: () => emptyReturningBuilder(),
+          andWhere: () => emptyReturningBuilder(),
+          orWhere: () => emptyReturningBuilder(),
+          orderBy: () => emptyReturningBuilder(),
+          limit: () => emptyReturningBuilder(),
+          offset: () => emptyReturningBuilder(),
+          toSQL: () => makeExecutableQuery(null as any, '') as any,
+          execute: async () => [],
+          get: async () => [],
+          first: noRow,
+          executeTakeFirst: noRow,
+          firstOrFail: noRowOrFail,
+          executeTakeFirstOrThrow: noRowOrFail,
+        }
+      }
       const isPostgres = config.dialect === 'postgres'
 
       // Quote identifier based on dialect. SQLite supports double-quoted
@@ -6683,9 +6727,24 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           const rows = Array.isArray(data) ? data : [data]
           const rowCount = rows.length
           if (rowCount === 0) {
-            built = _sql.unsafe('SELECT 1')
+            // Inserting no rows is a no-op, not a query. This used to run
+            // `SELECT 1` as a stand-in, which meant `.execute()` resolved to a
+            // fabricated row — `[{ '?column?': 1 }]` on Postgres, `[{ '1': 1 }]`
+            // on SQLite — so a caller checking `result.length` saw 1 where the
+            // truth was 0, a query hook fired for an insert that never
+            // happened, and `.returning(...)` appended RETURNING to `SELECT 1`
+            // and died on a syntax error. See #1097.
+            //
+            // `values(rows)` where `rows` came back empty is ordinary calling
+            // code — the seeder scaffold this package generates is written that
+            // way — so this answers empty rather than throwing.
+            noRows = true
+            built = null
+            sqlText = ''
+            params.length = 0
             return this
           }
+          noRows = false
 
           const firstRow = rows[0]
           const keys = Object.keys(firstRow)
@@ -6760,6 +6819,11 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return this
         },
         returning(...cols: (keyof any & string)[]) {
+          // Nothing was inserted, so there is nothing to return. Without this
+          // the RETURNING clause was appended to the `SELECT 1` stand-in and
+          // the statement failed to parse.
+          if (noRows)
+            return emptyReturningBuilder()
           // Append RETURNING clause to the existing SQL
           const returningSql = `${sqlText} RETURNING ${cols.join(', ')}`
           const q = _sql.unsafe(returningSql, params)
@@ -6798,10 +6862,14 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           }
         },
         toSQL() {
+          if (noRows)
+            return makeExecutableQuery(null as any, '') as any
           if (!built) built = _sql.unsafe(sqlText, params)
           return makeExecutableQuery(built, sqlText) as any
         },
         execute() {
+          if (noRows)
+            return Promise.resolve(emptyInsertResult())
           // Ultra-fast path: use _prepareStatement to skip unsafe() and runWithHooks overhead
           const hooks = activeHooks()
           const hasHooks = hooks && (hooks.onQueryStart || hooks.onQueryEnd || hooks.onQueryError || hooks.startSpan || hooks.beforeCreate || hooks.afterCreate || hasSlowQueryHook(hooks))
@@ -6816,11 +6884,15 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return runWithHooks(built, 'insert')
         },
         async executeTakeFirst() {
+          if (noRows)
+            return emptyInsertResult()
           if (!built) built = _sql.unsafe(sqlText, params)
           const result = await runWithHooks(built, 'insert')
           return result
         },
         async executeTakeFirstOrThrow() {
+          if (noRows)
+            throw new Error('Insert failed')
           if (!built) built = _sql.unsafe(sqlText, params)
           const result = await runWithHooks(built, 'insert')
           if (!result)
@@ -6828,6 +6900,9 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return result
         },
         returningAll() {
+          // As in returning(): no rows inserted, nothing to return.
+          if (noRows)
+            return emptyReturningBuilder()
           const returningSql = `${sqlText} RETURNING *`
           const q = _sql.unsafe(returningSql, params)
           const runFirst = async () => {

--- a/packages/bun-query-builder/test/client.insert-empty-values.test.ts
+++ b/packages/bun-query-builder/test/client.insert-empty-values.test.ts
@@ -1,0 +1,168 @@
+/**
+ * `insertInto(t).values([])` must be a no-op, not a stand-in query.
+ * stacksjs/bun-query-builder#1097.
+ *
+ * It ran `SELECT 1` when handed an empty batch, which is invisible in the
+ * database — no row is ever written — but wrong at every other layer:
+ *
+ *  - `.execute()` resolved to a FABRICATED row: `[{ '?column?': 1 }]` on
+ *    Postgres, `[{ '1': 1 }]` on SQLite. A caller checking `result.length` saw
+ *    1 where the truth was 0.
+ *  - a query hook fired, labelled `insert`, for an insert that never happened.
+ *  - `.returning(...)` appended RETURNING to `SELECT 1` and died with
+ *    `near "RETURNING": syntax error`.
+ *
+ * It answers empty rather than throwing because `values(rows)` where `rows`
+ * came back empty is ordinary calling code — the seeder scaffold this package
+ * generates (`actions/seed.ts`) is written exactly that way, so a throw would
+ * turn an empty dataset into a failed seed.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  t: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' } } },
+} as any
+
+// A file rather than `:memory:`: the client opens its own connection from the
+// configured path, and a `:memory:` database is per-connection, so the table
+// created here would be invisible to it.
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown>, hooks: unknown }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+/** Row count read through a fresh connection, not the builder's. */
+function rowCount(): number {
+  const probe = new Database(dbPath)
+  const [{ c }] = probe.query('SELECT count(*) c FROM t').all() as any[]
+  probe.close()
+  return c
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database }, hooks: (config as any).hooks }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1097-'))
+  dbPath = join(dir, 'empty-values.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)')
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  ;(config as any).hooks = snapshot.hooks
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('insertInto().values([]) is a no-op (#1097)', () => {
+  it('reports nothing inserted instead of a fabricated row', async () => {
+    const result: any = await qb().insertInto('t').values([]).execute()
+
+    // The bun:sqlite wrapper reports { changes, lastInsertRowid }; zeros are
+    // the honest answer. What must never come back is a row.
+    expect(Array.isArray(result)).toBe(false)
+    expect(result.changes).toBe(0)
+
+    expect(rowCount()).toBe(0)
+  })
+
+  it('does not run a query, so no hook fires', async () => {
+    const seen: string[] = []
+    setConfig({ hooks: { onQueryStart: () => { seen.push('start') } } } as any)
+
+    await qb().insertInto('t').values([]).execute()
+
+    expect(seen).toEqual([])
+  })
+
+  it('emits no SQL', () => {
+    const sql = qb().insertInto('t').values([]).toSQL()
+    expect(String(sql?.sql ?? '')).toBe('')
+  })
+
+  describe('returning()', () => {
+    it('resolves empty instead of failing to parse', async () => {
+      // Previously: `near "RETURNING": syntax error`, because RETURNING was
+      // appended to the `SELECT 1` stand-in.
+      const rows = await qb().insertInto('t').values([]).returning('id').execute()
+      expect(rows).toEqual([])
+    })
+
+    it('keeps the row accessors present and empty', async () => {
+      const b = qb().insertInto('t').values([]).returning('id')
+
+      // `.returning(...).first()` exists on the real builder, so it has to
+      // exist here too rather than throwing "first is not a function".
+      expect(await b.get()).toEqual([])
+      expect(await b.first()).toBeUndefined()
+      expect(await b.executeTakeFirst()).toBeUndefined()
+      await expect(b.firstOrFail()).rejects.toThrow(/returned no rows/)
+    })
+
+    it('behaves the same through returningAll()', async () => {
+      const rows = await qb().insertInto('t').values([]).returningAll().execute()
+      expect(rows).toEqual([])
+    })
+  })
+
+  it('leaves a non-empty insert alone', async () => {
+    const seen: string[] = []
+    setConfig({ hooks: { onQueryStart: () => { seen.push('start') } } } as any)
+
+    const result: any = await qb().insertInto('t').values([{ name: 'a' }]).execute()
+    expect(result.changes).toBe(1)
+    expect(seen.length).toBe(1)
+
+    const rows = await qb().insertInto('t').values([{ name: 'b' }]).returning('id').execute()
+    expect(rows).toHaveLength(1)
+
+    expect(rowCount()).toBe(2)
+  })
+
+  it('reuses the builder correctly when a later call has rows', async () => {
+    // The empty batch sets a flag; a subsequent values() with rows has to clear
+    // it, or the second insert would silently do nothing.
+    const b = qb().insertInto('t')
+    b.values([])
+    b.values([{ name: 'later' }])
+    const result: any = await b.execute()
+
+    expect(result.changes).toBe(1)
+    expect(rowCount()).toBe(1)
+  })
+})
+
+describe('insertInto().values([]) on Postgres (#1097)', () => {
+  it('resolves to [] — what a real insert affecting no rows returns', async () => {
+    // No connection is opened: the empty batch short-circuits before touching
+    // the driver, which is what makes this assertable without a live server.
+    setConfig({ dialect: 'postgres', database: { url: 'postgres://unused:5432/none' } } as any)
+    resetConnection()
+
+    const result = await qb().insertInto('t').values([]).execute()
+
+    // Postgres returns [] for an insert without RETURNING, so an empty batch is
+    // deliberately indistinguishable from a real one that inserted nothing.
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #1097.

`insertInto(t).values([])` ran `SELECT 1`. The database is never left wrong — no row is written either way — but every layer above it was:

| call | before | after |
|---|---|---|
| `.execute()` (SQLite) | `[{ '1': 1 }]` — a fabricated row | `{ changes: 0, lastInsertRowid: 0 }` |
| `.execute()` (Postgres) | `[{ '?column?': 1 }]` | `[]` |
| query hooks | fires `insert` for a query that never happened | nothing fires |
| `.returning('id')` | throws `near "RETURNING": syntax error` | `[]` |

The first row is the one that bites: a caller checking `result.length` saw **1** where the truth was **0**.

The `.returning()` failure came from appending RETURNING to the `SELECT 1` stand-in.

## The empty result is not invented

`.execute()` returns what each dialect returns for an insert that affected no rows, which I measured rather than picked:

```
PG   values([{name:'a'}]).execute()  ->  []                              # real insert, no RETURNING
PG   values([]).execute()            ->  []                              # now identical
SQLite values([{name:'a'}]).execute() -> { changes: 1, lastInsertRowid: 1 }
SQLite values([]).execute()          ->  { changes: 0, lastInsertRowid: 0 }
```

So on Postgres an empty batch is deliberately indistinguishable from a real one that inserted nothing — which is the correct reading of "insert these zero rows".

`.returning()` / `.returningAll()` hand back a builder carrying the same method set as the real one, so `.returning('id').first()` still resolves instead of throwing "first is not a function" — the failure mode that was already fixed once for the non-empty path.

## Empty, not a throw

`values(rows)` where `rows` came back empty is ordinary calling code. The seeder scaffold this package *generates* (`src/actions/seed.ts:213`) is written exactly that way:

```ts
await qb.insertInto('table_name').values(records).execute()
```

A throw would turn an empty dataset into a failed seed. The database is never at risk here — the row count is 0 before and after in every probe — so there is no correctness argument for making callers guard.

## Tests

`test/client.insert-empty-values.test.ts` — 9 tests, 6 of which fail without the src change. The other three are invariant guards that must pass both ways: non-empty inserts unaffected, no SQL emitted, and builder reuse (`values([])` then `values([...])`) still inserting, so the new flag cannot strand a later call.

## Checks

- typecheck and pickier clean
- `bun test` — 1963 pass, 4 skip, 2 fail

Both failures are pre-existing and reproduce on clean `main`: the stale-`bin/qbx` `CLI > version` test, and `migration locking (#1067)`, which passes in isolation and fails only in the full suite under load. Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)