### PR TITLE
fix(orm): scope destructive statements the way reads are scoped

### DIFF
--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -2672,6 +2672,33 @@ class ModelQueryBuilder<
    * the soft-delete predicate. User clauses are parenthesised when both are
    * present so a top-level `OR` can't escape the soft-delete filter.
    */
+  /**
+   * Refuse a destructive statement that carries clauses it will not emit.
+   *
+   * `delete()`, `update()` and `increment()` read none of `_limit`, `_offset`
+   * or `_orderBy`, so `query().where(...).orderBy('id').limit(1).delete()`
+   * quietly deleted every matching row rather than one — the caller's cap was
+   * dropped on the floor. LIMIT on an UPDATE/DELETE is not portable (Postgres
+   * has no such form), so these cannot simply be emitted; being loud is the
+   * honest option. See #1111.
+   */
+  private assertNoUnappliedClauses(method: string): void {
+    const ignored: string[] = []
+    if (this._limit !== undefined)
+      ignored.push('limit()')
+    if (this._offset !== undefined)
+      ignored.push('offset()')
+    if (this._orderBy.length > 0)
+      ignored.push('orderBy()')
+
+    if (ignored.length > 0) {
+      throw new TypeError(
+        `[orm] ${method}() cannot apply ${ignored.join(', ')} — an UPDATE/DELETE takes no ORDER BY or LIMIT on every supported dialect. `
+        + `Previously these were ignored, so the statement affected every matching row. Narrow it with where() instead.`,
+      )
+    }
+  }
+
   private composeWhere(params: unknown[]): string {
     const userClause = this._wheres.length > 0 ? this.buildWhereClauses(params) : ''
     const sd = this.softDeleteClause()
@@ -3020,6 +3047,7 @@ class ModelQueryBuilder<
    */
   async increment<K extends NumericColumns<TDef>>(column: K, amount = 1): Promise<number> {
     assertValidIdentifier(column, 'increment(column)')
+    this.assertNoUnappliedClauses('increment')
     const exec = getExecutor()
     const params: unknown[] = [amount]
 
@@ -3031,9 +3059,11 @@ class ModelQueryBuilder<
       params.push(formatNow())
     }
 
-    if (this._wheres.length > 0) {
-      const clauses = this.buildWhereClauses(params)
-      sql += ` WHERE ${clauses}`
+    // See delete(): composeWhere is the only path that adds the soft-delete
+    // predicate, so a scoped counter bump has to go through it. #1111.
+    const whereBody = this.composeWhere(params)
+    if (whereBody) {
+      sql += ` WHERE ${whereBody}`
     }
 
     return (await exec.run(sql, params)).changes
@@ -3185,18 +3215,26 @@ class ModelQueryBuilder<
   }
 
   async delete(): Promise<number> {
+    this.assertNoUnappliedClauses('delete')
     const exec = getExecutor()
     const params: unknown[] = []
     let sql = `DELETE FROM ${this._definition.table}`
 
-    if (this._wheres.length > 0) {
-      sql += ` WHERE ${this.buildWhereClauses(params)}`
+    // composeWhere, not buildWhereClauses: the soft-delete predicate is added
+    // only by composeWhere, so building the WHERE here meant a scope that
+    // exists purely as that predicate contributed nothing to the statement.
+    // `onlyTrashed().delete()` — purge the trash — emitted a bare DELETE and
+    // removed every row, live ones included. See #1111.
+    const whereBody = this.composeWhere(params)
+    if (whereBody) {
+      sql += ` WHERE ${whereBody}`
     }
 
     return (await exec.run(sql, params)).changes
   }
 
   async update(data: Partial<Pick<InferModelAttributes<TDef>, FillableKeys<TDef>>>): Promise<number> {
+    this.assertNoUnappliedClauses('update')
     const exec = getExecutor()
     const entries = Object.entries(data)
     const sets = entries.map(([k]) => `${sqlColumn(k)} = ?`).join(', ')
@@ -3208,8 +3246,11 @@ class ModelQueryBuilder<
 
     let sql = `UPDATE ${this._definition.table} SET ${sets}${timestampsEnabled(this._definition) ? ', updated_at = ?' : ''}`
 
-    if (this._wheres.length > 0) {
-      sql += ` WHERE ${this.buildWhereClauses(params)}`
+    // See delete(): composeWhere is the only path that adds the soft-delete
+    // predicate, so a scoped update has to go through it. #1111.
+    const whereBody = this.composeWhere(params)
+    if (whereBody) {
+      sql += ` WHERE ${whereBody}`
     }
 
     return (await exec.run(sql, params)).changes

--- a/packages/bun-query-builder/test/orm.destructive-scope.test.ts
+++ b/packages/bun-query-builder/test/orm.destructive-scope.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The ORM's destructive statements must be scoped the way its reads are.
+ * stacksjs/bun-query-builder#1111.
+ *
+ * `delete()`, `update()` and `increment()` built their WHERE with
+ * `buildWhereClauses()`, guarded by `this._wheres.length > 0`. Every read path
+ * uses `composeWhere()` — and `composeWhere` is the only place the soft-delete
+ * predicate is added.
+ *
+ * So a scope expressed purely as that predicate contributed nothing to a
+ * write, and when it was the ONLY scope the statement went out with no WHERE
+ * at all:
+ *
+ *     Post.query().onlyTrashed().delete()   ->  DELETE FROM posts    (every row)
+ *
+ * "Purge the trash" was the exact call that destroyed the live rows.
+ *
+ * These assert row counts rather than emitted SQL. The defect was the gap
+ * between two WHERE builders, so only the resulting table settles it.
+ */
+
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { clearModelRegistry, configureOrm, createModel, createTableFromModel } from '../src'
+
+let db: Database
+let Post: any
+
+beforeEach(async () => {
+  clearModelRegistry()
+  db = new Database(':memory:', { create: true })
+  configureOrm({ database: db })
+
+  Post = createModel({
+    name: 'Sdpost',
+    table: 'sd_posts',
+    primaryKey: 'id',
+    autoIncrement: true,
+    traits: { useSoftDeletes: true },
+    attributes: {
+      title: { type: 'string', fillable: true },
+      views: { type: 'integer', fillable: true },
+    },
+  } as any)
+
+  await createTableFromModel(Post.getDefinition())
+  for (const title of ['a', 'b', 'c', 'd'])
+    await Post.create({ title, views: 0 })
+  // 'a' and 'b' are trashed; 'c' and 'd' are live.
+  db.run(`UPDATE sd_posts SET deleted_at = '2026-01-01' WHERE title IN ('a','b')`)
+})
+
+afterEach(() => {
+  clearModelRegistry()
+})
+
+const total = (): number => (db.query('SELECT count(*) c FROM sd_posts').get() as any).c
+const alive = (): number => (db.query('SELECT count(*) c FROM sd_posts WHERE deleted_at IS NULL').get() as any).c
+const titles = (): string[] => (db.query('SELECT title FROM sd_posts ORDER BY title').all() as any[]).map(r => r.title)
+
+describe('delete() honours the soft-delete scope (#1111)', () => {
+  it('onlyTrashed().delete() removes the trashed rows and spares the live ones', async () => {
+    expect([total(), alive()]).toEqual([4, 2])
+
+    await Post.query().onlyTrashed().delete()
+
+    // Previously: total 0 — the live rows went too.
+    expect(total()).toBe(2)
+    expect(alive()).toBe(2)
+    expect(titles()).toEqual(['c', 'd'])
+  })
+
+  it('an unscoped delete still excludes trashed rows, as reads do', async () => {
+    await Post.query().delete()
+
+    // The default scope hides trashed rows, so a hard delete must not reach
+    // them either — otherwise the same query means two different row sets
+    // depending on whether it reads or writes.
+    expect(titles()).toEqual(['a', 'b'])
+  })
+
+  it('a user filter still applies alongside the scope', async () => {
+    await Post.query().where('title', 'c').delete()
+
+    expect(titles()).toEqual(['a', 'b', 'd'])
+  })
+})
+
+describe('update() and increment() honour the scope (#1111)', () => {
+  it('onlyTrashed().update() rewrites only the trashed rows', async () => {
+    await Post.query().onlyTrashed().update({ title: 'PURGED' })
+
+    const purged = (db.query(`SELECT count(*) c FROM sd_posts WHERE title='PURGED'`).get() as any).c
+    expect(purged).toBe(2)
+    expect(total()).toBe(4)
+  })
+
+  it('onlyTrashed().increment() bumps only the trashed rows', async () => {
+    await Post.query().onlyTrashed().increment('views', 5)
+
+    const bumped = (db.query('SELECT count(*) c FROM sd_posts WHERE views = 5').get() as any).c
+    expect(bumped).toBe(2)
+  })
+
+  it('an unscoped update leaves trashed rows alone', async () => {
+    await Post.query().update({ views: 9 })
+
+    const bumped = (db.query('SELECT count(*) c FROM sd_posts WHERE views = 9').get() as any).c
+    expect(bumped).toBe(2)
+  })
+})
+
+describe('clauses a write cannot emit are refused (#1111)', () => {
+  // Silently ignoring limit() is what turned `limit(1).delete()` into a delete
+  // of every matching row. LIMIT on UPDATE/DELETE is not portable — Postgres
+  // has no such form — so being loud is the honest option.
+  it('limit() on a delete throws instead of being dropped', async () => {
+    await expect(Post.query().limit(1).delete()).rejects.toThrow(/cannot apply limit/)
+    expect(total()).toBe(4)
+  })
+
+  it('orderBy() on a delete throws instead of being dropped', async () => {
+    await expect(Post.query().orderBy('id').delete()).rejects.toThrow(/cannot apply .*orderBy/)
+    expect(total()).toBe(4)
+  })
+
+  it('limit() on an update throws instead of being dropped', async () => {
+    await expect(Post.query().limit(1).update({ views: 3 })).rejects.toThrow(/cannot apply limit/)
+    const bumped = (db.query('SELECT count(*) c FROM sd_posts WHERE views = 3').get() as any).c
+    expect(bumped).toBe(0)
+  })
+
+  it('a write with no ordering or limit is unaffected', async () => {
+    await expect(Post.query().where('title', 'c').update({ views: 7 })).resolves.toBeDefined()
+    const bumped = (db.query('SELECT count(*) c FROM sd_posts WHERE views = 7').get() as any).c
+    expect(bumped).toBe(1)
+  })
+})
+
+describe('a model without soft deletes is unchanged (#1111)', () => {
+  it('deletes exactly what the filter selects', async () => {
+    clearModelRegistry()
+    const plain = new Database(':memory:', { create: true })
+    configureOrm({ database: plain })
+
+    const Item = createModel({
+      name: 'Plainitem',
+      table: 'plain_items',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { name: { type: 'string', fillable: true } },
+    } as any)
+    await createTableFromModel((Item as any).getDefinition())
+    for (const name of ['x', 'y', 'z'])
+      await (Item as any).create({ name })
+
+    await (Item as any).query().where('name', 'y').delete()
+
+    const left = (plain.query('SELECT name FROM plain_items ORDER BY name').all() as any[]).map(r => r.name)
+    expect(left).toEqual(['x', 'z'])
+  })
+})


### PR DESCRIPTION
Closes #1111.

`delete()`, `update()` and `increment()` built their WHERE with `buildWhereClauses()`, guarded by `this._wheres.length > 0`. Every **read** path uses `composeWhere()` — and `composeWhere` is the only place the soft-delete predicate is added.

So a scope expressed purely as that predicate contributed nothing to a write, and when it was the *only* scope the statement went out with no WHERE at all:

```sql
Post.query().onlyTrashed().delete()   ->   DELETE FROM sd_posts
```

"Purge the trash" was the exact call that destroyed the live rows.

Measured on a 4-row table with 2 trashed:

| call | before | after |
|---|---|---|
| `onlyTrashed().delete()` | total **0** — live rows gone | total 2, both live rows intact |
| `onlyTrashed().update({...})` | all 4 rewritten | 2 rewritten |
| `onlyTrashed().increment('views', 5)` | all 4 bumped | 2 bumped |
| `query().delete()` | trashed rows deleted too | trashed rows survive, as reads imply |
| `limit(1).delete()` | **every matching row deleted** | throws, table intact |

## The fix is the shared function, not the symptom

All three now go through `composeWhere` — the same function that scopes a read. Two builders answering "which rows does this query mean?" *is* the defect; patching each symptom would leave them free to drift apart again. This is the same shape as #1094, where two column-type mappings disagreed.

## limit / offset / orderBy

None of the three read those fields, so `query().where(...).orderBy('id').limit(1).delete()` silently deleted every matching row instead of one. They now throw.

They cannot simply be emitted: `LIMIT` on an `UPDATE`/`DELETE` is not portable — Postgres has no such form, and SQLite needs a non-default compile flag. Given the choice between dropping a caller's cap on the floor and saying so, the second is the only safe one.

## Deliberately unchanged

`query().where(...).delete()` still **hard**-deletes on a model declaring `useSoftDeletes`, while the instance-level `delete()` soft-deletes. I verified the asymmetry (4 rows → 2, rather than 4 with 2 marked) and left it alone: the query builder has **no `forceDelete()`**, so making this path soft-delete would leave no way to hard-delete through it at all.

That wants `forceDelete()` added first, and it is a behaviour change to a documented method — a separate PR, not a rider on this one. Raising it rather than picking silently.

## Tests

`test/orm.destructive-scope.test.ts` — 11 tests, **8 fail without the src change**. The three that pass both ways are the invariants: a user filter still applies, an unaffected write still works, and a model *without* soft deletes behaves exactly as before.

They assert row counts rather than emitted SQL, because the defect was the gap between two WHERE builders — only the resulting table settles it.

## Checks

- typecheck clean; `bun test` — 2031 pass, 4 skip, 1 fail (stale local `bin/qbx` `CLI > version`, pre-existing, rebuilt by CI)
- pickier reports one `brace-style` warning at `orm.ts:465` — pre-existing, sits at `:421` on `main` and moved only because this PR adds lines above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)