### PR TITLE
fix(client): refuse a write whose predicate the builder cannot read

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -6960,9 +6960,32 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
             return this
           }
 
+          // A lone SQL fragment: `where(raw('id = 1'))`, `where(sql\`...\`)`.
+          // The declared signature accepts SqlFragment, so this is an
+          // advertised call — and it matched no branch, fell through to the
+          // bare `return this` below, and left the UPDATE with no WHERE at all.
+          // Every row was rewritten, silently, and the full count was reported
+          // as success. Handled before the object branch because a bound
+          // expression is an object and would otherwise be read as the column
+          // map `{ sql: ... }`. See #1101.
+          if (isRawExpression(expr)) {
+            sqlText = `${sqlText} ${getWhereKeyword()} ${expr.raw}`
+            built = _sql.unsafe(sqlText, params)
+            return this
+          }
+          if (isBoundSqlExpression(expr)) {
+            const rendered = renderBoundSqlExpression(expr, params.length + 1)
+            sqlText = `${sqlText} ${getWhereKeyword()} ${rendered.text}`
+            params.push(...rendered.parameters)
+            built = _sql.unsafe(sqlText, params)
+            return this
+          }
+
           // Handle object format: where({ column: value })
-          if (expr && typeof expr === 'object' && !('raw' in expr)) {
+          if (expr && typeof expr === 'object') {
             const keys = Object.keys(expr)
+            if (keys.length === 0)
+              throw new TypeError('[query-builder] updateTable.where({}): an empty object is not a filter. Pass a condition, or drop the where() call if updating every row is intended.')
             const len = keys.length
             const baseIdx = params.length
             const conditions: string[] = Array.from({ length: len })
@@ -6972,8 +6995,19 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
             }
             sqlText = `${sqlText} ${getWhereKeyword()} ${conditions.join(' AND ')}`
             built = _sql.unsafe(sqlText, params)
+            return this
           }
-          return this
+
+          // Nothing above could turn this into a predicate. Refuse it.
+          //
+          // Returning `this` unchanged meant `where(undefined)` and
+          // `where(null)` produced an UPDATE with no WHERE, so a filter the
+          // caller believed they had applied rewrote the whole table without
+          // an error. A write builder is the wrong place to read "I could not
+          // understand your filter" as "match every row". The select builder
+          // dropped this same fall-through in #1083; the write builders kept
+          // it. See #1101.
+          throw new TypeError(`[query-builder] updateTable.where(): expected a condition, got ${expr === null ? 'null' : typeof expr}. Refusing to run an UPDATE with no WHERE — drop the where() call if updating every row is intended.`)
         },
         whereNull(column: string) {
           const keyword = SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
@@ -7153,9 +7187,31 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
             built = null
             return this
           }
+          // A lone SQL fragment, handled before the object branch for the same
+          // reason as in updateTable.where: a bound expression is an object and
+          // would otherwise be read as the column map `{ sql: ... }`. Rendering
+          // it here also fixes it — routed through applyWhere() below, a
+          // fragment was interpolated as a bound value, so Postgres rejected
+          // `where(raw('id = 1'))` with "invalid input syntax for type
+          // boolean". The signature accepts SqlFragment, so it has to work.
+          if (isRawExpression(expr)) {
+            sqlText += ` ${getWhereKeyword()} ${expr.raw}`
+            built = null
+            return this
+          }
+          if (isBoundSqlExpression(expr)) {
+            const rendered = renderBoundSqlExpression(expr, delParams.length + 1)
+            sqlText += ` ${getWhereKeyword()} ${rendered.text}`
+            delParams.push(...rendered.parameters)
+            built = null
+            return this
+          }
+
           // Object format: where({ id: 1 })
