### PR TITLE
fix(browser): stop serialising an exclusion as an inclusion

### DIFF
--- a/packages/bun-query-builder/src/browser.ts
+++ b/packages/bun-query-builder/src/browser.ts
@@ -525,11 +525,15 @@ export class BrowserQueryBuilder<T = any> {
   private buildQueryParams(): URLSearchParams {
     const params = new URLSearchParams()
 
+    // As in BrowserModelQueryBuilder: `boolean` is not read, so an `orWhere`
+    // serialises as an AND. Left alone deliberately — see #1096.
     // Add where clauses as query params
     for (const where of this.state.wheres) {
       if (where.operator === '=') {
         params.append(where.column, String(where.value))
       }
+      // `in` only — `not in` falls through to the filter branch, so an
+      // exclusion stays distinguishable from an inclusion (#1096).
       else if (where.operator === 'in' && Array.isArray(where.value)) {
         params.append(`${where.column}[]`, where.value.join(','))
       }
@@ -970,11 +974,22 @@ else {
   private buildQueryParams(): URLSearchParams {
     const params = new URLSearchParams()
 
+    // `where.boolean` is not read here, so an `orWhere` serialises exactly like
+    // a `where` and the server reads it as AND. Representing OR needs a wire
+    // format that this file has no precedent for, so it is left alone rather
+    // than invented — see #1096. BrowserQueryBuilder.buildQueryParams has the
+    // same gap.
     for (const where of this._wheres) {
       if (where.operator === '=') {
         params.append(where.column, String(where.value))
       }
-else if ((where.operator === 'in' || where.operator === 'not in') && Array.isArray(where.value)) {
+      // `in` only. Including `not in` here made an exclusion serialise
+      // byte-identically to an inclusion — `whereNotIn('role', ['banned'])`
+      // and `whereIn('role', ['banned'])` both sent `role[]=banned`, so the
+      // server returned precisely the rows the caller meant to exclude.
+      // Falling through to the filter branch below is what the sibling
+      // BrowserQueryBuilder already does. See #1096.
+      else if (where.operator === 'in' && Array.isArray(where.value)) {
         params.append(`${where.column}[]`, where.value.join(','))
       }
 else if (where.operator === 'is' && where.value === null) {

--- a/packages/bun-query-builder/test/browser.not-in-serialisation.test.ts
+++ b/packages/bun-query-builder/test/browser.not-in-serialisation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `whereNotIn` must not serialise identically to `whereIn`.
+ * stacksjs/bun-query-builder#1096.
+ *
+ * `BrowserModelQueryBuilder.buildQueryParams` matched `in` and `not in` in the
+ * same branch, so both emitted `column[]=a,b`. An exclusion went out on the
+ * wire byte-identical to an inclusion, and the server answered with exactly the
+ * rows the caller meant to remove.
+ *
+ * The idiom is overwhelmingly "exclude banned / deleted / private", so the
+ * failure mode is showing the records you meant to hide — with no error, and
+ * with a request that looks correct in a network panel.
+ *
+ * The sibling `BrowserQueryBuilder` already matched `in` alone and let `not in`
+ * fall through to the `filter[column][operator]` branch, so this asserts the
+ * two builders agree as well as that the exclusion survives.
+ *
+ * These read the outgoing URL rather than a mock server's interpretation of it:
+ * the defect was entirely in what went on the wire.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { BrowserQueryBuilder, configureBrowser, createBrowserModel } from '../src/browser'
+
+const realFetch = globalThis.fetch
+let captured: string[] = []
+
+beforeEach(() => {
+  captured = []
+  globalThis.fetch = (async (input: any) => {
+    captured.push(typeof input === 'string' ? input : String(input?.url ?? input))
+    return new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as any
+  configureBrowser({ baseUrl: 'http://x.test/api' } as any)
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+/** The query string of the single request the call produced. */
+function sentQuery(): URLSearchParams {
+  expect(captured).toHaveLength(1)
+  return new URL(captured[0]).searchParams
+}
+
+const Widget = createBrowserModel({
+  name: 'Nwidget',
+  table: 'nwidgets',
+  primaryKey: 'id',
+  attributes: {
+    role: { type: 'string', fillable: true },
+    name: { type: 'string', fillable: true },
+  },
+} as any)
+
+describe('BrowserModelQueryBuilder not-in serialisation (#1096)', () => {
+  it('sends an exclusion differently from an inclusion', async () => {
+    await (Widget as any).query().whereIn('role', ['banned']).get()
+    const inclusion = sentQuery()
+
+    captured = []
+    await (Widget as any).query().whereNotIn('role', ['banned']).get()
+    const exclusion = sentQuery()
+
+    // The whole bug: these two were identical.
+    expect(exclusion.toString()).not.toBe(inclusion.toString())
+  })
+
+  it('keeps the inclusion form unchanged', async () => {
+    await (Widget as any).query().whereIn('role', ['a', 'b']).get()
+    expect(sentQuery().get('role[]')).toBe('a,b')
+  })
+
+  it('sends an exclusion under a filter key naming the operator', async () => {
+    await (Widget as any).query().whereNotIn('role', ['banned']).get()
+    const q = sentQuery()
+
+    // Must not go out as the inclusion form.
+    expect(q.get('role[]')).toBeNull()
+    expect(q.get('filter[role][not in]')).toBe('banned')
+  })
+
+  it('agrees with the sibling BrowserQueryBuilder', async () => {
+    await (Widget as any).query().whereNotIn('role', ['banned']).get()
+    const model = sentQuery()
+
+    captured = []
+    await new BrowserQueryBuilder('nwidgets').whereNotIn('role', ['banned']).get()
+    const plain = sentQuery()
+
+    // The two builders serialise the same query the same way. They did not.
+    expect(model.get('filter[role][not in]')).toBe(plain.get('filter[role][not in]'))
+    expect(model.get('role[]')).toBe(plain.get('role[]'))
+  })
+})


### PR DESCRIPTION
Half of #1096. **The issue should stay open** — see the last section.

`BrowserModelQueryBuilder.buildQueryParams` matched `in` and `not in` in the same branch:

```ts
else if ((where.operator === 'in' || where.operator === 'not in') && Array.isArray(where.value)) {
  params.append(`${where.column}[]`, where.value.join(','))
}
```

So an exclusion and an inclusion went out **byte-identically**:

| call | before | after |
|---|---|---|
| `whereIn('role', ['banned'])` | `role[]=banned` | `role[]=banned` |
| `whereNotIn('role', ['banned'])` | `role[]=banned` | `filter[role][not in]=banned` |

The server therefore answered a `whereNotIn` with precisely the rows the caller meant to remove. The idiom is overwhelmingly "exclude banned / deleted / private", so the failure mode is **showing the records you meant to hide** — with no error, and a request that looks correct in a network panel.

## No new wire format

Matching `in` alone lets `not in` fall through to the `filter[column][operator]` branch, which is **what the sibling `BrowserQueryBuilder` has always emitted** for `not in`. So this makes the two builders agree rather than inventing a format — there is a test asserting they now serialise the same query the same way.

## Tests

`test/browser.not-in-serialisation.test.ts` reads the **outgoing URL** by capturing `fetch`, rather than asserting on a mock server's interpretation of it — the defect was entirely in what went on the wire, so anything downstream of that is the wrong place to look.

3 of 4 fail without the src change; the fourth pins the inclusion form as unchanged.

## What this does not fix

`where.boolean` is read by **neither** serialiser, so `orWhere` still serialises as an AND — the other half of #1096, and also a silent wrong answer.

I left it deliberately. Representing OR needs a wire format this file has no precedent for, and choosing one unilaterally risks emitting params no backend parses, which is not obviously better than today. That is a call about the API contract with whatever server consumes these params.

Both call sites now carry a comment recording the gap so it is not rediscovered as a surprise. Options, when you want it: an `or` group key (`filter[or][col][op]`), or making `orWhere` throw on this builder so a wrong answer becomes a loud one.

Worth noting separately: the file spells two-word operators inconsistently — `is not` becomes `filter[col][is_not]`, while `not in` becomes `filter[col][not in]`. I matched the sibling's existing output rather than normalising, since that key is the wire contract.

## Checks

- typecheck and pickier clean
- `bun test` — 2 failures, both pre-existing and reproducing on clean `main` (stale `bin/qbx` `CLI > version`, and the `migration locking (#1067)` flake that passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)