### PR TITLE
fix(client): choose WHERE vs AND from builder state, not a text search

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -6966,6 +6966,31 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
 
       let sqlText = `UPDATE ${quoteId(String(table))}`
 
+      /**
+       * Whether this builder has already emitted a predicate — which is the
+       * thing the keyword actually depends on.
+       *
+       * It used to be inferred by testing the whole statement for
+       * `/\bWHERE\b/`, and plenty of text that is not this builder's predicate
+       * satisfies that: a subquery inside `set()`, a table named `where`, a
+       * column named `where`. The first real predicate then came out as `AND`
+       * and fused onto the SET expression:
+       *
+       *     SET "flag" = (SELECT ... WHERE x.id > 3) AND "id" = ?
+       *
+       * which leaves the UPDATE with no WHERE at all. Postgres rejects that
+       * only when the types happen not to line up; where the SET target is
+       * boolean, or on SQLite, it runs against every row and writes the
+       * predicate into the value. See #1113.
+       *
+       * A boolean cannot be fooled by any of that.
+       */
+      let hasPredicate = false
+      const appendPredicate = (predicate: string): void => {
+        sqlText = `${sqlText} ${hasPredicate ? 'AND' : 'WHERE'} ${predicate}`
+        hasPredicate = true
+      }
+
       return {
         set(values) {
           const keys = Object.keys(values)
@@ -6992,9 +7017,6 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
           return this
         },
         where(expr: any, op?: string, value?: any) {
-          // Helper to get the correct keyword (WHERE for first condition, AND for subsequent)
-          const getWhereKeyword = () => SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
-
           // Handle 3-arg format: where('column', '=', value)
           if (op !== undefined && (typeof expr === 'string' || isRawExpression(expr) || isBoundSqlExpression(expr))) {
             const safeOperator = assertSafeWhereOperator(op, 'updateTable.where')
@@ -7020,14 +7042,14 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
             if (safeOperator.toLowerCase() === 'in' || safeOperator.toLowerCase() === 'not in') {
               const values = Array.isArray(value) ? value : [value]
               const placeholders = getPlaceholders(values.length, params.length + 1)
-              sqlText = `${sqlText} ${getWhereKeyword()} ${left} ${safeOperator.toUpperCase()} (${placeholders})`
+              appendPredicate(`${left} ${safeOperator.toUpperCase()} (${placeholders})`)
               params.push(...values)
               built = _sql.unsafe(sqlText, params)
               return this
             }
 
             const paramIndex = params.length + 1
-            sqlText = `${sqlText} ${getWhereKeyword()} ${left} ${safeOperator} ${getPlaceholder(paramIndex)}`
+            appendPredicate(`${left} ${safeOperator} ${getPlaceholder(paramIndex)}`)
             params.push(value)
             built = _sql.unsafe(sqlText, params)
             return this
@@ -7041,14 +7063,14 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
             if (safeOperator.toLowerCase() === 'in' || safeOperator.toLowerCase() === 'not in') {
               const values = Array.isArray(val) ? val : [val]
               const placeholders = getPlaceholders(values.length, params.length + 1)
-              sqlText = `${sqlText} ${getWhereKeyword()} ${quoteId(String(col))} ${safeOperator.toUpperCase()} (${placeholders})`
+              appendPredicate(`${quoteId(String(col))} ${safeOperator.toUpperCase()} (${placeholders})`)
               params.push(...values)
               built = _sql.unsafe(sqlText, params)
               return this
             }
 
             const paramIndex = params.length + 1
-            sqlText = `${sqlText} ${getWhereKeyword()} ${quoteId(String(col))} ${safeOperator} ${getPlaceholder(paramIndex)}`
+            appendPredicate(`${quoteId(String(col))} ${safeOperator} ${getPlaceholder(paramIndex)}`)
             params.push(val)
             built = _sql.unsafe(sqlText, params)
             return this
@@ -7063,13 +7085,13 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
           // expression is an object and would otherwise be read as the column
           // map `{ sql: ... }`. See #1101.
           if (isRawExpression(expr)) {
-            sqlText = `${sqlText} ${getWhereKeyword()} ${expr.raw}`
+            appendPredicate(expr.raw)
             built = _sql.unsafe(sqlText, params)
             return this
           }
           if (isBoundSqlExpression(expr)) {
             const rendered = renderBoundSqlExpression(expr, params.length + 1)
-            sqlText = `${sqlText} ${getWhereKeyword()} ${rendered.text}`
+            appendPredicate(rendered.text)
             params.push(...rendered.parameters)
             built = _sql.unsafe(sqlText, params)
             return this
@@ -7087,7 +7109,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
               conditions[i] = `${quoteId(keys[i])} = ${getPlaceholder(baseIdx + i + 1)}`
               params.push((expr as any)[keys[i]])
             }
-            sqlText = `${sqlText} ${getWhereKeyword()} ${conditions.join(' AND ')}`
+            appendPredicate(conditions.join(' AND '))
             built = _sql.unsafe(sqlText, params)
             return this
           }
@@ -7104,14 +7126,12 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
           throw new TypeError(`[query-builder] updateTable.where(): expected a condition, got ${expr === null ? 'null' : typeof expr}. Refusing to run an UPDATE with no WHERE — drop the where() call if updating every row is intended.`)
         },
         whereNull(column: string) {
-          const keyword = SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
-          sqlText = `${sqlText} ${keyword} ${quoteId(String(column))} IS NULL`
+          appendPredicate(`${quoteId(String(column))} IS NULL`)
           built = _sql.unsafe(sqlText, params)
           return this
         },
         whereNotNull(column: string) {
-          const keyword = SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
-          sqlText = `${sqlText} ${keyword} ${quoteId(String(column))} IS NOT NULL`
+          appendPredicate(`${quoteId(String(column))} IS NOT NULL`)
           built = _sql.unsafe(sqlText, params)
           return this
         },
@@ -7237,13 +7257,21 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
       const delParams: any[] = []
       let whereCondition: any = null
 
-      // First .where() emits ` WHERE `; subsequent calls emit ` AND `.
+      // First predicate emits ` WHERE `; subsequent ones emit ` AND `.
       // Without this, chained `.where('a', '=', 1).where('b', '=', 2)`
       // compiled to `... WHERE a = ? WHERE b = ?` and SQLite 500'd
-      // with `near "WHERE": syntax error`. Mirrors the same helper in
-      // updateTable() at line ~5454.
+      // with `near "WHERE": syntax error`.
       // See https://github.com/stacksjs/bun-query-builder/issues/1015
-      const getWhereKeyword = () => SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
+      //
+      // Tracked as builder state rather than read back out of the statement:
+      // `DELETE FROM "where"` matches /\bWHERE\b/ too, and inferring it from
+      // the text turned the first predicate into `AND` — `DELETE FROM "where"
+      // AND "id" = ?`. Mirrors updateTable(). See #1113.
+      let hasPredicate = false
+      const appendPredicate = (predicate: string): void => {
+        sqlText += ` ${hasPredicate ? 'AND' : 'WHERE'} ${predicate}`
+        hasPredicate = true
+      }
 
       const ensureDelBuilt = () => {
         if (built === null) {
@@ -7271,14 +7299,14 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
             if (safeOperator.toLowerCase() === 'in' || safeOperator.toLowerCase() === 'not in') {
               const values = Array.isArray(value) ? value : [value]
               const placeholders = getPlaceholders(values.length, delParams.length + 1)
-              sqlText += ` ${getWhereKeyword()} ${quoteId(expr)} ${safeOperator.toUpperCase()} (${placeholders})`
+              appendPredicate(`${quoteId(expr)} ${safeOperator.toUpperCase()} (${placeholders})`)
               delParams.push(...values)
               built = null
               return this
             }
 
             const paramIndex = delParams.length + 1
-            sqlText += ` ${getWhereKeyword()} ${quoteId(expr)} ${safeOperator} ${getPlaceholder(paramIndex)}`
+            appendPredicate(`${quoteId(expr)} ${safeOperator} ${getPlaceholder(paramIndex)}`)
             delParams.push(value)
             built = null
             return this
@@ -7291,14 +7319,14 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
             if (safeOperator.toLowerCase() === 'in' || safeOperator.toLowerCase() === 'not in') {
               const values = Array.isArray(val) ? val : [val]
               const placeholders = getPlaceholders(values.length, delParams.length + 1)
-              sqlText += ` ${getWhereKeyword()} ${quoteId(String(col))} ${safeOperator.toUpperCase()} (${placeholders})`
+              appendPredicate(`${quoteId(String(col))} ${safeOperator.toUpperCase()} (${placeholders})`)
               delParams.push(...values)
               built = null
               return this
             }
 
             const paramIndex = delParams.length + 1
-            sqlText += ` ${getWhereKeyword()} ${quoteId(String(col))} ${safeOperator} ${getPlaceholder(paramIndex)}`
+            appendPredicate(`${quoteId(String(col))} ${safeOperator} ${getPlaceholder(paramIndex)}`)
             delParams.push(val)
             built = null
             return this
@@ -7311,13 +7339,13 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
           // `where(raw('id = 1'))` with "invalid input syntax for type
           // boolean". The signature accepts SqlFragment, so it has to work.
           if (isRawExpression(expr)) {
-            sqlText += ` ${getWhereKeyword()} ${expr.raw}`
+            appendPredicate(expr.raw)
             built = null
             return this
           }
           if (isBoundSqlExpression(expr)) {
             const rendered = renderBoundSqlExpression(expr, delParams.length + 1)
-            sqlText += ` ${getWhereKeyword()} ${rendered.text}`
+            appendPredicate(rendered.text)
             delParams.push(...rendered.parameters)
             built = null
             return this
@@ -7334,7 +7362,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
               conditions.push(`${quoteId(key)} = ${getPlaceholder(paramIndex)}`)
               delParams.push((expr as any)[key])
             }
-            sqlText += ` ${getWhereKeyword()} ${conditions.join(' AND ')}`
+            appendPredicate(conditions.join(' AND '))
             built = null
             return this
           }
@@ -7350,12 +7378,12 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
           throw new TypeError(`[query-builder] deleteFrom.where(): expected a condition, got ${expr === null ? 'null' : typeof expr}. Refusing to run a DELETE with no WHERE — drop the where() call if deleting every row is intended.`)
         },
         whereNull(column: string) {
-          sqlText += ` ${getWhereKeyword()} ${quoteId(String(column))} IS NULL`
+          appendPredicate(`${quoteId(String(column))} IS NULL`)
           built = null
           return this
         },
         whereNotNull(column: string) {
-          sqlText += ` ${getWhereKeyword()} ${quoteId(String(column))} IS NOT NULL`
+          appendPredicate(`${quoteId(String(column))} IS NOT NULL`)
           built = null
           return this
         },

--- a/packages/bun-query-builder/test/client.where-keyword-state.test.ts
+++ b/packages/bun-query-builder/test/client.where-keyword-state.test.ts
@@ -1,0 +1,180 @@
+/**
+ * The WHERE/AND keyword follows builder state, not a text search.
+ * stacksjs/bun-query-builder#1113.
+ *
+ * Both write builders chose their keyword by testing the statement built so
+ * far for `/\bWHERE\b/`:
+ *
+ *     const getWhereKeyword = () => SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
+ *
+ * Plenty of text that is not this builder's predicate satisfies that. A
+ * subquery inside `set()`, a table named `where`, a column named `where` —
+ * each one made the FIRST predicate come out as `AND`, which fuses it onto
+ * whatever preceded it:
+ *
+ *     UPDATE "t" SET "flag" = (SELECT ... WHERE x.id > 3) AND "id" = ?
+ *     DELETE FROM "where" AND "id" = ?
+ *
+ * The DELETE is a syntax error. The UPDATE is worse: it parses, the predicate
+ * becomes part of the value being written, and the statement has no WHERE, so
+ * it rewrites every row. Postgres only rejects it when the SET target's type
+ * happens not to be boolean; SQLite takes it as written.
+ *
+ * That last case is why the UPDATE assertions here seed a non-zero column and
+ * check every row. The reported repro writes `0` to rows that already held
+ * `0`, so the damage is invisible unless the fixture makes it visible.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder, raw } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+// `where` is a legal identifier in every dialect this builder targets, as long
+// as it is quoted — and the builder does quote it.
+const MODELS = {
+  t: {
+    columns: {
+      id: { type: 'integer', isPrimaryKey: true },
+      name: { type: 'string' },
+      flag: { type: 'integer' },
+    },
+  },
+  where: {
+    columns: {
+      id: { type: 'integer', isPrimaryKey: true },
+      name: { type: 'string' },
+    },
+  },
+  hasreserved: {
+    columns: {
+      id: { type: 'integer', isPrimaryKey: true },
+      where: { type: 'string' },
+    },
+  },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown> }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+function all(table: string): any[] {
+  const probe = new Database(dbPath)
+  const out = probe.query(`SELECT * FROM "${table}" ORDER BY id`).all() as any[]
+  probe.close()
+  return out
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database } }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1113-'))
+  dbPath = join(dir, 'kw.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, flag INTEGER)')
+  // Non-zero flags: an UPDATE that reaches every row has to be visible.
+  seed.run(`INSERT INTO t (id,name,flag) VALUES (1,'a',7),(2,'b',7),(3,'c',7),(4,'d',7)`)
+  seed.run('CREATE TABLE "where" (id INTEGER PRIMARY KEY, name TEXT)')
+  seed.run(`INSERT INTO "where" (id,name) VALUES (1,'a'),(2,'b')`)
+  seed.run('CREATE TABLE hasreserved (id INTEGER PRIMARY KEY, "where" TEXT)')
+  seed.run(`INSERT INTO hasreserved (id,"where") VALUES (1,'a'),(2,'b')`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('a WHERE inside a set() fragment does not steal the keyword (#1113)', () => {
+  it('emits WHERE for the predicate, not AND', () => {
+    const sql = String(qb()
+      .updateTable('t')
+      .set({ flag: raw('(SELECT count(*) FROM t x WHERE x.id > 3)') })
+      .where({ id: 1 })
+      .toSQL())
+
+    expect(sql).toContain(') WHERE "id"')
+    expect(sql).not.toContain(') AND "id"')
+  })
+
+  it('updates only the row the predicate selects', async () => {
+    await qb()
+      .updateTable('t')
+      .set({ flag: raw('(SELECT count(*) FROM t x WHERE x.id > 3)') })
+      .where({ id: 1 })
+      .execute()
+
+    // Previously every row was rewritten: the predicate became part of the
+    // value, so rows 2-4 were assigned `(1) AND (id = 1)` = 0 and row 1 got 1.
+    // Seeding 7 is what makes that visible.
+    expect(all('t').map(r => r.flag)).toEqual([1, 7, 7, 7])
+  })
+})
+
+describe('an identifier named `where` does not steal the keyword (#1113)', () => {
+  it('a table named `where` still gets a WHERE clause on DELETE', async () => {
+    const sql = String(qb().deleteFrom('where').where({ id: 1 }).toSQL())
+    expect(sql).toBe('DELETE FROM "where" WHERE "id" = ?')
+
+    // It used to emit `DELETE FROM "where" AND "id" = ?` — a syntax error.
+    await qb().deleteFrom('where').where({ id: 1 }).execute()
+    expect(all('where').map(r => r.id)).toEqual([2])
+  })
+
+  it('a table named `where` still gets a WHERE clause on UPDATE', async () => {
+    await qb().updateTable('where').set({ name: 'X' }).where({ id: 1 }).execute()
+    expect(all('where').map(r => r.name)).toEqual(['X', 'b'])
+  })
+
+  it('a column named `where` in set() does not absorb the predicate', async () => {
+    await qb().updateTable('hasreserved').set({ where: 'X' }).where({ id: 1 }).execute()
+    expect(all('hasreserved').map(r => r.where)).toEqual(['X', 'b'])
+  })
+})
+
+describe('chained predicates still join with AND (#1015 stays fixed)', () => {
+  it('UPDATE: second where() is AND', () => {
+    const sql = String(qb().updateTable('t').set({ name: 'X' }).where('id', '=', 1).where('name', '=', 'a').toSQL())
+    expect(sql).toContain('WHERE "id" = ?')
+    expect(sql).toContain('AND "name" = ?')
+  })
+
+  it('DELETE: second where() is AND', () => {
+    const sql = String(qb().deleteFrom('t').where('id', '=', 1).where('name', '=', 'a').toSQL())
+    expect(sql).toContain('WHERE "id" = ?')
+    expect(sql).toContain('AND "name" = ?')
+  })
+
+  it('DELETE: whereNull then whereNotNull', () => {
+    const sql = String(qb().deleteFrom('t').whereNull('name').whereNotNull('flag').toSQL())
+    expect(sql).toBe('DELETE FROM "t" WHERE "name" IS NULL AND "flag" IS NOT NULL')
+  })
+
+  it('UPDATE: a raw fragment first, then a column predicate', () => {
+    const sql = String(qb().updateTable('t').set({ name: 'X' }).where(raw('id > 2')).where('name', '=', 'c').toSQL())
+    expect(sql).toContain('WHERE id > 2')
+    expect(sql).toContain('AND "name" = ?')
+  })
+
+  it('DELETE: a raw fragment carrying its own WHERE is still the first predicate', () => {
+    const sql = String(qb().deleteFrom('t').where(raw('id IN (SELECT id FROM t x WHERE x.id > 3)')).whereNotNull('name').toSQL())
+    expect(sql).toBe('DELETE FROM "t" WHERE id IN (SELECT id FROM t x WHERE x.id > 3) AND "name" IS NOT NULL')
+  })
+})


### PR DESCRIPTION
Closes #1113.

Both write builders picked their keyword by testing the statement built so far for `/\bWHERE\b/`:

```ts
const getWhereKeyword = () => SQL_PATTERNS.WHERE.test(sqlText) ? 'AND' : 'WHERE'
```

Plenty of text that is not *this builder's predicate* satisfies that test. The first real predicate then comes out as `AND` and fuses onto whatever preceded it:

```sql
UPDATE "t" SET "flag" = (SELECT count(*) FROM t x WHERE x.id > 3) AND "id" = ?
UPDATE "where" SET "name" = ? AND "id" = ?
UPDATE "t" SET "where" = ? AND "id" = ?
DELETE FROM "where" AND "id" = ?
```

The issue reported the first one. The other three came out of checking how far the defect reached: **`where` is a legal quoted identifier**, so any table or column with that name breaks both builders outright.

## Why the UPDATE is the serious half

The DELETE is a syntax error — loud, caught immediately. The UPDATE parses. The predicate becomes part of the value being written, the statement carries no WHERE, and it rewrites every row. Postgres rejects it only when the SET target's type happens not to line up (`argument of AND must be type boolean, not type bigint`); where that target *is* boolean, or on SQLite, it runs exactly as written.

That is also why the test fixture seeds `flag = 7` rather than `0`. The repro in the issue writes `0` to rows that already hold `0`, so the whole-table write leaves no trace — the damage is invisible unless the fixture makes it visible.

## The change

A boolean on each builder, set when a predicate is actually appended. Nothing the caller can put in the statement can fool it.

Both builders now append through one `appendPredicate()` helper rather than repeating the keyword expression at nine call sites each, so there is one place left that can get this wrong.

## Verification

Executed against sqlite, not asserted on SQL text alone:

- the `set()` subquery case emits `WHERE` and updates **only** the selected row — `[1, 7, 7, 7]`, previously `[1, 0, 0, 0]`
- a table named `where` works on both UPDATE and DELETE
- a column named `where` in `set()` no longer absorbs the predicate
- chained predicates still join with `AND` — #1015 stays fixed
- a raw fragment carrying its own `WHERE` is still treated as the first predicate

5 of the 10 new tests fail without the fix. Full suite **2037 pass / 0 fail**, typecheck clean, pickier 0 errors.

## Not in this PR

The select builder has a third copy of the same inference (`client.ts:3350`), reached after a set operator. `selectFrom('a').where(...).union(selectFrom('b')).where(...)` emits `... UNION SELECT * FROM b AND x = $2`. Filed separately — different builder, different fix, and it is a syntax error rather than silent damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)