### PR TITLE
fix(client): pick the select builder's keywords from state, not from text

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -3413,6 +3413,28 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
     // UNION/INTERSECT/EXCEPT belong to the RIGHT-hand SELECT and must render at
     // the end of `text`, or their params would bind in the wrong order.
     let whereTail = false
+    /**
+     * Whether the operand a tail predicate would attach to already carries one.
+     *
+     * Only consulted once `whereTail` is set. It used to be inferred by testing
+     * the WHOLE statement for `/\bWHERE\b/`, but by then `text` holds the LEFT
+     * select — WHERE and all — so a predicate on the left was read as one on
+     * the right and the right side's first predicate came out as `AND`:
+     *
+     *     SELECT * FROM a WHERE y = $1 UNION SELECT * FROM b AND x = $2
+     *
+     * which does not parse. Set from the right-hand operand alone. See #1120.
+     */
+    let tailHasPredicate = false
+    /**
+     * Whether this builder has emitted its HAVING.
+     *
+     * Same defect as #1113, different keyword: scanning `text` for
+     * `/\bHAVING\b/` also matches a raw select fragment that merely contains
+     * the word, so the first real HAVING was emitted as `AND` and fused onto
+     * the GROUP BY list. See #1122.
+     */
+    let hasHaving = false
 
     // Lazy building: don't prepare statement until execution
     // built is initialized lazily to avoid expensive template tag calls on every query
@@ -3479,7 +3501,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
       if (!body)
         return text
       if (whereTail) {
-        const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'
+        const kw = tailHasPredicate ? 'AND' : 'WHERE'
         return `${text} ${kw} ${body}`
       }
       const cut = firstTailIndex(text)
@@ -3600,7 +3622,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
     // the other side's bound params and renumbering its `$n` placeholders past
     // ours on Postgres — previously the set-op appended text only, dropping the
     // right side's params and colliding `$1`. See stacksjs/bun-query-builder#1029.
-    const appendSetOp = (op: string, other: { toSQL: () => any, __rawState?: () => { sql: string, params: unknown[] } }) => {
+    const appendSetOp = (op: string, other: { toSQL: () => any, __rawState?: () => { sql: string, params: unknown[] }, __hasPredicate?: () => boolean }) => {
       // Params are one flat array in push order, so the WHERE text has to
       // precede the set operator's params in the emitted string. Materialize it
       // into `text` now; terms added after this point belong to the RIGHT-hand
@@ -3618,10 +3640,17 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
           : st.sql
         text += ` ${op} ${otherSql}`
         whereParams.push(...st.params)
+        // A predicate added after this point attaches to the RIGHT operand, so
+        // the keyword depends on that operand alone — not on the statement,
+        // which by now also holds the left side's WHERE. Ask the builder; only
+        // scan when it is a foreign one that cannot answer. See #1120.
+        tailHasPredicate = other.__hasPredicate?.() ?? SQL_PATTERNS.WHERE.test(otherSql)
       }
       else {
         // Foreign builder without __rawState — fall back to text-only (no param merge).
-        text += ` ${op} ${String(other.toSQL())}`
+        const otherSql = String(other.toSQL())
+        text += ` ${op} ${otherSql}`
+        tailHasPredicate = other.__hasPredicate?.() ?? SQL_PATTERNS.WHERE.test(otherSql)
       }
       built = null
     }
@@ -5614,12 +5643,15 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
       having(expr: any) {
         // Chained having() calls join with AND, not a second HAVING keyword
         // (`HAVING a HAVING b` is invalid). See stacksjs/bun-query-builder#1034.
-        const kw = /\bHAVING\b/i.test(text) ? 'AND' : 'HAVING'
+        // Read from builder state, not from `text` — a raw select fragment that
+        // merely contains the word made the first HAVING emit as AND. See #1122.
+        const kw = hasHaving ? 'AND' : 'HAVING'
         // Handle array format: ['COUNT(id)', '>', 3]
         if (Array.isArray(expr)) {
           const paramIdx = whereParams.length + 1
           text = `${text} ${kw} ${expr[0]} ${expr[1]} ${getPlaceholder(paramIdx)}`
           whereParams.push(expr[2])
+          hasHaving = true
           built = null
         }
         // Handle object format
@@ -5635,20 +5667,23 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
               whereParams.push(expr[key])
             }
             text = `${text} ${kw} ${conditions.join(' AND ')}`
+            hasHaving = true
             built = null
           }
         }
         // Handle raw expressions
         else if (expr && typeof (expr as any).raw !== 'undefined') {
           text += ` ${kw} ${(expr as any).raw}`
+          hasHaving = true
           built = null
         }
         return this as any
       },
       havingRaw(fragment: any) {
         const frag = renderRawFragment(fragment, 'havingRaw(fragment)')
-        const kw = /\bHAVING\b/i.test(text) ? 'AND' : 'HAVING'
+        const kw = hasHaving ? 'AND' : 'HAVING'
         text += ` ${kw} ${frag}`
+        hasHaving = true
         built = null
         return this as any
       },