-          if (expr && typeof expr === 'object' && !('raw' in expr)) {
+          if (expr && typeof expr === 'object') {
             const keys = Object.keys(expr)
+            if (keys.length === 0)
+              throw new TypeError('[query-builder] deleteFrom.where({}): an empty object is not a filter. Pass a condition, or drop the where() call if deleting every row is intended.')
             const conditions: string[] = []
             for (const key of keys) {
               const paramIndex = delParams.length + 1
@@ -7166,8 +7222,16 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
             built = null
             return this
           }
-          built = applyWhere(({} as any), ensureDelBuilt(), expr)
-          return this
+
+          // Nothing above could turn this into a predicate.
+          //
+          // This previously fell through to applyWhere({}, ..., expr), whose
+          // first line is `if (!expr) return q` — so `where(undefined)` and
+          // `where(null)` appended nothing and the DELETE removed every row,
+          // returning the count as though the filter had been honoured. See
+          // #1101, and #1083 where the select builder lost the same
+          // fall-through.
+          throw new TypeError(`[query-builder] deleteFrom.where(): expected a condition, got ${expr === null ? 'null' : typeof expr}. Refusing to run a DELETE with no WHERE — drop the where() call if deleting every row is intended.`)
         },
         whereNull(column: string) {
           sqlText += ` ${getWhereKeyword()} ${quoteId(String(column))} IS NULL`

--- a/packages/bun-query-builder/test/client.write-predicate-required.test.ts
+++ b/packages/bun-query-builder/test/client.write-predicate-required.test.ts
@@ -1,0 +1,182 @@
+/**
+ * A write must never run without the predicate the caller supplied.
+ * stacksjs/bun-query-builder#1101 (and the empty-object half of #1095).
+ *
+ * `updateTable(...).where(x)` and `deleteFrom(...).where(x)` accepted argument
+ * shapes they could not turn into a predicate and then returned `this`
+ * unchanged. The statement kept no WHERE at all, so it ran against every row
+ * and reported the full affected count as success:
+ *
+ *     deleteFrom(t).where(undefined)                -> deleted all 4 rows
+ *     updateTable(t).set(v).where(raw('id = 1'))    -> rewrote all 4 rows
+ *
+ * The `raw()` case is the serious one, because it is not a mistake the types
+ * catch: the declared signature is `WhereExpression | K | SqlFragment` and
+ * `raw` is a public export, so that call reads correctly and passes review.
+ *
+ * Two different remedies, deliberately:
+ *  - a fragment is SUPPORTED, because the signature promises it,
+ *  - anything the builder genuinely cannot read is REFUSED, because a write
+ *    builder is the wrong place to treat "I could not understand your filter"
+ *    as "match every row".
+ *
+ * `where({})` throws with a message naming the problem instead of the SQL
+ * syntax error it used to produce — that is #1095, whose reported symptom was
+ * always the safe one.
+ *
+ * Every assertion below checks SURVIVING ROWS, not just that a call threw. The
+ * bug was damage, so the table is the thing worth asserting on.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder, raw } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  t: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' } } },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown> }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+function rows(): Array<{ id: number, name: string }> {
+  const probe = new Database(dbPath)
+  const out = probe.query('SELECT id, name FROM t ORDER BY id').all() as any[]
+  probe.close()
+  return out
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database } }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1101-'))
+  dbPath = join(dir, 'writes.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+  seed.run(`INSERT INTO t (id, name) VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d')`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('DELETE refuses to run without a predicate (#1101)', () => {
+  for (const [label, value] of [['undefined', undefined], ['null', null]] as const) {
+    it(`where(${label}) throws and leaves every row in place`, () => {
+      // Synchronously, at the point of the mistake — no statement is ever built.
+      expect(() => qb().deleteFrom('t').where(value as any))
+        .toThrow(/expected a condition/)
+
+      // The assertion that matters: all four rows are still here.
+      expect(rows()).toHaveLength(4)
+    })
+  }
+
+  it('where({}) names the problem instead of emitting a broken statement', () => {
+    expect(() => qb().deleteFrom('t').where({}))
+      .toThrow(/an empty object is not a filter/)
+    expect(rows()).toHaveLength(4)
+  })
+})
+
+describe('UPDATE refuses to run without a predicate (#1101)', () => {
+  for (const [label, value] of [['undefined', undefined], ['null', null]] as const) {
+    it(`where(${label}) throws and rewrites nothing`, () => {
+      expect(() => qb().updateTable('t').set({ name: 'X' }).where(value as any))
+        .toThrow(/expected a condition/)
+
+      expect(rows().filter(r => r.name === 'X')).toHaveLength(0)
+    })
+  }
+
+  it('where({}) names the problem instead of emitting a broken statement', () => {
+    expect(() => qb().updateTable('t').set({ name: 'X' }).where({}))
+      .toThrow(/an empty object is not a filter/)
+    expect(rows().filter(r => r.name === 'X')).toHaveLength(0)
+  })
+})
+
+describe('a SQL fragment is honoured, not dropped (#1101)', () => {
+  // The signature accepts SqlFragment, so these have to work — refusing them
+  // would swap a silent catastrophe for a broken advertised API.
+
+  it('DELETE where(raw(...)) removes only the matching row', async () => {
+    await qb().deleteFrom('t').where(raw('id = 1')).execute()
+
+    // Previously this threw on Postgres (the fragment was bound as a value)
+    // and, on the update side, wiped the table.
+    expect(rows().map(r => r.id)).toEqual([2, 3, 4])
+  })
+
+  it('UPDATE where(raw(...)) rewrites only the matching row', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where(raw('id = 1')).execute()
+
+    const after = rows()
+    expect(after.filter(r => r.name === 'X').map(r => r.id)).toEqual([1])
+    expect(after).toHaveLength(4)
+  })
+
+  it('DELETE honours a parameterised fragment', async () => {
+    await qb().deleteFrom('t').where({ sql: 'id = ?', parameters: [2] } as any).execute()
+    expect(rows().map(r => r.id)).toEqual([1, 3, 4])
+  })
+
+  it('UPDATE honours a parameterised fragment', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where({ sql: 'id = ?', parameters: [2] } as any).execute()
+    expect(rows().filter(r => r.name === 'X').map(r => r.id)).toEqual([2])
+  })
+
+  it('does not mistake a bound fragment for a column map', async () => {
+    // `{ sql, parameters }` is an object, so an ordering slip would render it
+    // as `"sql" = ? AND "parameters" = ?` and match nothing — silently.
+    await qb().deleteFrom('t').where({ sql: 'id = ?', parameters: [3] } as any).execute()
+    expect(rows().map(r => r.id)).toEqual([1, 2, 4])
+  })
+})
+
+describe('ordinary writes are unaffected (#1101)', () => {
+  it('DELETE with an object filter still removes exactly its rows', async () => {
+    await qb().deleteFrom('t').where({ id: 1 }).execute()
+    expect(rows().map(r => r.id)).toEqual([2, 3, 4])
+  })
+
+  it('UPDATE with an object filter still rewrites exactly its rows', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where({ id: 2 }).execute()
+    expect(rows().filter(r => r.name === 'X').map(r => r.id)).toEqual([2])
+  })
+
+  it('the 3-arg form still works on both builders', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where('id', '=', 3).execute()
+    expect(rows().filter(r => r.name === 'X').map(r => r.id)).toEqual([3])
+
+    await qb().deleteFrom('t').where('id', '=', 4).execute()
+    expect(rows().map(r => r.id)).toEqual([1, 2, 3])
+  })
+
+  it('an intentional unfiltered write is still possible without where()', async () => {
+    // Refusing an unreadable filter must not remove the ability to write the
+    // whole table on purpose — the point is that it has to be explicit.
+    await qb().deleteFrom('t').execute()
+    expect(rows()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #1101. Closes #1095.

`updateTable().where()` and `deleteFrom().where()` accepted argument shapes they could not turn into a predicate, then returned `this` unchanged. The statement kept **no WHERE at all**, ran against every row, and reported the full affected count as success.

Measured on live Postgres 17, 4 rows seeded, before → after:

| `where(...)` | DELETE before | UPDATE before | after (both) |
|---|---|---|---|
| `undefined` | **all 4 deleted** | **all 4 rewritten** | throws, table intact |
| `null` | **all 4 deleted** | **all 4 rewritten** | throws, table intact |
| `{}` | SQL syntax error | SQL syntax error | throws, naming the problem |
| `raw('id = 1')` | `invalid input syntax for type boolean` | **all 4 rewritten** | affects exactly 1 row |

## Why `raw()` is the serious one

It is not a mistake the types catch. The declared signature is

```ts
// client.ts:1981
expr: WhereExpression<DB[TTable]['columns']> | K | SqlFragment
```

and `raw` is a public export. So `where(raw('id = 1'))` reads correctly, typechecks, passes review — and rewrote the table.

## Two shapes, two different remedies

**A fragment is honoured**, on both builders, because the signature promises it. Refusing it would trade a silent catastrophe for a broken advertised API. Note the delete side was *already* broken here in a different way: routed through `applyWhere()` it was bound as a value, which is why Postgres complained about a boolean. That works now too.

Fragments are matched **ahead of** the object branch on purpose: `{ sql, parameters }` is an object, so the old ordering would have rendered it as `"sql" = ? AND "parameters" = ?` and matched nothing. There is a test pinning that specific ordering trap.

**Anything genuinely unreadable is refused**, synchronously at the `where()` call rather than at `execute()` — it fails at the point of the mistake, before a statement exists. A write builder is the wrong place to read "I could not understand your filter" as "match every row".

This is the same fall-through the *select* builder dropped in #1083. The write builders kept it.

## #1095 comes along with it

`where({})` now throws naming the problem instead of emitting a dangling `WHERE` and dying on a syntax error. Worth recording that the symptom #1095 reports was always the **safe** one — it never wrote anything. The dangerous siblings were sitting in the same method unreported.

## Deliberately still possible

```ts
await db.deleteFrom('t').execute()   // whole table, on purpose
```

Refusing an unreadable filter must not remove the ability to write a whole table intentionally. The point is that it has to be explicit. There is a test for this.

## Tests

`test/client.write-predicate-required.test.ts` — 15 tests, **11 fail without the src change**. The remaining 4 are the invariants that ordinary writes are untouched.

Every assertion checks **surviving rows**, not merely that a call threw. The bug was damage, so the table is the thing worth asserting on — a test that only checked for an exception would pass against a builder that threw *after* deleting everything.

## Out of scope, found while measuring

`where({ id: [1, 2] })` on both write builders renders `"id" = $1` rather than `id IN (...)`, so it matches nothing — silently deleting/updating zero rows where the same call on a select matches both. That is a *narrowing* failure rather than the widening one this PR is about, and it deserves its own issue rather than being folded in here.

## Checks

- typecheck and pickier clean
- `bun test` — 1970 pass, 4 skip, 1 fail (the stale-`bin/qbx` `CLI > version` test, pre-existing and reproducing on clean `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)