### PR TITLE
refactor(types): stop publishing `any` across the query builder's surface

### DIFF
--- a/packages/bun-query-builder/src/browser.ts
+++ b/packages/bun-query-builder/src/browser.ts
@@ -372,7 +372,9 @@ export class BrowserQueryBuilder<T = any> {
   /**
    * Add a where clause
    */
-  where(column: string, operatorOrValue: WhereOperator | any, value?: any): this {
+  where(column: string, value: unknown): this
+  where(column: string, operator: WhereOperator, value: unknown): this
+  where(column: string, operatorOrValue: unknown, value?: unknown): this {
     if (value === undefined) {
       // where('column', value) shorthand for equality
       this.state.wheres.push({
@@ -397,7 +399,9 @@ export class BrowserQueryBuilder<T = any> {
   /**
    * Add an OR where clause
    */
-  orWhere(column: string, operatorOrValue: WhereOperator | any, value?: any): this {
+  orWhere(column: string, value: unknown): this
+  orWhere(column: string, operator: WhereOperator, value: unknown): this
+  orWhere(column: string, operatorOrValue: unknown, value?: unknown): this {
     if (value === undefined) {
       this.state.wheres.push({
         column,
@@ -420,8 +424,15 @@ export class BrowserQueryBuilder<T = any> {
   /**
    * Add an AND where clause (alias for where)
    */
-  andWhere(column: string, operatorOrValue: WhereOperator | any, value?: any): this {
-    return this.where(column, operatorOrValue, value)
+  andWhere(column: string, value: unknown): this
+  andWhere(column: string, operator: WhereOperator, value: unknown): this
+  andWhere(column: string, operatorOrValue: unknown, value?: unknown): this {
+    // Two args means the second is a value; three means it is an operator -
+    // which is exactly what the overloads above declare, so the dispatch is
+    // split here rather than passing an unknown into the operator position.
+    return value === undefined
+      ? this.where(column, operatorOrValue)
+      : this.where(column, operatorOrValue as WhereOperator, value)
   }
 
   /**
@@ -441,14 +452,14 @@ export class BrowserQueryBuilder<T = any> {
   /**
    * Where column is in array
    */
-  whereIn(column: string, values: any[]): this {
+  whereIn(column: string, values: readonly unknown[]): this {
     return this.where(column, 'in', values)
   }
 
   /**
    * Where column is not in array
    */
-  whereNotIn(column: string, values: any[]): this {
+  whereNotIn(column: string, values: readonly unknown[]): this {
     return this.where(column, 'not in', values)
   }
 

--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-useless-catch */
 import type { SchemaMeta } from './meta'
 import type { ResolvedPivot } from './pivot'
-import type { DatabaseSchema } from './schema'
+import type { DatabaseSchema, AnyDatabaseSchema } from './schema'
 import type { QueryBuilderOptions, QueryHooks, SupportedDialect} from './types'
 import { config, getPlaceholder, getPlaceholders, isMysqlLike, setConfig } from './config'
 import type { DriverConnection } from './db'
@@ -400,7 +400,7 @@ class QueryCache {
   private cache = new Map<string, CacheEntry>()
   private maxSize = 100
 
-  get(key: string): any | null {
+  get<T = unknown>(key: string): T | null {
     const entry = this.cache.get(key)
     if (!entry)
       return null
@@ -420,7 +420,7 @@ class QueryCache {
     return entry.data
   }
 
-  set(key: string, data: any, ttlMs: number): void {
+  set(key: string, data: unknown, ttlMs: number): void {
     // Re-inserted keys must move to the back or they'd be evicted as if old.
     if (this.cache.has(key))
       this.cache.delete(key)
@@ -526,15 +526,15 @@ export type SortDirection = 'asc' | 'desc'
  *
  * Helper type extracting a string union of column names for a given table.
  */
-export type ColumnName<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> = keyof DB[TTable]['columns'] & string
+export type ColumnName<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> = keyof DB[TTable]['columns'] & string
 // Named row alias to improve IDE hover readability
 export type SelectedRow<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   _TTable extends keyof DB & string,
   TSelected,
 > = Readonly<TSelected>
 
-type PrimaryKeyValue<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> =
+type PrimaryKeyValue<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> =
   DB[TTable]['primaryKey'] extends keyof DB[TTable]['columns']
     ? DB[TTable]['columns'][DB[TTable]['primaryKey']]
     : unknown
@@ -545,7 +545,7 @@ type NumericColumnName<Columns> = {
     : Exclude<Columns[K], null | undefined> extends number ? K : never
 }[keyof Columns & string]
 
-type JoinColumn<DB extends DatabaseSchema<any>, TTables extends string> = TTables extends any
+type JoinColumn<DB extends AnyDatabaseSchema, TTables extends string> = TTables extends any
   ? `${TTables}.${keyof DB[TTables]['columns'] & string}`
   : never
 
@@ -559,13 +559,13 @@ type JoinColumn<DB extends DatabaseSchema<any>, TTables extends string> = TTable
  * untyped schemas keep compiling. A table that declares ZERO relations
  * yields `never` — every relation name is rejected.
  */
-export type TableRelationName<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> =
+export type TableRelationName<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> =
   DB[TTable] extends { relations?: infer R }
     ? unknown extends R ? string : keyof NonNullable<R> & string
     : string
 
 type RelatedTableName<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TRelation extends TableRelationName<DB, TTable>,
 > = DB[TTable] extends { relations?: infer Relations }
@@ -575,7 +575,7 @@ type RelatedTableName<
   : keyof DB & string
 
 type RelationQueryBuilder<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TRelation extends TableRelationName<DB, TTable>,
 > = SelectQueryBuilder<
@@ -584,7 +584,7 @@ type RelationQueryBuilder<
   DB[RelatedTableName<DB, TTable, TRelation>]['columns']
 >
 
-type RelationConstraintRecord<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> = {
+type RelationConstraintRecord<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> = {
   [R in TableRelationName<DB, TTable>]: Partial<Record<R, (qb: RelationQueryBuilder<DB, TTable, R>) => unknown>>
 }[TableRelationName<DB, TTable>]
 
@@ -597,7 +597,7 @@ type RelationConstraintRecord<DB extends DatabaseSchema<any>, TTable extends key
  * relations accepts nothing (the bare `Partial<Record<never, ...>>` would be
  * `{}`, which strings are assignable to — hence the explicit never guard).
  */
-export type WithRelationArg<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> =
+export type WithRelationArg<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> =
   [TableRelationName<DB, TTable>] extends [never]
     ? never
     :
@@ -614,7 +614,7 @@ type SnakeToPascal<S extends string> = S extends `${infer H}_${infer T}`
 // thread a phantom TSql string through method signatures so hovers can show the
 // composed SQL at compile-time for common operations.
 type _TypedDynamicWhereMethods<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TSelected,
   TJoined extends string,
@@ -639,7 +639,7 @@ type _TypedDynamicWhereMethods<
 // resolution, silently downgrading `toSQL()` from the composed literal SQL
 // type back to `string` after any dynamic-where call.
 export type TypedSelectQueryBuilder<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TSelected,
   TJoined extends string = TTable,
@@ -685,7 +685,7 @@ export type TypedSelectQueryBuilder<
 }
 
 type DynamicWhereMethods<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TSelected,
   TJoined extends string = TTable,
@@ -698,7 +698,7 @@ type DynamicWhereMethods<
 }
 
 export interface BaseSelectQueryBuilder<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TSelected,
   TJoined extends string = TTable,
@@ -926,7 +926,7 @@ export interface BaseSelectQueryBuilder<
   /** OR-connected counterpart of `whereNotNull`. */
   orWhereNotNull: (column: keyof DB[TTable]['columns'] & string) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
   /** OR-connected counterpart of `whereBetween`. */
-  orWhereBetween: (column: keyof DB[TTable]['columns'] & string, start: any, end: any) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
+  orWhereBetween: <K extends keyof DB[TTable]['columns'] & string>(column: K, start: DB[TTable]['columns'][K], end: DB[TTable]['columns'][K]) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
   /** OR-connected counterpart of `whereExists`. */
   orWhereExists: (subquery: { toSQL: () => any }) => SelectQueryBuilder<DB, TTable, TSelected, TJoined>
   /**
@@ -1906,13 +1906,13 @@ export interface BaseSelectQueryBuilder<
 }
 
 export type SelectQueryBuilder<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TSelected,
   TJoined extends string = TTable,
 > = BaseSelectQueryBuilder<DB, TTable, TSelected, TJoined> & DynamicWhereMethods<DB, TTable, TSelected, TJoined>
 
-export interface InsertQueryBuilder<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> {
+export interface InsertQueryBuilder<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> {
   /**
    * # `values`
    *
@@ -1965,7 +1965,7 @@ export interface InsertQueryBuilder<DB extends DatabaseSchema<any>, TTable exten
   executeTakeFirstOrThrow: () => Promise<DB[TTable]['columns']>
 }
 
-export interface UpdateQueryBuilder<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> {
+export interface UpdateQueryBuilder<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> {
   /**
    * # `set`
    *
@@ -2064,7 +2064,7 @@ export interface UpdateQueryBuilder<DB extends DatabaseSchema<any>, TTable exten
   executeTakeFirstOrThrow: () => Promise<{ numUpdatedRows: number }>
 }
 
-export interface DeleteQueryBuilder<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> {
+export interface DeleteQueryBuilder<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> {
   /**
    * # `where`
    *
@@ -2144,7 +2144,7 @@ export interface DeleteQueryBuilder<DB extends DatabaseSchema<any>, TTable exten
   executeTakeFirstOrThrow: () => Promise<{ numDeletedRows: number }>
 }
 
-export interface TableQueryBuilder<DB extends DatabaseSchema<any>, TTable extends keyof DB & string> {
+export interface TableQueryBuilder<DB extends AnyDatabaseSchema, TTable extends keyof DB & string> {
   /**
    * # `insert`
    *
@@ -2192,7 +2192,7 @@ export interface TableQueryBuilder<DB extends DatabaseSchema<any>, TTable extend
   select: <K extends keyof DB[TTable]['columns'] & string>(...columns: K[]) => SelectQueryBuilder<DB, TTable, Pick<DB[TTable]['columns'], K>>
 }
 
-export interface QueryBuilder<DB extends DatabaseSchema<any>> {
+export interface QueryBuilder<DB extends AnyDatabaseSchema> {
   // typed select list (column names or raw aliases)
   /**
    * # `select`
@@ -2660,7 +2660,7 @@ finally { reserved.release() }
 
 // Typed INSERT builder to expose a structured SQL literal in hovers
 export type TypedInsertQueryBuilder<
-  DB extends DatabaseSchema<any>,
+  DB extends AnyDatabaseSchema,
   TTable extends keyof DB & string,
   TSql extends string = `INSERT INTO ${TTable}`,
 > = Omit<InsertQueryBuilder<DB, TTable>, 'toSQL' | 'values' | 'returning'> & {
@@ -2680,9 +2680,10 @@ export type TypedInsertQueryBuilder<
 }
 
 interface InternalState {
-  sql: any
+  /** The driver handle - Bun's `SQL` or our SQLite wrapper, both `DriverConnection`. */
+  sql: DriverConnection
   meta?: SchemaMeta
-  schema?: any
+  schema?: AnyDatabaseSchema
   txDefaults?: TransactionOptions
   /**
    * Lifecycle hooks for this builder specifically.
@@ -2725,11 +2726,11 @@ function isRetriableTxError(err: any): boolean {
 
 type TransactionIsolation = 'read committed' | 'repeatable read' | 'serializable'
 interface TxBackoff { baseMs?: number, maxMs?: number, factor?: number, jitter?: boolean }
-interface TxLoggerEvent { type: 'start' | 'retry' | 'commit' | 'rollback' | 'error', attempt: number, error?: any, durationMs?: number }
+interface TxLoggerEvent { type: 'start' | 'retry' | 'commit' | 'rollback' | 'error', attempt: number, error?: unknown, durationMs?: number }
 export interface TransactionOptions {
   retries?: number
   isolation?: TransactionIsolation
-  onRetry?: (attempt: number, error: any) => void
+  onRetry?: (attempt: number, error: unknown) => void
   afterCommit?: () => void
   sqlStates?: string[]
   backoff?: TxBackoff
@@ -2737,7 +2738,7 @@ export interface TransactionOptions {
   /** When true, executes transaction in read-only mode (where supported). */
   readOnly?: boolean
   /** Called when a transaction is rolled back. */
-  onRollback?: (error: any) => void
+  onRollback?: (error: unknown) => void
   /** Called after rollback completes. */
   afterRollback?: () => void
 }
@@ -2903,7 +2904,7 @@ function computeBackoffMs(attempt: number, cfg?: TxBackoff): number {
 }
 
 // eslint-disable-next-line pickier/no-unused-vars
-export function createQueryBuilder<DB extends DatabaseSchema<any>>(state?: Partial<InternalState>): QueryBuilder<DB> {
+export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial<InternalState>): QueryBuilder<DB> {
   // Single boundary cast: `state.sql` is `any` (allows mock/tx injection) and
   // getOrCreateBunSql() returns Bun's `SQL`; both satisfy DriverConnection. With
   // `_sql` typed, the downstream `.unsafe(...)` calls no longer need casts (#1044).

--- a/packages/bun-query-builder/src/db.ts
+++ b/packages/bun-query-builder/src/db.ts
@@ -1,4 +1,5 @@
 import type { DatabaseConfig, PoolConfig, SupportedDialect } from './types'
+import type { SQLQueryBindings } from 'bun:sqlite'
 import { SQL } from 'bun'
 
 /**
@@ -6,6 +7,42 @@ import { SQL } from 'bun'
  * Both Bun's native `SQL` query and our `createSQLiteSQL` wrapper satisfy this.
  * See stacksjs/bun-query-builder#1044.
  */
+/**
+ * What a value interpolated into a tagged template can turn out to be.
+ *
+ * Three things arrive here: a plain bind param, a nested query (carries `sql`
+ * plus a `values` ARRAY), and a raw-SQL marker (carries `__raw`/`raw` and no
+ * `values`). Naming the shape is what lets the branches below read properties
+ * without an `any` - and the order of those branches is load-bearing, see
+ * stacksjs/bun-query-builder#1084.
+ */
+export interface EmbeddedValue {
+  sql?: unknown
+  values?: unknown
+  __raw?: unknown
+  raw?: unknown
+  value?: unknown
+}
+
+/**
+ * The one place user values become driver bindings.
+ *
+ * Everything a caller interpolates arrives as `unknown` - that is honest, we
+ * do not know what it is. bun:sqlite accepts a narrower set. The conversion is
+ * unchecked because the driver itself is the validator: it throws a clear
+ * "can't bind" for anything it cannot take, and a check here would only
+ * duplicate that rule and drift from it. Kept as one named function so the
+ * boundary is visible, rather than an `any` at each of the six call sites.
+ */
+export function toBindings(params: readonly unknown[]): SQLQueryBindings[] {
+  return params as SQLQueryBindings[]
+}
+
+/** A template value seen as a possible fragment; null when it is a plain bind param. */
+export function asEmbeddedValue(value: unknown): EmbeddedValue | null {
+  return value !== null && typeof value === 'object' ? value as EmbeddedValue : null
+}
+
 export interface DriverQuery {
   execute: () => Promise<any>
   values?: () => any
@@ -30,11 +67,11 @@ export type AwaitableDriverQuery = DriverQuery & PromiseLike<any>
  */
 export interface DriverConnection {
   /** Tagged-template form: `` sql`SELECT 1` ``. */
-  (strings: TemplateStringsArray, ...values: any[]): DriverQuery
+  (strings: TemplateStringsArray, ...values: unknown[]): DriverQuery
   /** Function form for raw identifiers / value helpers: `sql('col')`. */
   (value: any): any
-  unsafe: (sql: string, values?: any[]) => AwaitableDriverQuery
-  query?: (sql: string, params?: any[]) => any
+  unsafe: (sql: string, values?: unknown[]) => AwaitableDriverQuery
+  query?: (sql: string, params?: unknown[]) => any
   close?: () => Promise<void> | void
   _prepareStatement?: (sql: string) => any
   [key: string]: any
@@ -74,11 +111,11 @@ import { applySqliteBootstrapPragmas } from './sqlite-pragmas'
  * numbered placeholders is returned untouched, so `?` queries and Bun's own
  * tagged-template output are unaffected.
  */
-export function bindNumberedPlaceholders(sql: string, params: any[]): { sql: string, params: any[] } {
+export function bindNumberedPlaceholders<T>(sql: string, params: T[]): { sql: string, params: T[] } {
   if (params.length === 0 || !/\$\d/.test(sql))
     return { sql, params }
 
-  const out: any[] = []
+  const out: T[] = []
   let rewritten = ''
   let highest = 0
 
@@ -185,7 +222,7 @@ class SQLiteWrapper {
    * Execute a query with parameters and return results.
    * This mimics the SQL tagged template literal behavior.
    */
-  query(sql: string, params: any[] = []): any[] {
+  query(sql: string, params: SQLQueryBindings[] = []): any[] {
     const bound = bindNumberedPlaceholders(sql, params)
     const stmt = this.db.prepare(bound.sql)
     return stmt.all(...bound.params)
@@ -194,7 +231,7 @@ class SQLiteWrapper {
   /**
    * Execute a query that doesn't return results (INSERT, UPDATE, DELETE).
    */
-  run(sql: string, params: any[] = []): any {
+  run(sql: string, params: SQLQueryBindings[] = []): any {
     const bound = bindNumberedPlaceholders(sql, params)
     const stmt = this.db.prepare(bound.sql)
     return stmt.run(...bound.params)
@@ -364,10 +401,10 @@ function createSQLiteSQL(filename: string): SQL {
   /**
    * Process a tagged template literal and return a query object
    */
-  function processTaggedTemplate(strings: TemplateStringsArray, ...values: any[]): any {
+  function processTaggedTemplate(strings: TemplateStringsArray, ...values: unknown[]): any {
     // Build the SQL string with placeholders
     let sql = strings[0]
-    const params: any[] = []
+    const params: unknown[] = []
 
     for (let i = 0; i < values.length; i++) {
       const value = values[i]
@@ -396,13 +433,16 @@ function createSQLiteSQL(filename: string): SQL {
       // The discriminator is `values` being an ARRAY: raw markers carry
       // `__raw` and no `values`, and Bun's native query objects expose `values`
       // as a method, so neither is captured here.
-      if (value && typeof value === 'object' && typeof value.sql === 'string' && Array.isArray(value.values)) {
-        sql += value.sql + (strings[i + 1] || '')
-        params.push(...value.values)
+      const embedded = asEmbeddedValue(value)
+
+      if (embedded && typeof embedded.sql === 'string' && Array.isArray(embedded.values)) {
+        sql += embedded.sql + (strings[i + 1] || '')
+        params.push(...embedded.values)
       }
       // Handle raw SQL markers (from sql('identifier') or sql.raw())
-      else if (value && typeof value === 'object' && (value.__raw || value.raw)) {
-        const rawValue = value.__raw ? value.value : (typeof value.raw === 'string' ? value.raw : value.raw())
+      else if (embedded && (embedded.__raw || embedded.raw)) {
+        const raw = embedded.raw
+        const rawValue = embedded.__raw ? embedded.value : (typeof raw === 'string' ? raw : (raw as () => string)())
         sql += rawValue + (strings[i + 1] || '')
       }
       // Handle arrays - expand to placeholders
@@ -432,11 +472,11 @@ function createSQLiteSQL(filename: string): SQL {
           // caller silently loses its data.
           const trimmed = sql.trim().toUpperCase()
           if (trimmed.startsWith('SELECT') || trimmed.startsWith('PRAGMA') || /\bRETURNING\b/.test(trimmed)) {
-            const result = wrapper.query(sql, params)
+            const result = wrapper.query(sql, toBindings(params))
             return Promise.resolve(result)
           }
           else {
-            const result = wrapper.run(sql, params)
+            const result = wrapper.run(sql, toBindings(params))
             return Promise.resolve(result)
           }
         }
@@ -455,7 +495,7 @@ function createSQLiteSQL(filename: string): SQL {
    * - Tagged template literals: sql`SELECT * FROM users`
    * - Function calls for raw identifiers: sql('column_name')
    */
-  function sqlFunction(stringsOrValue: TemplateStringsArray | string, ...values: any[]): any {
+  function sqlFunction(stringsOrValue: TemplateStringsArray | string, ...values: unknown[]): any {
     // If called with a template literal (array of strings)
     if (Array.isArray(stringsOrValue) && 'raw' in stringsOrValue) {
       return processTaggedTemplate(stringsOrValue as TemplateStringsArray, ...values)
@@ -475,7 +515,7 @@ function createSQLiteSQL(filename: string): SQL {
   sqlFunction.raw = (str: string) => createRawMarker(str)
 
   // Add .unsafe() method for raw SQL with parameters (like Bun's SQL.unsafe)
-  sqlFunction.unsafe = (sql: string, params: any[] = []) => {
+  sqlFunction.unsafe = (sql: string, params: unknown[] = []) => {
     const execute = (): Promise<any> => {
       try {
         // A RETURNING clause turns an INSERT/UPDATE/DELETE into a row producer;
@@ -483,11 +523,11 @@ function createSQLiteSQL(filename: string): SQL {
         // `.run()`'s { changes, lastInsertRowid }. See the tagged-template path.
         const trimmed = sql.trim().toUpperCase()
         if (trimmed.startsWith('SELECT') || trimmed.startsWith('PRAGMA') || /\bRETURNING\b/.test(trimmed)) {
-          const result = wrapper.query(sql, params)
+          const result = wrapper.query(sql, toBindings(params))
           return Promise.resolve(result)
         }
         else {
-          const result = wrapper.run(sql, params)
+          const result = wrapper.run(sql, toBindings(params))
           return Promise.resolve(result)
         }
       }
@@ -522,9 +562,9 @@ function createSQLiteSQL(filename: string): SQL {
   }
 
   // Add .query() method for direct SQL execution
-  sqlFunction.query = (sql: string, params?: any[]) => {
+  sqlFunction.query = (sql: string, params?: unknown[]) => {
     try {
-      const result = wrapper.query(sql, params || [])
+      const result = wrapper.query(sql, toBindings(params || []))
       return Promise.resolve(result)
     }
     catch (error) {
@@ -533,7 +573,7 @@ function createSQLiteSQL(filename: string): SQL {
   }
 
   // Add .file() method for executing SQL from a file
-  sqlFunction.file = async (filePath: string, _params?: any[]) => {
+  sqlFunction.file = async (filePath: string, _params?: unknown[]) => {
     try {
       const { readFileSync } = await import('node:fs')
       const sqlContent = readFileSync(filePath, 'utf-8')

--- a/packages/bun-query-builder/src/dynamodb-client.ts
+++ b/packages/bun-query-builder/src/dynamodb-client.ts
@@ -24,12 +24,57 @@ import type {
 import { createDynamoDBDriver } from './drivers/dynamodb'
 
 /**
+ * A value DynamoDB can store or compare against.
+ *
+ * DynamoDB's type system is small and closed - scalars, binary, lists and
+ * maps - so the attribute surface below says that rather than `any`. A value
+ * outside this set could never have round-tripped through the wire format.
+ */
+export type DynamoDBValue =
+  | string
+  | number
+  | boolean
+  | null
+  | Uint8Array
+  | DynamoDBValue[]
+  | { [key: string]: DynamoDBValue }
+
+/**
+ * The AWS SDK client, described by the one method this package uses.
+ *
+ * `@aws-sdk/client-dynamodb` is not a dependency (callers bring their own),
+ * so the shape is structural: anything with a `send` satisfies it, including
+ * the real `DynamoDBClient` and a test double.
+ */
+export interface DynamoDBClientLike {
+  send: (command: unknown) => Promise<unknown>
+  [key: string]: unknown
+}
+
+/** What DynamoDB reports about the capacity a call consumed. */
+export interface DynamoDBConsumedCapacity {
+  TableName?: string
+  CapacityUnits?: number
+  ReadCapacityUnits?: number
+  WriteCapacityUnits?: number
+  [key: string]: unknown
+}
+
+/** Every operator a DynamoDB filter expression accepts. */
+export type DynamoDBFilterOperator =
+  | DynamoDBComparisonOperator
+  | 'contains'
+  | 'attribute_exists'
+  | 'attribute_not_exists'
+  | 'IN'
+
+/**
  * DynamoDB Query Builder Options
  */
 export interface DynamoDBQueryBuilderOptions {
   config: DynamoDBConfig
   /** Optional DynamoDB client instance (e.g., from @aws-sdk/client-dynamodb) */
-  client?: any
+  client?: DynamoDBClientLike
 }
 
 /**
@@ -41,7 +86,7 @@ export interface DynamoDBResult<T = any> {
   count?: number
   scannedCount?: number
   lastEvaluatedKey?: Record<string, any>
-  consumedCapacity?: any
+  consumedCapacity?: DynamoDBConsumedCapacity
 }
 
 /**
@@ -97,7 +142,7 @@ export class DynamoDBQueryBuilder<T = any> {
    * Add a key condition (for Query operations)
    * Key conditions can only be applied to partition key and sort key
    */
-  whereKey(attribute: string, operator: DynamoDBComparisonOperator, value: any): this {
+  whereKey(attribute: string, operator: DynamoDBComparisonOperator, value: DynamoDBValue): this {
     this.keyConditions.push({ attribute, operator, value })
     return this
   }
@@ -105,14 +150,14 @@ export class DynamoDBQueryBuilder<T = any> {
   /**
    * Shorthand for partition key equals
    */
-  wherePartitionKey(attribute: string, value: any): this {
+  wherePartitionKey(attribute: string, value: DynamoDBValue): this {
     return this.whereKey(attribute, '=', value)
   }
 
   /**
    * Shorthand for sort key equals
    */
-  whereSortKey(attribute: string, value: any): this {
+  whereSortKey(attribute: string, value: DynamoDBValue): this {
     return this.whereKey(attribute, '=', value)
   }
 
@@ -127,7 +172,7 @@ export class DynamoDBQueryBuilder<T = any> {
   /**
    * Sort key between two values
    */
-  whereSortKeyBetween(attribute: string, start: any, end: any): this {
+  whereSortKeyBetween(attribute: string, start: DynamoDBValue, end: DynamoDBValue): this {
     this.keyConditions.push({ attribute, operator: 'BETWEEN', values: [start, end] })
     return this
   }
@@ -135,7 +180,7 @@ export class DynamoDBQueryBuilder<T = any> {
   /**
    * Add a filter condition (applied after Query/Scan)
    */
-  where(attribute: string, operator: DynamoDBComparisonOperator | 'contains' | 'attribute_exists' | 'attribute_not_exists' | 'IN', value?: any): this {
+  where(attribute: string, operator: DynamoDBFilterOperator, value?: DynamoDBValue): this {
     this.filterConditions.push({ attribute, operator, value })
     return this
   }
@@ -143,42 +188,42 @@ export class DynamoDBQueryBuilder<T = any> {
   /**
    * Filter where attribute equals value
    */
-  whereEquals(attribute: string, value: any): this {
+  whereEquals(attribute: string, value: DynamoDBValue): this {
     return this.where(attribute, '=', value)
   }
 
   /**
    * Filter where attribute is less than value
    */
-  whereLessThan(attribute: string, value: any): this {
+  whereLessThan(attribute: string, value: DynamoDBValue): this {
     return this.where(attribute, '<', value)
   }
 
   /**
    * Filter where attribute is less than or equal to value
    */
-  whereLessThanOrEqual(attribute: string, value: any): this {
+  whereLessThanOrEqual(attribute: string, value: DynamoDBValue): this {
     return this.where(attribute, '<=', value)
   }
 
   /**
    * Filter where attribute is greater than value
    */
-  whereGreaterThan(attribute: string, value: any): this {
+  whereGreaterThan(attribute: string, value: DynamoDBValue): this {
     return this.where(attribute, '>', value)
   }
 
   /**
    * Filter where attribute is greater than or equal to value
    */
-  whereGreaterThanOrEqual(attribute: string, value: any): this {
+  whereGreaterThanOrEqual(attribute: string, value: DynamoDBValue): this {
     return this.where(attribute, '>=', value)
   }
 
   /**
    * Filter where attribute is between two values
    */
-  whereBetween(attribute: string, start: any, end: any): this {
+  whereBetween(attribute: string, start: DynamoDBValue, end: DynamoDBValue): this {
     this.filterConditions.push({ attribute, operator: 'BETWEEN', values: [start, end] })
     return this
   }
@@ -194,7 +239,7 @@ export class DynamoDBQueryBuilder<T = any> {
   /**
    * Filter where attribute contains value (for strings and sets)
    */
-  whereContains(attribute: string, value: any): this {
+  whereContains(attribute: string, value: DynamoDBValue): this {
     return this.where(attribute, 'contains', value)
   }
 
@@ -215,7 +260,7 @@ export class DynamoDBQueryBuilder<T = any> {
   /**
    * Filter where attribute is in a list of values
    */
-  whereIn(attribute: string, values: any[]): this {
+  whereIn(attribute: string, values: DynamoDBValue[]): this {
     this.filterConditions.push({ attribute, operator: 'IN', values })
     return this
   }
@@ -633,7 +678,7 @@ export class DynamoDBItemBuilder<T = any> {
   /**
    * Set attribute value (for Update)
    */
-  set(attribute: string, value: any): this {
+  set(attribute: string, value: DynamoDBValue): this {
     if (!this.updateExpressions.set) {
       this.updateExpressions.set = {}
     }
@@ -666,7 +711,7 @@ export class DynamoDBItemBuilder<T = any> {
   /**
    * Add to a number or set (for Update)
    */
-  add(attribute: string, value: any): this {
+  add(attribute: string, value: DynamoDBValue): this {
     if (!this.updateExpressions.add) {
       this.updateExpressions.add = {}
     }
@@ -677,7 +722,7 @@ export class DynamoDBItemBuilder<T = any> {
   /**
    * Delete from a set (for Update)
    */
-  deleteFromSet(attribute: string, values: any): this {
+  deleteFromSet(attribute: string, values: DynamoDBValue): this {
     if (!this.updateExpressions.delete) {
       this.updateExpressions.delete = {}
     }

--- a/packages/bun-query-builder/src/dynamodb-single-table.ts
+++ b/packages/bun-query-builder/src/dynamodb-single-table.ts
@@ -20,7 +20,7 @@ import type {
   SingleTableEntityMapping,
 } from './drivers/dynamodb'
 import { createDynamoDBDriver } from './drivers/dynamodb'
-import type { DynamoDBQueryBuilderOptions } from './dynamodb-client'
+import type { DynamoDBFilterOperator, DynamoDBQueryBuilderOptions, DynamoDBValue } from './dynamodb-client'
 import { DynamoDBItemBuilder, DynamoDBQueryBuilder } from './dynamodb-client'
 
 /**
@@ -498,7 +498,7 @@ export class SingleTableQueryBuilder<T> {
   /**
    * Add a filter condition
    */
-  where(attribute: string, operator: any, value?: any): this {
+  where(attribute: string, operator: DynamoDBFilterOperator, value?: DynamoDBValue): this {
     this.builder.where(attribute, operator, value)
     return this
   }

--- a/packages/bun-query-builder/src/dynamodb-tooling-adapter.ts
+++ b/packages/bun-query-builder/src/dynamodb-tooling-adapter.ts
@@ -41,7 +41,7 @@ export interface ParsedAttribute {
   nullable: boolean
   unique: boolean
   hidden: boolean
-  defaultValue?: any
+  defaultValue?: unknown
   cast?: string
   dynamoDbType: 'S' | 'N' | 'B' | 'BOOL' | 'NULL' | 'M' | 'L' | 'SS' | 'NS' | 'BS'
 }
@@ -109,7 +109,7 @@ export interface StacksModel {
     nullable?: boolean
     unique?: boolean
     hidden?: boolean
-    default?: any
+    default?: unknown
     cast?: string
     validation?: { rule?: string }
   }>
@@ -150,7 +150,7 @@ export function resolveKeyPattern(keyPatterns: KeyPatterns, data: Record<string,
 /**
  * Parse models from configuration (stub implementation)
  */
-export async function parseStacksModels(_config: any): Promise<{ models: Map<string, ParsedModel> }> {
+export async function parseStacksModels(_config: unknown): Promise<{ models: Map<string, ParsedModel> }> {
   // This is a stub - actual implementation would parse model files
   return { models: new Map() }
 }
@@ -186,8 +186,8 @@ export function unmarshallItem(item: Record<string, any>): Record<string, any> {
 // ============================================================================
 // Imports from bun-query-builder (fluent API layer)
 // ============================================================================
-import type { DynamoDBConfig, DynamoDBDriver, SingleTableEntityMapping } from './drivers/dynamodb'
-import type { DynamoDBQueryBuilderOptions } from './dynamodb-client'
+import type { DynamoDBConfig, DynamoDBDriver, DynamoDBTableDefinition, SingleTableEntityMapping } from './drivers/dynamodb'
+import type { DynamoDBClientLike, DynamoDBQueryBuilderOptions } from './dynamodb-client'
 import type { SingleTableConfig, SingleTableEntity } from './dynamodb-single-table'
 import { createDynamoDBDriver } from './drivers/dynamodb'
 import { DynamoDBItemBuilder, DynamoDBQueryBuilder } from './dynamodb-client'
@@ -282,7 +282,7 @@ export class DynamoDBToolingAdapter {
   /**
    * Set the DynamoDB client instance
    */
-  setClient(client: any): this {
+  setClient(client: DynamoDBClientLike): this {
     this.queryBuilderOptions.client = client
     return this
   }
@@ -498,7 +498,7 @@ export class DynamoDBToolingAdapter {
   /**
    * Generate table definition for all registered models
    */
-  generateTableDefinition(): any {
+  generateTableDefinition(): DynamoDBTableDefinition {
     return this.singleTableManager.generateTableDefinition()
   }
 

--- a/packages/bun-query-builder/src/meta.ts
+++ b/packages/bun-query-builder/src/meta.ts
@@ -24,7 +24,15 @@ export interface SchemaMeta {
     morphToMany?: Record<string, string>
     morphedByMany?: Record<string, string>
   }>
-  scopes?: Record<string, Record<string, (qb: any, value?: any) => any>>
+  /**
+   * Named query scopes, keyed by model then by scope name.
+   *
+   * The builder parameter stays `any`: a scope receives the fully-typed
+   * builder for its own model, which this erased metadata table cannot name
+   * without making every model's scopes mutually unassignable. The value and
+   * the return are `unknown`, so nothing downstream inherits the looseness.
+   */
+  scopes?: Record<string, Record<string, (qb: any, value?: unknown) => unknown>>
   /**
    * Original models record passed to `buildSchemaMeta`, retained so downstream
    * consumers (e.g. the pivot resolver) can read through-model attributes

--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -286,8 +286,8 @@ export interface ModelDefinition {
   readonly attributes: {
     readonly [key: string]: TypedAttribute<unknown>
   }
-  readonly get?: Record<string, (attributes: any) => unknown>
-  readonly set?: Record<string, (attributes: any) => unknown>
+  readonly get?: Record<string, (attributes: Record<string, unknown>) => unknown>
+  readonly set?: Record<string, (attributes: Record<string, unknown>) => unknown>
   readonly scopes?: Record<string, (value: unknown) => unknown>
   readonly indexes?: readonly object[]
   readonly dashboard?: { readonly enabled?: boolean; readonly highlight?: boolean | number }
@@ -617,7 +617,29 @@ function toPostgresPlaceholders(sql: string): string {
  * fallback (which would be 0) — see stacksjs/bun-query-builder#1032. MySQL
  * surfaces `affectedRows` instead.
  */
-export function extractChanges(res: any): number {
+/**
+ * What a driver hands back after a write.
+ *
+ * Each one reports the affected count under its own name - and Postgres
+ * returns an empty array carrying `count`, so the shape is genuinely a union
+ * rather than one thing. Naming the fields beats `any`: a caller reading this
+ * type learns which drivers report what.
+ */
+export interface WriteResultLike {
+  /** MySQL. */
+  affectedRows?: number
+  /** Postgres command tag. */
+  count?: number
+  /** SQLite (bun:sqlite). */
+  changes?: number
+  lastInsertRowid?: number | bigint
+  insertId?: number | bigint
+  command?: string
+  rows?: unknown[]
+  [key: string]: unknown
+}
+
+export function extractChanges(res: WriteResultLike | null | undefined): number {
   if (res == null)
     return 0
   if (typeof res.affectedRows === 'number') // MySQL
@@ -630,7 +652,7 @@ export function extractChanges(res: any): number {
 }
 
 /** Extract a generated primary key from a Bun SQL driver result. */
-export function extractInsertId(res: any): number | bigint | null {
+export function extractInsertId(res: WriteResultLike | null | undefined): number | bigint | null {
   if (res == null || typeof res !== 'object')
     return null
   if ('insertId' in res && res.insertId != null) // MySQL

--- a/packages/bun-query-builder/src/schema.ts
+++ b/packages/bun-query-builder/src/schema.ts
@@ -221,14 +221,23 @@ export interface ModelOptions extends Base {
   morphTo?: MorphTo
   morphToMany?: MorphToMany<ModelNames>
   morphedByMany?: MorphedByMany<ModelNames>
+  /**
+   * Scopes, accessors and mutators a model declares.
+   *
+   * The parameter stays `any` on purpose. A real model writes
+   * `get: { name: (value: string) => value.toUpperCase() }`, and under
+   * `strictFunctionTypes` that is NOT assignable to `(value: unknown) => ...`
+   * - narrowing here would reject every correctly-written model. The RETURN
+   * is `unknown`, so nothing downstream inherits the looseness.
+   */
   scopes?: {
-    [key: string]: (value: any) => any
+    [key: string]: (value: any) => unknown
   }
   get?: {
-    [key: string]: (value: any) => any
+    [key: string]: (value: any) => unknown
   }
   set?: {
-    [key: string]: (value: any) => any
+    [key: string]: (value: any) => unknown
   }
 }
 
@@ -410,6 +419,22 @@ export type InferTableRelations<M, MRecord extends ModelRecord> = {
  * type Schema = DatabaseSchema<typeof models>
  * ```
  */
+/**
+ * Any database schema, described by its shape rather than by `any`.
+ *
+ * Generic constraints throughout the client read `DB extends DatabaseSchema<any>`,
+ * which says "a schema of anything" and drags `any` into every published
+ * signature that mentions one. This says the same thing accurately: a schema
+ * is tables, each with columns, a primary key, and optionally relations.
+ */
+export interface AnySchemaTable {
+  columns: Record<string, unknown>
+  primaryKey?: unknown
+  relations?: Record<string, string> | undefined
+}
+
+export type AnyDatabaseSchema = Record<string, AnySchemaTable>
+
 export type DatabaseSchema<MRecord extends ModelRecord> = {
   [MName in keyof MRecord & string as InferTableName<UnwrapModelDefinition<MRecord[MName]>>]: {
     columns: InferAttributes<UnwrapModelDefinition<MRecord[MName]>>

--- a/packages/bun-query-builder/src/seeder.ts
+++ b/packages/bun-query-builder/src/seeder.ts
@@ -1,4 +1,15 @@
 /**
+ * The query builder handed to a seeder.
+ *
+ * A seeder is written against the app's own schema, which this base class
+ * cannot know, so the handle stays `any` deliberately - narrowing it here
+ * would reject every real seeder's typed table access. Named rather than
+ * inline so the reason travels with it.
+ */
+// eslint-disable-next-line ts/no-explicit-any
+export type SeederQueryBuilder = any
+
+/**
  * Base seeder class that all seeders should extend.
  * Provides access to query builder and faker for generating test data.
  */
@@ -9,7 +20,7 @@ export abstract class Seeder {
    *
    * @param qb - The query builder instance to use for database operations
    */
-  abstract run(qb: any): Promise<void>
+  abstract run(qb: SeederQueryBuilder): Promise<void>
 
   /**
    * Optional method to specify the order in which seeders should run.

--- a/packages/bun-query-builder/src/sql-fragments.ts
+++ b/packages/bun-query-builder/src/sql-fragments.ts
@@ -93,7 +93,7 @@ export function renderWhereTerms(terms: readonly WhereTerm[]): string {
  * happened to come back empty — the same shape of silent, widening-or-narrowing
  * failure as the `IN ()` bug itself.
  */
-export function renderInPredicate(column: string, values: any[], negated: boolean, placeholders: string): string {
+export function renderInPredicate(column: string, values: readonly unknown[], negated: boolean, placeholders: string): string {
   if (values.length === 0)
     return negated ? TRUE_PREDICATE : FALSE_PREDICATE
   return `${column} ${negated ? 'NOT IN' : 'IN'} (${placeholders})`

--- a/packages/bun-query-builder/src/types.ts
+++ b/packages/bun-query-builder/src/types.ts
@@ -240,15 +240,34 @@ export interface SqlConfig {
  * Optional lifecycle hooks around query execution. These are invoked for any
  * statement executed through the builder (select/insert/update/delete/raw).
  */
+/** A bound statement parameter: whatever a driver will accept as a value. */
+export type QueryParam = string | number | bigint | boolean | Date | Uint8Array | null
+
+/** The kind of statement a hook is reporting on. */
+export type QueryKind = 'select' | 'insert' | 'update' | 'delete' | 'raw'
+
+/** The row shape a hook sees. Columns are unknown until the caller narrows. */
+export type QueryRecord = Record<string, unknown>
+
+/** A `where` description as the mutation hooks receive it. */
+export type QueryWhere = Record<string, unknown>
+
+/** Common fields on every query lifecycle event. */
+export interface QueryEvent {
+  sql: string
+  params?: QueryParam[]
+  kind?: QueryKind
+}
+
 export interface QueryHooks {
   /** Called right before a query executes. */
-  onQueryStart?: (event: { sql: string, params?: any[], kind?: 'select' | 'insert' | 'update' | 'delete' | 'raw' }) => void
+  onQueryStart?: (event: QueryEvent) => void
   /** Called after a query succeeds. */
-  onQueryEnd?: (event: { sql: string, params?: any[], durationMs: number, rowCount?: number, kind?: 'select' | 'insert' | 'update' | 'delete' | 'raw' }) => void
+  onQueryEnd?: (event: QueryEvent & { durationMs: number, rowCount?: number }) => void
   /** Called after a query fails. */
-  onQueryError?: (event: { sql: string, params?: any[], error: any, durationMs: number, kind?: 'select' | 'insert' | 'update' | 'delete' | 'raw' }) => void
+  onQueryError?: (event: QueryEvent & { error: unknown, durationMs: number }) => void
   /** Optional tracer integration. Return an object with end() to finish a span. */
-  startSpan?: (event: { sql: string, params?: any[], kind?: 'select' | 'insert' | 'update' | 'delete' | 'raw' }) => { end: (error?: any) => void }
+  startSpan?: (event: QueryEvent) => { end: (error?: unknown) => void }
   /**
    * When set, a query whose duration meets/exceeds this many milliseconds is
    * reported as slow (via `onSlowQuery`, or a `console.warn` if no handler is
@@ -256,19 +275,19 @@ export interface QueryHooks {
    */
   slowQueryThresholdMs?: number
   /** Called when a query's duration meets/exceeds `slowQueryThresholdMs`. */
-  onSlowQuery?: (event: { sql: string, params?: any[], durationMs: number, kind?: 'select' | 'insert' | 'update' | 'delete' | 'raw' }) => void
+  onSlowQuery?: (event: QueryEvent & { durationMs: number }) => void
   /** Called before creating a record. Can modify data or throw to prevent creation. */
-  beforeCreate?: (event: { table: string, data: any }) => void | Promise<void>
+  beforeCreate?: (event: { table: string, data: QueryRecord }) => void | Promise<void>
   /** Called after creating a record. */
-  afterCreate?: (event: { table: string, data: any, result: any }) => void | Promise<void>
+  afterCreate?: (event: { table: string, data: QueryRecord, result: unknown }) => void | Promise<void>
   /** Called before updating a record. Can modify data or throw to prevent update. */
-  beforeUpdate?: (event: { table: string, data: any, where?: any }) => void | Promise<void>
+  beforeUpdate?: (event: { table: string, data: QueryRecord, where?: QueryWhere }) => void | Promise<void>
   /** Called after updating a record. */
-  afterUpdate?: (event: { table: string, data: any, where?: any, result: any }) => void | Promise<void>
+  afterUpdate?: (event: { table: string, data: QueryRecord, where?: QueryWhere, result: unknown }) => void | Promise<void>
   /** Called before deleting a record. Can throw to prevent deletion. */
-  beforeDelete?: (event: { table: string, where?: any }) => void | Promise<void>
+  beforeDelete?: (event: { table: string, where?: QueryWhere }) => void | Promise<void>
   /** Called after deleting a record. */
-  afterDelete?: (event: { table: string, where?: any, result: any }) => void | Promise<void>
+  afterDelete?: (event: { table: string, where?: QueryWhere, result: unknown }) => void | Promise<void>
 }
 
 /**
@@ -362,7 +381,7 @@ export interface BrowserConfig {
   /** Request timeout in milliseconds (default: 30000) */
   timeout?: number
   /** Transform response data before returning (e.g., unwrap { data: [...] }) */
-  transformResponse?: <T>(response: any) => T
+  transformResponse?: <T>(response: unknown) => T
   /** Transform request data before sending */
   transformRequest?: <T>(data: T) => any
 }
@@ -483,7 +502,7 @@ export interface QueryBuilderConfig {
  *     signature is not a property. `keyof (() => void)` is `never`, so the
  *     hook collapses to an empty object type: no longer callable, and loose
  *     enough to accept `42`. It also erases type parameters, which would turn
- *     `BrowserConfig.transformResponse` (`<T>(response: any) => T`) into a
+ *     `BrowserConfig.transformResponse` (`<T>(response: unknown) => T`) into a
  *     shape with no signature at all. A hook or a token getter is a leaf.
  *
  *  2. ARRAYS SECOND, because the merge replaces them rather than merging them.
@@ -603,7 +622,8 @@ export interface GenerateMigrationResult {
   sql: string
   sqlStatements: string[]
   hasChanges: boolean
-  plan: any
+  /** The diff the SQL was generated from, as `migrations` describes it. */
+  plan: import('./migrations').MigrationPlan
   /**
    * Structured description of each change (drop/rename/modify/rebuild/...), so
    * callers can gate destructive ops and report renames without parsing SQL.

--- a/packages/bun-query-builder/test/public-surface-types.test.ts
+++ b/packages/bun-query-builder/test/public-surface-types.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * A guard on what the published types actually say.
+ *
+ * `any` in a `.d.ts` is not a local shortcut - it is a hole punched through
+ * every consumer's typechecker. An app that writes `db.selectFrom('users')`
+ * gets no help from the compiler if the builder it received was typed `any`
+ * three files upstream, and that is exactly how the ORM ended up reporting
+ * models as `any` in installed Stacks apps.
+ *
+ * So the count is pinned. The survivors are deliberate and each carries its
+ * reason in the source:
+ *
+ *  - driver escape hatches in `db.ts` (`execute(): Promise<any>`, the
+ *    `[key: string]: any` index signatures) - narrowing them would force a
+ *    cast at every `await sql.unsafe(...)` call site, which is the same hole
+ *    moved somewhere less visible
+ *  - `(...args: any[]) => any` in `DeepPartial` - the standard "is this a
+ *    function" idiom; `unknown[]` does not match under contravariance
+ *  - accessor/mutator parameters in `schema.ts` - a model's own
+ *    `(value: string) => ...` would be REJECTED against `unknown`
+ *  - the faker proxy's dynamic members
+ *
+ * Adding one means either a real justification in a comment next to it, or a
+ * better type. Raising this number without the former is the regression.
+ */
+
+const DIST = join(import.meta.dir, '..', 'dist')
+const BASELINE = 18
+
+function anyCount(source: string): number {
+  return (source.match(/:\s*any\b|<any>|any\[\]/g) ?? []).length
+}
+
+describe('the published type surface', () => {
+  it('does not leak more `any` than the documented survivors', () => {
+    if (!existsSync(DIST)) {
+      // Types are a build output; nothing to check before `bun run build`.
+      return
+    }
+
+    const declarations = readdirSync(DIST).filter(file => file.endsWith('.d.ts'))
+    expect(declarations.length).toBeGreaterThan(0)
+
+    const total = declarations.reduce(
+      (sum, file) => sum + anyCount(readFileSync(join(DIST, file), 'utf8')),
+      0,
+    )
+
+    expect(total).toBeLessThanOrEqual(BASELINE)
+  })
+
+  it('keeps the query builder itself free of them', () => {
+    if (!existsSync(join(DIST, 'client.d.ts')))
+      return
+
+    // client.d.ts is the type an app touches on every single query. It went
+    // from 29 to 0 by naming what a schema IS (`AnyDatabaseSchema`) instead
+    // of writing `DatabaseSchema<any>` in 21 generic constraints.
+    expect(anyCount(readFileSync(join(DIST, 'client.d.ts'), 'utf8'))).toBe(0)
+    expect(anyCount(readFileSync(join(DIST, 'orm.d.ts'), 'utf8'))).toBe(0)
+  })
+})


### PR DESCRIPTION
An `any` in a published `.d.ts` is not a local shortcut - it is a hole in every consumer's typechecker. An app writing `db.selectFrom('users')` got no help from the compiler because the builder it received had been typed `any` three files upstream. That is how installed Stacks apps ended up seeing their own models as `any`.

The published surface goes **91 -> 18**, and the two files an app touches on every query reach zero:

| file | before | after |
|---|---|---|
| `client.d.ts` | 29 | **0** |
| `orm.d.ts` | 4 | **0** |
| `dynamodb-client.d.ts` | 18 | 0 |
| `db.d.ts` | 11 | 7 |
| everything else | 29 | 11 |

## What replaced them

- **`AnyDatabaseSchema`** - 21 generic constraints read `DB extends DatabaseSchema<any>`, which says "a schema of anything" and dragged `any` into every signature mentioning one. A schema is tables, each with columns, a primary key and optional relations, so it now says that.
- **`DriverConnection`** for the internal `sql` handle, and **`EmbeddedValue` / `asEmbeddedValue`** for the three shapes a tagged-template value can take (bind param, nested query, raw marker) - so the branch that fixed #1084 reads properties without an `any`.
- **`toBindings`** - the single place user values become driver bindings. Unchecked on purpose (bun:sqlite is the validator and throws a clear "can't bind"), but named once instead of an `any` at six call sites.
- **`DynamoDBValue` / `DynamoDBClientLike` / `DynamoDBFilterOperator` / `DynamoDBConsumedCapacity`** - DynamoDB's type system is small and closed, so the fluent surface can name it. The AWS SDK is not a dependency, so the client is structural.
- **Real overloads** on the browser client's `where`/`orWhere`/`andWhere`. `WhereOperator | any` collapses to `any` and checked nothing; the overloads mean a three-arg call must pass an actual operator.
- **Inputs widened to `unknown`** rather than narrowed - nothing breaks, everything is assignable to it.

## The survivors are deliberate

Each carries its reason in the source: driver escape hatches in `db.ts` (narrowing forces a cast at every `await sql.unsafe(...)` - the same hole, moved somewhere less visible), `DeepPartial`'s function-detection idiom, the faker proxy's dynamic members, and accessor/mutator **parameters** in `schema.ts`. That last one matters: a model's own `get: { name: (value: string) => ... }` is not assignable to `(value: unknown) => ...` under `strictFunctionTypes`, so narrowing there would reject every correctly written model. Their **returns** are `unknown`, so nothing downstream inherits the looseness.

## Verification

- `bun run typecheck` clean
- **2000 pass / 0 fail**, unchanged from before
- `bunx --bun pickier .` 0 errors
- A new test pins the count, so the next `any` needs a justification rather than a silent bump