### PR TITLE
fix(client): updateMany runs with the caller's predicate, or not at all

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -8079,23 +8079,54 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
 
       let sql = `UPDATE ${table} SET ${setClauses.join(',')}`
 
-      // Build WHERE clause
+      // Build WHERE clause.
+      //
+      // Every branch below either appends a predicate or throws. `conditions`
+      // is a required parameter, so there is no shape of it that means "every
+      // row" — passing one is the caller saying they have a filter. Anything
+      // this cannot turn into a predicate used to fall straight through to an
+      // UPDATE with no WHERE, which rewrote the whole table and reported the
+      // full count as success. See #1112, and #1101 for the same defect in
+      // updateTable().
       if (Array.isArray(conditions)) {
-        sql += ` WHERE ${conditions[0]}${conditions[1]}${getPlaceholder(params.length + 1)}`
+        // Separated by spaces: the three parts used to be concatenated bare,
+        // which is fine for `=` and `>=` and produces `namelike?` for every
+        // word operator the allowed set contains.
+        const safeOperator = assertSafeWhereOperator(String(conditions[1]), 'updateMany')
+        sql += ` WHERE ${conditions[0]} ${safeOperator} ${getPlaceholder(params.length + 1)}`
         params.push(conditions[2])
       }
-      else if (conditions && typeof conditions === 'object' && !('raw' in conditions)) {
+      // A fragment is inside the declared `WhereExpression` type (through
+      // `WhereRaw`) and `raw` is a public export, so `updateMany(t, raw('id =
+      // 1'), data)` typechecks and reads like the intended way to express a
+      // condition this signature cannot otherwise carry. It matched no branch.
+      else if (isRawExpression(conditions)) {
+        sql += ` WHERE ${conditions.raw}`
+      }
+      else if (isBoundSqlExpression(conditions)) {
+        const rendered = renderBoundSqlExpression(conditions, params.length + 1)
+        sql += ` WHERE ${rendered.text}`
+        params.push(...rendered.parameters)
+      }
+      else if (conditions && typeof conditions === 'object' && Object.keys(conditions).length > 0) {
         const condKeys = Object.keys(conditions)
         const condLen = condKeys.length
-        if (condLen > 0) {
-          const baseIdx = params.length
-          const whereClauses: string[] = Array.from({ length: condLen })
-          for (let i = 0; i < condLen; i++) {
-            whereClauses[i] = `${condKeys[i]}=${getPlaceholder(baseIdx + i + 1)}`
-            params.push((conditions as any)[condKeys[i]])
-          }
-          sql += ` WHERE ${whereClauses.join(' AND ')}`
+        const baseIdx = params.length
+        const whereClauses: string[] = Array.from({ length: condLen })
+        for (let i = 0; i < condLen; i++) {
+          whereClauses[i] = `${condKeys[i]}=${getPlaceholder(baseIdx + i + 1)}`
+          params.push((conditions as any)[condKeys[i]])
         }
+        sql += ` WHERE ${whereClauses.join(' AND ')}`
+      }
+      // The empty object is the one that bites in production: `conditions` is
+      // usually built from request input, and `updateMany(t, buildFilter(req.query), data)`
+      // rewrote every row the moment the filter came back empty.
+      else if (conditions && typeof conditions === 'object') {
+        throw new TypeError('[query-builder] updateMany(): an empty object is not a filter. Pass a condition, or use updateTable(table).set(data).execute() if updating every row is intended.')
+      }
+      else {
+        throw new TypeError(`[query-builder] updateMany(): expected a condition, got ${conditions === null ? 'null' : typeof conditions}. Refusing to run an UPDATE with no WHERE — use updateTable(table).set(data).execute() if updating every row is intended.`)
       }
 
       return _sql.unsafe(sql, params).execute()

--- a/packages/bun-query-builder/test/client.update-many-predicate.test.ts
+++ b/packages/bun-query-builder/test/client.update-many-predicate.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `updateMany` runs with the predicate the caller gave it, or not at all.
+ * stacksjs/bun-query-builder#1112.
+ *
+ * The WHERE clause was appended only for an array, or for an object that both
+ * lacked a `raw` key and had at least one key. Every other shape produced an
+ * UPDATE with no predicate — no error, full affected count reported as
+ * success:
+ *
+ *     updateMany('t', raw('id = 1'), { name: 'T' })   -> all four rows rewritten
+ *     updateMany('t', {},            { name: 'T' })   -> all four rows rewritten
+ *
+ * The fragment form is the one that reads like correct code: `conditions` is
+ * declared `WhereExpression`, which includes `WhereRaw`, and `raw` is a public
+ * export — so it typechecks and passes review. The empty-object form is the
+ * one that reaches production, because `conditions` is typically built from
+ * request input and an empty filter is what you get from an empty query
+ * string.
+ *
+ * `conditions` is a required parameter, so no value of it can legitimately
+ * mean "every row". Anything unreadable is refused rather than dropped; the
+ * caller who really wants an unfiltered update writes
+ * `updateTable(t).set(data).execute()`, which says so.
+ *
+ * The array form also interpolated its operator into the SQL unvalidated,
+ * while every other builder ran it through `assertSafeWhereOperator` — see the
+ * last block.
+ *
+ * Assertions are on surviving rows. The bug was damage.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder, raw } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  t: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' } } },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown> }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+function names(): string[] {
+  const probe = new Database(dbPath)
+  const out = (probe.query('SELECT name FROM t ORDER BY id').all() as any[]).map(r => r.name)
+  probe.close()
+  return out
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database } }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1112-'))
+  dbPath = join(dir, 'many.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+  seed.run(`INSERT INTO t (id, name) VALUES (1,'a'),(2,'b'),(3,'c'),(4,'d')`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('a fragment is honoured as a predicate (#1112)', () => {
+  it('raw() updates only the rows it selects', async () => {
+    await qb().updateMany('t', raw('id = 1') as any, { name: 'T' })
+
+    // Previously: ['T','T','T','T'].
+    expect(names()).toEqual(['T', 'b', 'c', 'd'])
+  })
+
+  it('a bound fragment keeps its own parameters ahead of nothing else', async () => {
+    await qb().updateMany('t', { sql: 'id > ?', parameters: [2] } as any, { name: 'T' })
+
+    expect(names()).toEqual(['a', 'b', 'T', 'T'])
+  })
+})
+
+describe('an unreadable condition is refused, not dropped (#1112)', () => {
+  it('{} names the problem and rewrites nothing', async () => {
+    await expect(qb().updateMany('t', {} as any, { name: 'T' }))
+      .rejects.toThrow(/an empty object is not a filter/)
+
+    expect(names()).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  for (const [label, value] of [['undefined', undefined], ['null', null]] as const) {
+    it(`${label} throws and rewrites nothing`, async () => {
+      await expect(qb().updateMany('t', value as any, { name: 'T' }))
+        .rejects.toThrow(/expected a condition/)
+
+      expect(names()).toEqual(['a', 'b', 'c', 'd'])
+    })
+  }
+
+  it('the message points at the call that does mean every row', async () => {
+    await expect(qb().updateMany('t', {} as any, { name: 'T' }))
+      .rejects.toThrow(/updateTable\(table\)\.set\(data\)\.execute\(\)/)
+  })
+})
+
+describe('the forms that already worked still work (#1112)', () => {
+  it('object conditions', async () => {
+    await qb().updateMany('t', { id: 2 } as any, { name: 'T' })
+    expect(names()).toEqual(['a', 'T', 'c', 'd'])
+  })
+
+  it('array conditions', async () => {
+    await qb().updateMany('t', ['id', '>=', 3] as any, { name: 'T' })
+    expect(names()).toEqual(['a', 'b', 'T', 'T'])
+  })
+
+  it('an empty data object is still a no-op', async () => {
+    expect(await qb().updateMany('t', { id: 2 } as any, {})).toBe(0)
+    expect(names()).toEqual(['a', 'b', 'c', 'd'])
+  })
+})
+
+describe('the array form validates its operator (#1112)', () => {
+  // Every other builder routes the operator through assertSafeWhereOperator;
+  // this one interpolated it. The array form is exactly the shape a filter DSL
+  // builds from request input, so the operator slot is reachable.
+  //
+  // A payload has to keep the placeholder count at one to get past the driver's
+  // arity check — `'>0 OR id>'` does, and rewrote the whole table.
+  it('refuses an operator outside the allowed set, and writes nothing', async () => {
+    await expect(qb().updateMany('t', ['id', '>0 OR id>', 0] as any, { name: 'PWNED' }))
+      .rejects.toThrow(/refusing to use '>0 OR id>' as a SQL operator/)
+
+    expect(names()).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('still accepts the operators it is supposed to', async () => {
+    await qb().updateMany('t', ['name', 'like', 'c'] as any, { name: 'T' })
+    expect(names()).toEqual(['a', 'b', 'T', 'd'])
+  })
+})


### PR DESCRIPTION
Closes #1112.

`updateMany` appended a WHERE only for an array, or for an object that both lacked a `raw` key and had at least one key. Every other shape produced an UPDATE with no predicate — no error, full affected count reported as success:

```ts
await db.updateMany('t', raw('id = 1'), { name: 'T' })   // -> all four rows rewritten
await db.updateMany('t', {},            { name: 'T' })   // -> all four rows rewritten
```

The fragment form reads like correct code. `conditions` is declared `WhereExpression`, which includes `WhereRaw`, and `raw` is a public export — so it typechecks and passes review. The empty-object form is the one that reaches production, because `conditions` is usually built from request input and an empty filter is what an empty query string gives you.

`conditions` is a **required** parameter, so no value of it can legitimately mean "every row". Fragments are now rendered as predicates; anything that cannot become one is refused, naming the call that does mean every row — `updateTable(table).set(data).execute()`. Same remedy as #1101.

## Two more defects in the same branch

Both found while writing coverage for the above, both in the array form:

**The operator was interpolated unvalidated.** Every other builder routes it through `assertSafeWhereOperator`; this one did not. The array form `[col, op, value]` is exactly the shape a filter DSL builds from request input, so the operator slot is reachable. The naive payload is stopped by accident — `--` comments out the placeholder and the driver's arity check fires — but one that keeps the count at one goes straight through:

```ts
await db.updateMany('t', ['id', '>0 OR id>', 0], { name: 'PWNED' })
// UPDATE t SET name=$1 WHERE id>0 OR id>$2   -> every row
```

Now refused with the same message the other builders use.

**The three parts were concatenated bare.** Fine for `=` and `>=`; for every word operator in `WhereOperator` — `like`, `in`, `not in`, `is`, `is not` — it emitted `namelike?`, a syntax error. Now space-separated.

## Verification

Executed against sqlite, asserting on surviving rows rather than SQL text. **8 of the 11 new tests fail without this change.** Full suite **2048 pass / 0 fail**, typecheck clean, pickier 0 errors.

## Related, not fixed here

The survey behind this turned up two more disagreements between `WhereExpression` and what `updateMany` does at runtime, both already tracked by #1114: an array value (`{ id: [1,2,3] }`) is type-legal and means `IN` on a SELECT, but binds the whole array to one placeholder here; and a fragment as an object *value* (`{ created_at: sql\`now()\` }`) is type-legal and gets bound as a plain parameter rather than rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)