@@ -6329,6 +6364,14 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
       // placeholders. See stacksjs/bun-query-builder#1029.
       __rawState() {
         return { sql: reorderSelectClauses(currentSql()), params: [...whereParams] }
+      },
+      // Internal: does this builder's SQL already carry a predicate that a
+      // further where() would have to join with AND? Used by appendSetOp on
+      // the other side, so it can answer that about the right-hand operand
+      // instead of scanning a statement that also contains the left one.
+      // See stacksjs/bun-query-builder#1120.
+      __hasPredicate() {
+        return whereTerms.length > 0 || tailHasPredicate
       },
       raw() {
         return (ensureBuilt() as any).raw()

--- a/packages/bun-query-builder/test/client.select-keyword-state.test.ts
+++ b/packages/bun-query-builder/test/client.select-keyword-state.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The select builder's clause keywords follow builder state, not a text scan.
+ * stacksjs/bun-query-builder#1120 and #1122.
+ *
+ * Two sites picked a keyword by searching the statement built so far — the
+ * same defect #1113 fixed in the write builders, in a builder that kept it:
+ *
+ *     const kw = SQL_PATTERNS.WHERE.test(text) ? 'AND' : 'WHERE'   // :3482
+ *     const kw = /\bHAVING\b/i.test(text) ? 'AND' : 'HAVING'       // :5617, :5650
+ *
+ * #1120 — the WHERE branch is reached only after a set operator, and by then
+ * `text` holds the LEFT select including its WHERE. So a predicate on the left
+ * was read as one on the right:
+ *
+ *     SELECT * FROM a WHERE y = $1 UNION SELECT * FROM b AND x = $2
+ *
+ * #1122 — `text` also holds the select list, so a raw fragment that merely
+ * contains the word `having` made the first real HAVING emit as AND, fusing it
+ * onto the GROUP BY list.
+ *
+ * Both emit invalid SQL rather than running against the wrong rows, so unlike
+ * #1113 these assert on the emitted statement — that is where the defect lives.
+ * The union cases also execute, because a keyword decision that produces valid
+ * SQL can still produce the wrong ROWS, and only running it settles that.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder, raw } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  a: { columns: { id: { type: 'integer', isPrimaryKey: true }, x: { type: 'integer' }, y: { type: 'integer' } } },
+  b: { columns: { id: { type: 'integer', isPrimaryKey: true }, x: { type: 'integer' }, y: { type: 'integer' } } },
+  users: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' } } },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown> }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database } }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1120-'))
+  dbPath = join(dir, 'sel.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE a (id INTEGER PRIMARY KEY, x INTEGER, y INTEGER)')
+  seed.run('CREATE TABLE b (id INTEGER PRIMARY KEY, x INTEGER, y INTEGER)')
+  seed.run('INSERT INTO a (id,x,y) VALUES (1,1,2),(2,5,9)')
+  seed.run('INSERT INTO b (id,x,y) VALUES (3,1,4),(4,7,8)')
+  seed.run('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)')
+  seed.run(`INSERT INTO users (id,name) VALUES (1,'a'),(2,'b'),(3,'b')`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('a predicate after a set operator (#1120)', () => {
+  it('a WHERE on the left does not make the right one an AND', () => {
+    const sql = String(qb().selectFrom('a').where('y', '=', 2).union(qb().selectFrom('b')).where('x', '=', 1).toSQL())
+
+    // Previously: `... UNION SELECT * FROM b AND x = ?`, which does not parse.
+    expect(sql).toContain('UNION SELECT * FROM b WHERE x = ?')
+  })
+
+  it('and the statement actually runs', async () => {
+    const rows = await qb().selectFrom('a').where('y', '=', 2).union(qb().selectFrom('b')).where('x', '=', 1).execute()
+
+    expect(rows.map((r: any) => r.id).sort()).toEqual([1, 3])
+  })
+
+  it('with no predicate on the left, the right one is still WHERE', () => {
+    const sql = String(qb().selectFrom('a').union(qb().selectFrom('b')).where('x', '=', 1).toSQL())
+    expect(sql).toContain('UNION SELECT * FROM b WHERE x = ?')
+  })
+
+  it('when the RIGHT side has its own predicate, AND is correct and is what is emitted', () => {
+    const sql = String(qb().selectFrom('a').union(qb().selectFrom('b').where('y', '=', 4)).where('x', '=', 1).toSQL())
+
+    expect(sql).toContain('WHERE y = ? AND x = ?')
+  })
+
+  it('intersect behaves the same way', () => {
+    const sql = String(qb().selectFrom('a').where('y', '=', 2).intersect(qb().selectFrom('b')).where('x', '=', 1).toSQL())
+    expect(sql).toContain('INTERSECT SELECT * FROM b WHERE x = ?')
+  })
+
+  it('chained predicates on the tail still join with AND', () => {
+    const sql = String(qb().selectFrom('a').where('y', '=', 2).union(qb().selectFrom('b')).where('x', '=', 1).where('y', '=', 4).toSQL())
+    expect(sql).toContain('UNION SELECT * FROM b WHERE x = ? AND y = ?')
+  })
+})
+
+describe('HAVING is chosen from state, not from the select list (#1122)', () => {
+  it('havingRaw() after a raw fragment containing the word', () => {
+    const sql = String(qb().selectFrom('users').selectRaw(raw("'having a party' as t")).groupBy('id').havingRaw(raw('COUNT(id) > 3')).toSQL())
+
+    // Previously: `... GROUP BY id AND COUNT(id) > 3`.
+    expect(sql).toContain('GROUP BY id HAVING COUNT(id) > 3')
+  })
+
+  it('having() in its array form, same fragment', () => {
+    const sql = String(qb().selectFrom('users').selectRaw(raw("'having a party' as t")).groupBy('id').having(['COUNT(id)', '>', 3]).toSQL())
+
+    expect(sql).toContain('HAVING COUNT(id) > ?')
+    expect(sql).not.toContain('GROUP BY id AND')
+  })
+
+  it('chained having() calls still join with AND (#1034 stays fixed)', () => {
+    const sql = String(qb().selectFrom('users').groupBy('id').having(['COUNT(id)', '>', 1]).having(['COUNT(id)', '<', 9]).toSQL())
+
+    expect(sql).toContain('HAVING COUNT(id) > ?')
+    expect(sql).toContain('AND COUNT(id) < ?')
+  })
+
+  it('having() then havingRaw() joins with AND', () => {
+    const sql = String(qb().selectFrom('users').groupBy('id').having(['COUNT(id)', '>', 1]).havingRaw(raw('COUNT(id) < 9')).toSQL())
+
+    expect(sql).toContain('HAVING COUNT(id) > ?')
+    expect(sql).toContain('AND COUNT(id) < 9')
+  })
+
+  it('a having that appends nothing does not claim the keyword', () => {
+    // The empty-object branch emits no text, so the next call is still the
+    // first HAVING rather than a stray AND.
+    const sql = String(qb().selectFrom('users').groupBy('id').having({}).havingRaw(raw('COUNT(id) > 3')).toSQL())
+
+    expect(sql).toContain('HAVING COUNT(id) > 3')
+  })
+})


### PR DESCRIPTION
Closes #1120, closes #1122.

Two sites in the select builder chose a keyword by searching the statement built so far — the defect #1113 fixed in the write builders, in the builder that kept it. Grouped because it is one change made twice, and doing them together means the select builder gets the treatment once.

## #1120 — a predicate after a set operator

The `WHERE`/`AND` branch is only reachable once `whereTail` is set, and `appendSetOp` materialises the **left** select's WHERE into `text` before appending the operator. So the scan answered *"does the left side have a predicate?"* when the question was about the right:

```sql
SELECT * FROM a WHERE y = $1 UNION SELECT * FROM b AND x = $2
```

That doesn't parse — which made "filter the right-hand side of a union" unavailable to anyone who had also filtered the left.

The keyword now comes from the right-hand operand alone, recorded at `appendSetOp` time. Our own builders answer through a new internal `__hasPredicate()`; the text scan survives only as the fallback for a foreign `{ toSQL }` that can't.

## #1122 — HAVING

`having()` and `havingRaw()` scanned for `/\bHAVING\b/`, which a raw select fragment containing the word also satisfies. The first real HAVING emitted as `AND` and fused onto the GROUP BY list:

```sql
SELECT *, 'having a party' as t FROM users GROUP BY id AND COUNT(id) > 3
```

Now a boolean, set on each branch that actually appends — so the empty-object branch of `having()`, which emits nothing, correctly does not claim the keyword.

## What stays true

Chained predicates still join with `AND` on both paths — **#1015 and #1034 stay fixed** — and where the right operand genuinely does carry its own predicate, `AND` remains correct and is still what comes out. Both are covered.

## Verification

**6 of the 11 new tests fail without this change.** The union cases execute as well as assert on emitted text, because a keyword decision that yields valid SQL can still yield the wrong rows, and only running it settles that.

Full suite **2088 pass / 0 fail**, typecheck clean, pickier 0 errors.

## Still open

This does not touch #1121 — the three *clause placement* scanners, where a raw fragment containing a keyword inside a string literal or a comment swallows the WHERE or the JOIN and the query silently returns the wrong rows. That one is a design call rather than a boolean, and it is the more serious of the two families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)