### PR TITLE
fix(client): an array in object-form where() means IN on writes too

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -29,6 +29,35 @@ interface BoundSqlExpression {
   parameters?: readonly unknown[]
 }
 
+/**
+ * Render one `{ column: value }` entry of an object-form where() as a
+ * predicate, appending its bound parameters to `params`.
+ *
+ * An array value means IN. The select builder has read it that way since
+ * #1013/#1083; the write builders bound the whole array to a single
+ * placeholder, so `where({ id: [3, 2] })` selected two rows on a SELECT and
+ * matched nothing on an UPDATE or a DELETE — silently, reporting success. The
+ * bulk delete of a set of ids is exactly the call people write it for.
+ *
+ * An empty array renders as `1 = 0` rather than disappearing, which is what
+ * the select builder does and the only safe reading on a write: a filter the
+ * caller supplied must never widen to "every row".
+ *
+ * Shared by all three write paths so they cannot drift apart again — the
+ * divergence, not any one branch, is what kept producing these. See #1114.
+ */
+function renderColumnCondition(column: string, value: unknown, params: unknown[]): string {
+  if (Array.isArray(value)) {
+    const placeholders = getPlaceholders(value.length, params.length + 1)
+    const clause = renderInPredicate(column, value, false, placeholders)
+    params.push(...value)
+    return clause
+  }
+  const clause = `${column} = ${getPlaceholder(params.length + 1)}`
+  params.push(value)
+  return clause
+}
+
 function isBoundSqlExpression(expr: unknown): expr is BoundSqlExpression {
   return typeof expr === 'object'
     && expr !== null
@@ -7384,13 +7413,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
             const keys = Object.keys(expr)
             if (keys.length === 0)
               throw new TypeError('[query-builder] updateTable.where({}): an empty object is not a filter. Pass a condition, or drop the where() call if updating every row is intended.')
-            const len = keys.length
-            const baseIdx = params.length
-            const conditions: string[] = Array.from({ length: len })
-            for (let i = 0; i < len; i++) {
-              conditions[i] = `${quoteId(keys[i])} = ${getPlaceholder(baseIdx + i + 1)}`
-              params.push((expr as any)[keys[i]])
-            }
+            const conditions = keys.map(key => renderColumnCondition(quoteId(key), (expr as any)[key], params))
             appendPredicate(conditions.join(' AND '))
             built = _sql.unsafe(sqlText, params)
             return this
@@ -7688,12 +7711,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
             const keys = Object.keys(expr)
             if (keys.length === 0)
               throw new TypeError('[query-builder] deleteFrom.where({}): an empty object is not a filter. Pass a condition, or drop the where() call if deleting every row is intended.')
-            const conditions: string[] = []
-            for (const key of keys) {
-              const paramIndex = delParams.length + 1
-              conditions.push(`${quoteId(key)} = ${getPlaceholder(paramIndex)}`)
-              delParams.push((expr as any)[key])
-            }
+            const conditions = keys.map(key => renderColumnCondition(quoteId(key), (expr as any)[key], delParams))
             appendPredicate(conditions.join(' AND '))
             built = null
             return this
@@ -8487,14 +8505,8 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
         params.push(...rendered.parameters)
       }
       else if (conditions && typeof conditions === 'object' && Object.keys(conditions).length > 0) {
-        const condKeys = Object.keys(conditions)
-        const condLen = condKeys.length
-        const baseIdx = params.length
-        const whereClauses: string[] = Array.from({ length: condLen })
-        for (let i = 0; i < condLen; i++) {
-          whereClauses[i] = `${condKeys[i]}=${getPlaceholder(baseIdx + i + 1)}`
-          params.push((conditions as any)[condKeys[i]])
-        }
+        const whereClauses = Object.keys(conditions).map(key =>
+          renderColumnCondition(key, (conditions as any)[key], params))
         sql += ` WHERE ${whereClauses.join(' AND ')}`
       }
       // The empty object is the one that bites in production: `conditions` is

