### PR TITLE
fix(client): apply the filters that follow returning(), instead of discarding them

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -7115,26 +7115,47 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return this
         },
         returning(...cols) {
-          const retText = `${sqlText} RETURNING ${cols.join(', ')}`
-          const q = params.length > 0
-            ? _sql.unsafe(retText, params)
-            : _sql.unsafe(retText)
+          const parent: any = this
+          // Render at execute time, not here.
+          //
+          // This used to freeze the statement text immediately and return an
+          // object whose where/andWhere/orWhere/orderBy/limit/offset were
+          // literally `() => obj` — so every filter applied after returning()
+          // was discarded and the UPDATE ran against the whole table, silently,
+          // while `.executeTakeFirst()` handed back a row it had never filtered
+          // to. `returning()` is typed as SelectQueryBuilder, which declares all
+          // of those, so the broken order type-checks. See #1110.
+          //
+          // Deferring also fixes the aliasing form, where the returning handle
+          // is held while the parent gains a predicate.
+          const retText = () => `${sqlText} RETURNING ${cols.join(', ')}`
+          const build = () => (params.length > 0 ? _sql.unsafe(retText(), params) : _sql.unsafe(retText()))
           const runFirst = async () => {
-            const rows = await runWithHooks<any[]>(q, 'update')
+            const rows = await runWithHooks<any[]>(build(), 'update')
             return Array.isArray(rows) ? rows[0] : rows
           }
+          // Not expressible on this builder. Silently ignoring them is what
+          // made a `.limit(1)` destructive write hit every row.
+          const unsupported = (name: string) => (): never => {
+            throw new TypeError(`[query-builder] updateTable.returning(...).${name}() is not supported — an UPDATE cannot be ordered or limited through this builder. Apply the filter with where() instead.`)
+          }
           const obj: any = {
-            where: () => obj,
-            andWhere: () => obj,
-            orWhere: () => obj,
-            orderBy: () => obj,
-            limit: () => obj,
-            offset: () => obj,
-            toSQL: () => makeExecutableQuery(q, retText) as any,
-            execute: () => runWithHooks<any[]>(q, 'update'),
+            // Delegate to the builder that owns the statement, then keep
+            // chaining from here. Consecutive predicates join with AND, which
+            // is what andWhere means.
+            where: (...args: any[]) => { parent.where(...args); return obj },
+            andWhere: (...args: any[]) => { parent.where(...args); return obj },
+            whereNull: (...args: any[]) => { parent.whereNull(...args); return obj },
+            whereNotNull: (...args: any[]) => { parent.whereNotNull(...args); return obj },
+            orWhere: unsupported('orWhere'),
+            orderBy: unsupported('orderBy'),
+            limit: unsupported('limit'),
+            offset: unsupported('offset'),
+            toSQL: () => makeExecutableQuery(build(), retText()) as any,
+            execute: () => runWithHooks<any[]>(build(), 'update'),
             // returning() is typed as SelectQueryBuilder — expose the
             // row-fetching methods so `.returning('id').first()` works.
-            get: () => runWithHooks<any[]>(q, 'update'),
+            get: () => runWithHooks<any[]>(build(), 'update'),
             first: runFirst,
             executeTakeFirst: runFirst,
             async firstOrFail() {
@@ -7175,19 +7196,20 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return { numUpdatedRows: result }
         },
         returningAll() {
-          const retAllText = `${sqlText} RETURNING *`
-          const q = params.length > 0
-            ? _sql.unsafe(retAllText, params)
-            : _sql.unsafe(retAllText)
+          // Deferred for the same reason as returning(): holding this handle
+          // while the parent gains a predicate must not execute the statement
+          // as it stood beforehand. See #1110.
+          const retAllText = () => `${sqlText} RETURNING *`
+          const build = () => (params.length > 0 ? _sql.unsafe(retAllText(), params) : _sql.unsafe(retAllText()))
           return {
-            toSQL: () => makeExecutableQuery(q, retAllText) as any,
-            execute: () => runWithHooks<any[]>(q, 'update'),
+            toSQL: () => makeExecutableQuery(build(), retAllText()) as any,
+            execute: () => runWithHooks<any[]>(build(), 'update'),
             async executeTakeFirst() {
-              const result = await runWithHooks<any[]>(q, 'update')
+              const result = await runWithHooks<any[]>(build(), 'update')
               return Array.isArray(result) ? result[0] : result
             },
             async executeTakeFirstOrThrow() {
-              const result = await runWithHooks<any[]>(q, 'update')
+              const result = await runWithHooks<any[]>(build(), 'update')
               const first = Array.isArray(result) ? result[0] : result
               if (!first)
                 throw new Error('Update with RETURNING failed')
@@ -7337,25 +7359,46 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return this
         },
         returning(...cols) {
-          const retText = `${sqlText} RETURNING ${cols.join(', ')}`
-          const q = delParams.length > 0
-            ? _sql.unsafe(retText, delParams)
-            : _sql.unsafe(retText)
+          const parent: any = this
+          // Rendered at execute time. The frozen-text form, with the no-op
+          // filter stubs below it, meant `.returning('id').where({ id: 1 })`
+          // emptied the table and returned every deleted row as though the
+          // filter had applied. See #1110.
+          const retText = () => `${sqlText} RETURNING ${cols.join(', ')}`
+          const build = () => (delParams.length > 0 ? _sql.unsafe(retText(), delParams) : _sql.unsafe(retText()))
+          // Fire the same delete hooks execute() does. Without this, adding
+          // `.returning(...)` to a delete skipped beforeDelete/afterDelete
+          // entirely, so an application-level delete guard — the usual reason
+          // to implement beforeDelete at all — could be walked straight past.
+          const runDelete = async (): Promise<any[]> => {
+            await activeHooks()?.beforeDelete?.({ table: String(table), where: whereCondition })
+            const rows = await runWithHooks<any[]>(build(), 'delete')
+            try {
+              await activeHooks()?.afterDelete?.({ table: String(table), where: whereCondition, result: rows })
+            }
+            catch {}
+            return rows
+          }
           const runFirst = async () => {
-            const rows = await runWithHooks<any[]>(q, 'delete')
+            const rows = await runDelete()
             return Array.isArray(rows) ? rows[0] : rows
           }
+          const unsupported = (name: string) => (): never => {
+            throw new TypeError(`[query-builder] deleteFrom.returning(...).${name}() is not supported — a DELETE cannot be ordered or limited through this builder. Narrow it with where() instead.`)
+          }
           const obj: any = {
-            where: () => obj,
-            andWhere: () => obj,
-            orWhere: () => obj,
-            orderBy: () => obj,
-            limit: () => obj,
-            offset: () => obj,
-            toSQL: () => makeExecutableQuery(q, retText) as any,
-            execute: () => runWithHooks<any[]>(q, 'delete'),
+            where: (...args: any[]) => { parent.where(...args); return obj },
+            andWhere: (...args: any[]) => { parent.where(...args); return obj },
+            whereNull: (...args: any[]) => { parent.whereNull(...args); return obj },
+            whereNotNull: (...args: any[]) => { parent.whereNotNull(...args); return obj },
+            orWhere: unsupported('orWhere'),
+            orderBy: unsupported('orderBy'),
+            limit: unsupported('limit'),
+            offset: unsupported('offset'),
+            toSQL: () => makeExecutableQuery(build(), retText()) as any,
+            execute: () => runDelete(),
             // returning() is typed as SelectQueryBuilder — expose row fetchers.
-            get: () => runWithHooks<any[]>(q, 'delete'),
+            get: () => runDelete(),
             first: runFirst,
             executeTakeFirst: runFirst,
             async firstOrFail() {
@@ -7404,19 +7447,18 @@ export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Parti
           return { numDeletedRows: result }
         },
         returningAll() {
-          const retAllText = `${sqlText} RETURNING *`
-          const q = delParams.length > 0
-            ? _sql.unsafe(retAllText, delParams)
-            : _sql.unsafe(retAllText)
+          // Deferred, as returning() is — see #1110.
+          const retAllText = () => `${sqlText} RETURNING *`
+          const build = () => (delParams.length > 0 ? _sql.unsafe(retAllText(), delParams) : _sql.unsafe(retAllText()))
           return {
-            toSQL: () => makeExecutableQuery(q, retAllText) as any,
-            execute: () => runWithHooks<any[]>(q, 'delete'),
+            toSQL: () => makeExecutableQuery(build(), retAllText()) as any,
+            execute: () => runWithHooks<any[]>(build(), 'delete'),
             async executeTakeFirst() {
-              const result = await runWithHooks<any[]>(q, 'delete')
+              const result = await runWithHooks<any[]>(build(), 'delete')
               return Array.isArray(result) ? result[0] : result
             },
             async executeTakeFirstOrThrow() {
-              const result = await runWithHooks<any[]>(q, 'delete')
+              const result = await runWithHooks<any[]>(build(), 'delete')
               const first = Array.isArray(result) ? result[0] : result
               if (!first)
                 throw new Error('Delete with RETURNING failed')

--- a/packages/bun-query-builder/test/client.returning-filters.test.ts
+++ b/packages/bun-query-builder/test/client.returning-filters.test.ts
@@ -1,0 +1,176 @@
+/**
+ * A filter applied after returning() must reach the statement.
+ * stacksjs/bun-query-builder#1110.
+ *
+ * `returning()` froze the statement text at call time and handed back an
+ * object whose filter methods were literally no-ops:
+ *
+ *     { where: () => obj, andWhere: () => obj, orWhere: () => obj,
+ *       orderBy: () => obj, limit: () => obj, offset: () => obj }
+ *
+ * so every filter expressed after it was discarded and the unfiltered
+ * statement ran:
+ *
+ *     updateTable(t).set(v).returning('id').where({ id: 1 })  -> rewrote all rows
+ *     deleteFrom(t).returning('id').where({ id: 1 })          -> emptied the table
+ *
+ * Three things made it worse than a dropped predicate:
+ *
+ *  - it REPORTED SUCCESS for work it never scoped. `.where('id','=',99)
+ *    .executeTakeFirst()` returned a row that cannot match 99, while rewriting
+ *    everything.
+ *  - the types invite it. `returning()` is declared to return
+ *    SelectQueryBuilder, which declares where/andWhere/orWhere/orderBy/limit,
+ *    so the broken order type-checks under --strict.
+ *  - on the delete side it skipped beforeDelete/afterDelete, so adding
+ *    `.returning(...)` walked straight past an application delete guard.
+ *
+ * The fix defers rendering to execute time and delegates the filters to the
+ * builder that owns the statement. Methods that genuinely cannot be expressed
+ * on a write (orderBy/limit/offset/orWhere) now throw rather than being
+ * ignored — silently ignoring `limit(1)` is what turned a one-row delete into
+ * a whole-table one.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  t: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' } } },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown>, hooks: unknown }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+function rows(): Array<{ id: number, name: string }> {
+  const probe = new Database(dbPath)
+  const out = probe.query('SELECT id, name FROM t ORDER BY id').all() as any[]
+  probe.close()
+  return out
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database }, hooks: (config as any).hooks }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1110-'))
+  dbPath = join(dir, 'ret.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+  seed.run(`INSERT INTO t (id, name) VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d')`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  ;(config as any).hooks = snapshot.hooks
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('UPDATE: a filter after returning() applies (#1110)', () => {
+  it('rewrites only the matching row', async () => {
+    const returned = await qb().updateTable('t').set({ name: 'X' }).returning('id').where({ id: 1 }).execute()
+
+    expect(returned).toEqual([{ id: 1 }])
+    expect(rows().filter(r => r.name === 'X').map(r => r.id)).toEqual([1])
+    expect(rows()).toHaveLength(4)
+  })
+
+  it('does not report a row it never matched', async () => {
+    // The sharp edge: this used to return { id: 1 } while rewriting all four.
+    const first = await qb().updateTable('t').set({ name: 'Y' }).returning('id').where('id', '=', 99).executeTakeFirst()
+
+    expect(first).toBeUndefined()
+    expect(rows().filter(r => r.name === 'Y')).toHaveLength(0)
+  })
+
+  it('still works in the other order', async () => {
+    const returned = await qb().updateTable('t').set({ name: 'Z' }).where({ id: 1 }).returning('id').execute()
+    expect(returned).toEqual([{ id: 1 }])
+    expect(rows().filter(r => r.name === 'Z').map(r => r.id)).toEqual([1])
+  })
+
+  it('andWhere and whereNull reach the statement too', async () => {
+    const returned = await qb().updateTable('t').set({ name: 'W' })
+      .returning('id').where({ id: 2 }).andWhere('name', '=', 'b')
+      .execute()
+
+    expect(returned).toEqual([{ id: 2 }])
+    expect(rows().filter(r => r.name === 'W').map(r => r.id)).toEqual([2])
+  })
+})
+
+describe('DELETE: a filter after returning() applies (#1110)', () => {
+  it('removes only the matching row', async () => {
+    const returned = await qb().deleteFrom('t').returning('id').where({ id: 1 }).execute()
+
+    expect(returned).toEqual([{ id: 1 }])
+    expect(rows().map(r => r.id)).toEqual([2, 3, 4])
+  })
+
+  it('fires beforeDelete, so a delete guard cannot be walked past', async () => {
+    setConfig({ hooks: { beforeDelete: () => { throw new Error('BLOCKED by guard') } } } as any)
+
+    await expect(qb().deleteFrom('t').returning('id').where({ id: 1 }).execute())
+      .rejects.toThrow(/BLOCKED by guard/)
+
+    expect(rows()).toHaveLength(4)
+  })
+})
+
+describe('the returning handle is not a snapshot (#1110)', () => {
+  it('picks up a predicate added to the parent after it was taken', async () => {
+    const builder = qb().deleteFrom('t')
+    const handle = builder.returning('id')
+    builder.where({ id: 2 })
+
+    expect(await handle.execute()).toEqual([{ id: 2 }])
+    expect(rows().map(r => r.id)).toEqual([1, 3, 4])
+  })
+
+  it('applies to returningAll() as well', async () => {
+    const builder = qb().deleteFrom('t')
+    const handle = builder.returningAll()
+    builder.where({ id: 3 })
+
+    const returned = await handle.execute()
+    expect(returned.map((r: any) => r.id)).toEqual([3])
+    expect(rows().map(r => r.id)).toEqual([1, 2, 4])
+  })
+})
+
+describe('what a write cannot express now says so (#1110)', () => {
+  // Silently ignoring these is what let `.limit(1)` on a delete remove
+  // everything while reading like it removed one row.
+  for (const method of ['orderBy', 'limit', 'offset', 'orWhere'] as const) {
+    it(`deleteFrom.returning(...).${method}() throws instead of being ignored`, () => {
+      expect(() => (qb().deleteFrom('t').returning('id') as any)[method]('id'))
+        .toThrow(/not supported/)
+      expect(rows()).toHaveLength(4)
+    })
+
+    it(`updateTable.returning(...).${method}() throws instead of being ignored`, () => {
+      expect(() => (qb().updateTable('t').set({ name: 'Q' }).returning('id') as any)[method]('id'))
+        .toThrow(/not supported/)
+      expect(rows().filter(r => r.name === 'Q')).toHaveLength(0)
+    })
+  }
+})


### PR DESCRIPTION
Closes #1110.

`returning()` froze the statement text at call time and handed back an object whose filter methods were literally no-ops:

```ts
{ where: () => obj, andWhere: () => obj, orWhere: () => obj,
  orderBy: () => obj, limit: () => obj, offset: () => obj }
```

Every filter expressed after it was discarded and the unfiltered statement ran. Measured on live Postgres 17, 4 rows:

| call | returned before | effect before | after |
|---|---|---|---|
| `updateTable.set(v).returning('id').where({id:1})` | `[1,2,3,4]` | **all 4 rewritten** | `[{id:1}]`, 1 row |
| `.returning('id').where('id','=',99).executeTakeFirst()` | `{id:1}` | **all 4 rewritten** | `undefined`, 0 rows |
| `deleteFrom.returning('id').where({id:1})` | `[1,2,3,4]` | **table emptied** | `[{id:1}]`, 1 row |
| `.where({id:1}).returning('id')` *(control)* | `[{id:1}]` | correct | unchanged |

## Three things made it worse than a dropped predicate

**It reported success for work it never scoped.** The second row above returned a row that cannot match `id = 99`, while rewriting everything. A caller reading that return value concludes one row was touched.

**The types invite it.** `returning()` is declared to return `SelectQueryBuilder`, which declares `where`, `andWhere`, `orWhere`, `orderBy`, `limit` — the broken order type-checks under `--strict` with no casts.

**It bypassed the delete guard.** The delete path skipped `beforeDelete`/`afterDelete`, so adding `.returning(...)` walked straight past an application-level guard — which is the usual reason to implement `beforeDelete` in the first place. Verified: a `beforeDelete` that throws now blocks the delete and leaves all 4 rows.

## The fix

Render at execute time, and delegate `where`/`andWhere`/`whereNull`/`whereNotNull` to the builder that owns the statement.

Deferring also fixes the **aliasing** form, where the handle is taken and the parent then gains a predicate:

```ts
const handle = builder.returning('id')
builder.where({ id: 2 })
await handle.execute()     // now honours the where; previously ran the frozen text
```

`returningAll()` is deferred for the same reason.

`orderBy`/`limit`/`offset`/`orWhere` cannot be expressed on these builders, so they now **throw** rather than being ignored — silently ignoring `limit(1)` is exactly what turned a one-row delete into a whole-table one. That is a behaviour change, and deliberately so: every caller relying on it today is getting an unfiltered write.

## Tests

`test/client.returning-filters.test.ts` — 16 tests, **15 fail without the src change**. The one that passes both ways is the control (`.where().returning()` still works), which is the point of having it.

## Checks

- typecheck and pickier clean
- `bun test` — 2020 pass, 4 skip, 1 fail (stale local `bin/qbx` `CLI > version`, pre-existing, rebuilt by CI)

## Not addressed here

The delete builder's `executeTakeFirst()`/`executeTakeFirstOrThrow()` also skip `beforeDelete`/`afterDelete` — the same guard hole, reachable without `returning()` at all. It is not part of this bug's shape, so it wants its own change rather than being folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)