--- a/packages/bun-query-builder/test/client.write-array-in.test.ts
+++ b/packages/bun-query-builder/test/client.write-array-in.test.ts
@@ -1,0 +1,156 @@
+/**
+ * An array value in object-form where() means IN, on writes as well as reads.
+ * stacksjs/bun-query-builder#1114.
+ *
+ * The select builder has read `where({ id: [3, 2] })` as `id IN (3, 2)` since
+ * #1013/#1083. The write builders bound the whole array to a single
+ * placeholder, so the same input meant two different things depending on which
+ * statement it was attached to:
+ *
+ *     selectFrom(t).where({ id: [3, 2] })   -> rows 2 and 3
+ *     deleteFrom(t).where({ id: [3, 2] })   -> deletes nothing
+ *
+ * This is the opposite direction to #1101 — the write is too NARROW, so it
+ * destroys nothing. But it fails silently and reports success, and it fails in
+ * exactly the case people write it for: the bulk delete of a set of ids.
+ *
+ * All three write paths now share one renderer with the same semantics. The
+ * mixed case matters most for the shared code: the old per-key index
+ * arithmetic (`baseIdx + i + 1`) assumed one parameter per key, which an
+ * array breaks.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  t: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' }, tenant: { type: 'integer' } } },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown> }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+function ids(): number[] {
+  const probe = new Database(dbPath)
+  const out = (probe.query('SELECT id FROM t ORDER BY id').all() as any[]).map(r => r.id)
+  probe.close()
+  return out
+}
+
+function renamed(): number[] {
+  const probe = new Database(dbPath)
+  const out = (probe.query(`SELECT id FROM t WHERE name = 'X' ORDER BY id`).all() as any[]).map(r => r.id)
+  probe.close()
+  return out
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database } }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1114-'))
+  dbPath = join(dir, 'arr.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, tenant INTEGER)')
+  seed.run(`INSERT INTO t (id,name,tenant) VALUES (1,'a',1),(2,'b',1),(3,'c',1),(4,'d',999)`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('reads and writes agree on what an array means (#1114)', () => {
+  it('SELECT reads it as IN — the behaviour the writes now match', async () => {
+    const rows = await qb().selectFrom('t').select('id').where({ id: [3, 2] }).execute()
+    expect(rows.map((r: any) => r.id).sort()).toEqual([2, 3])
+  })
+
+  it('DELETE removes exactly those rows', async () => {
+    await qb().deleteFrom('t').where({ id: [3, 2] }).execute()
+
+    // Previously: deleted nothing, and reported success.
+    expect(ids()).toEqual([1, 4])
+  })
+
+  it('UPDATE rewrites exactly those rows', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where({ id: [3, 2] }).execute()
+    expect(renamed()).toEqual([2, 3])
+  })
+
+  it('updateMany does too', async () => {
+    await qb().updateMany('t', { id: [3, 2] } as any, { name: 'X' })
+    expect(renamed()).toEqual([2, 3])
+  })
+})
+
+describe('an array alongside a scalar binds in the right order (#1114)', () => {
+  // The old code computed each parameter index as `baseIdx + i + 1`, one per
+  // key. An array contributes several, so every parameter after it was bound
+  // to the wrong placeholder.
+  it('DELETE with both a list and a scalar', async () => {
+    const sql = String(qb().deleteFrom('t').where({ id: [2, 3], tenant: 1 } as any).toSQL())
+    expect(sql).toBe('DELETE FROM "t" WHERE "id" IN (?, ?) AND "tenant" = ?')
+
+    await qb().deleteFrom('t').where({ id: [2, 3], tenant: 1 } as any).execute()
+    expect(ids()).toEqual([1, 4])
+  })
+
+  it('the scalar still constrains — a row outside the tenant survives', async () => {
+    await qb().deleteFrom('t').where({ id: [3, 4], tenant: 1 } as any).execute()
+
+    // id 4 is tenant 999, so only 3 goes.
+    expect(ids()).toEqual([1, 2, 4])
+  })
+})
+
+describe('an empty array matches nothing, never everything (#1114)', () => {
+  // The only safe reading on a write: a filter the caller supplied must not
+  // widen to "every row" because the collection came back empty. This is what
+  // the select builder already does (FALSE_PREDICATE).
+  it('DELETE with an empty list deletes nothing', async () => {
+    await qb().deleteFrom('t').where({ id: [] } as any).execute()
+    expect(ids()).toEqual([1, 2, 3, 4])
+  })
+
+  it('and does not drop the other conditions either', async () => {
+    await qb().deleteFrom('t').where({ id: [], tenant: 1 } as any).execute()
+    expect(ids()).toEqual([1, 2, 3, 4])
+  })
+
+  it('UPDATE with an empty list rewrites nothing', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where({ id: [] } as any).execute()
+    expect(renamed()).toEqual([])
+  })
+})
+
+describe('the scalar form is unchanged (#1114)', () => {
+  it('DELETE', async () => {
+    await qb().deleteFrom('t').where({ id: 2 }).execute()
+    expect(ids()).toEqual([1, 3, 4])
+  })
+
+  it('UPDATE with two scalars', async () => {
+    await qb().updateTable('t').set({ name: 'X' }).where({ id: 2, tenant: 1 } as any).execute()
+    expect(renamed()).toEqual([2])
+  })
+})


### PR DESCRIPTION
Closes #1114.

The select builder has read `where({ id: [3, 2] })` as `id IN (3, 2)` since #1013/#1083. The write builders bound the whole array to a single placeholder, so the same input meant two different things depending on which statement it was attached to:

```ts
await db.selectFrom('t').select('id').where({ id: [3, 2] }).execute()  // -> rows 2 and 3
await db.deleteFrom('t').where({ id: [3, 2] }).execute()               // -> deletes nothing
```

This is the opposite direction to #1101 — the write is too **narrow**, so it destroys nothing. But it fails silently and reports success, and it does so in exactly the case people write it for: the bulk delete of a set of ids.

## One renderer, three call sites

`updateTable.where`, `deleteFrom.where` and `updateMany` each had their own copy of the same loop. They now share `renderColumnCondition()`. The divergence, not any one branch, is what kept producing this family of bugs — #1101, #1112, #1113 and this one are all two implementations of the same idea disagreeing.

Two details the shared renderer settles:

**An empty array renders as `1 = 0`**, matching the select builder, rather than vanishing. A filter the caller supplied must never widen to "every row" because the collection came back empty — the `{ id: [] }` case is the one the issue flagged as needing a decision, and on a write there is only one safe answer.

**Parameters are numbered as the array is built**, not as `baseIdx + i + 1`. The old arithmetic assumed one parameter per key, so in `where({ id: [2, 3], tenant: 1 })` every parameter after the list bound to the wrong placeholder. Now:

```sql
DELETE FROM "t" WHERE "id" IN (?, ?) AND "tenant" = ?
```

That case gets both a text assertion and an execution assertion, since it is the one the shared code most easily gets wrong.

## Verification

Executed against sqlite, asserting on surviving rows. **6 of the 11 new tests fail without this change.** Full suite **2088 pass / 0 fail**, typecheck clean, pickier 0 errors.

One claim from the original sweep is still **not** reproduced and is not addressed here: that the array is consumed as the entire positional bind list on sqlite, dropping other predicates. I could not make that happen before the fix, and the mixed array+scalar test above pins the behaviour either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)