### PR TITLE
feat(paginate): add a spelling that cannot be transposed

### DIFF
--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -622,6 +622,28 @@ export type WhereExpression<TableColumns> =
   | { [K in keyof TableColumns & string]: [key: K, op: WhereOperator, value: WhereValue<TableColumns[K]>] }[keyof TableColumns & string]
   | WhereRaw
 
+/**
+ * # `PaginateOptions`
+ *
+ * The unambiguous spelling of a paginate() call.
+ *
+ * `db.selectFrom(t).paginate(perPage, page)` and `Model.query().paginate(page,
+ * perPage)` take the same two numbers in opposite orders, and both parameters
+ * are `number` — so transposing them is not a type error, it just returns a
+ * different page. Passing this object instead says which is which.
+ *
+ * Both APIs accept it and both keep their positional forms, so this adds a
+ * safe spelling without moving anyone's existing call. See #1092.
+ */
+export interface PaginateOptions {
+  /** Rows per page. Defaults to each API's existing default. */
+  perPage?: number
+  /** 1-based page number. Defaults to 1. */
+  page?: number
+  /** Run the count and the page query inside this transaction — see #1051. */
+  tx?: { unsafe: (sql: string, params?: any[]) => any }
+}
+
 export type QueryResult = unknown
 
 /**
@@ -1930,7 +1952,7 @@ export interface BaseSelectQueryBuilder<
    * const res2 = await db.selectFrom('users').where({ active: true }).paginate(25)
    * ```
    */
-  paginate: (perPage: number, page?: number, opts?: { tx?: { unsafe: (sql: string, params?: unknown[]) => unknown } }) => Promise<{ data: SelectedRow<DB, TTable, TSelected>[], meta: { perPage: number, page: number, total: number, lastPage: number } }>
+  paginate: ((perPage: number, page?: number, opts?: { tx?: { unsafe: (sql: string, params?: unknown[]) => unknown } }) => Promise<{ data: SelectedRow<DB, TTable, TSelected>[], meta: { perPage: number, page: number, total: number, lastPage: number } }>) & ((options: PaginateOptions) => Promise<{ data: SelectedRow<DB, TTable, TSelected>[], meta: { perPage: number, page: number, total: number, lastPage: number } }>)
   /**
    * # `simplePaginate`
    *
@@ -5823,7 +5845,18 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
         const e = await (this as any).exists()
         return !e
       },
-      async paginate(perPage: number, page = 1, opts: { tx?: { unsafe: (sql: string, params?: any[]) => any } } = {}) {
+      async paginate(perPage: number | PaginateOptions, page = 1, opts: { tx?: { unsafe: (sql: string, params?: any[]) => any } } = {}) {
+        // Options form: `paginate({ perPage, page })`. The two paginate APIs in
+        // this library take the same two numbers in opposite orders — this one
+        // is (perPage, page), the ORM's is (page, perPage) — and both arguments
+        // are numbers, so getting it backwards is silent: you simply receive a
+        // different page. Naming them cannot be got wrong. See #1092.
+        if (typeof perPage === 'object' && perPage !== null) {
+          const options = perPage
+          page = options.page ?? 1
+          opts = options.tx ? { tx: options.tx } : {}
+          perPage = options.perPage ?? 10
+        }
         if (!Number.isFinite(perPage) || perPage <= 0 || !Number.isInteger(perPage))
           throw new TypeError(`[query-builder] paginate(perPage): expected positive integer, got ${perPage}`)
         if (!Number.isFinite(page) || page < 1 || !Number.isInteger(page))

--- a/packages/bun-query-builder/src/orm.ts
+++ b/packages/bun-query-builder/src/orm.ts
@@ -26,6 +26,7 @@
 
 import { Database, type SQLQueryBindings } from 'bun:sqlite'
 import type { FactoryFaker } from './faker-compat'
+import type { PaginateOptions } from './client'
 import type { SupportedDialect } from './types'
 import type { RelationCardinality } from './type-inference'
 import { isNumericPlanType, normalizeAttributeType, sqliteAffinityFor } from './column-types'
@@ -3116,7 +3117,7 @@ class ModelQueryBuilder<
     }
   }
 
-  async paginate(page = 1, perPage = 15): Promise<{
+  async paginate(page: number | PaginateOptions = 1, perPage = 15): Promise<{
     data: ModelInstance<TDef, TSelected>[]
     total: number
     page: number
@@ -3126,7 +3127,17 @@ class ModelQueryBuilder<
     isEmpty: boolean
     from: number | null
     to: number | null
+    meta: { perPage: number, page: number, total: number, lastPage: number }
   }> {
+    // Options form: `paginate({ page, perPage })`. This API is (page, perPage)
+    // and the query builder's is (perPage, page); both arguments are numbers,
+    // so transposing them returns a different page rather than raising
+    // anything. Naming them cannot be got wrong. See #1092.
+    if (typeof page === 'object' && page !== null) {
+      const options = page
+      perPage = options.perPage ?? 15
+      page = options.page ?? 1
+    }
     const total = await this.count()
     const lastPage = Math.ceil(total / perPage)
     this._limit = perPage
@@ -3142,6 +3153,12 @@ class ModelQueryBuilder<
       isEmpty: data.length === 0,
       from: data.length > 0 ? (page - 1) * perPage + 1 : null,
       to: data.length > 0 ? (page - 1) * perPage + data.length : null,
+      // Mirrors the query builder's result, which nests under `meta`. The flat
+      // fields above stay exactly as they were, so this is additive: code
+      // written against either shape now works against both, and a helper that
+      // reads `result.meta.total` stops depending on which API produced it.
+      // See #1092.
+      meta: { perPage, page, total, lastPage },
     }
   }
 
@@ -3319,7 +3336,7 @@ export type ModelStatic<TDef extends ModelDefinition> = StaticWhereOverloads<TDe
   count: () => Promise<number>
   exists: () => Promise<boolean>
   doesntExist: () => Promise<boolean>
-  paginate: (page?: number, perPage?: number) => Promise<{
+  paginate: (page?: number | PaginateOptions, perPage?: number) => Promise<{
     data: ModelRecord<TDef>[]
     total: number
     page: number
@@ -3457,7 +3474,7 @@ function createModelInternal<const TDef extends ModelDefinition>(definition: TDe
     count: () => new ModelQueryBuilder<TDef>(definition).count(),
     exists: () => new ModelQueryBuilder<TDef>(definition).exists(),
     doesntExist: () => new ModelQueryBuilder<TDef>(definition).doesntExist(),
-    paginate: (page?: number, perPage?: number) => new ModelQueryBuilder<TDef>(definition).paginate(page, perPage),
+    paginate: (page?: number | PaginateOptions, perPage?: number) => new ModelQueryBuilder<TDef>(definition).paginate(page as any, perPage),
 
     whereBetween<K extends Cols>(column: K, range: [min: K extends keyof Attrs ? Attrs[K] : unknown, max: K extends keyof Attrs ? Attrs[K] : unknown]) {
       return new ModelQueryBuilder<TDef>(definition).whereBetween(column, range as any)

--- a/packages/bun-query-builder/test/paginate-options.test.ts
+++ b/packages/bun-query-builder/test/paginate-options.test.ts
@@ -1,0 +1,153 @@
+/**
+ * paginate() gains a spelling that cannot be transposed.
+ * stacksjs/bun-query-builder#1092.
+ *
+ * The two paginate APIs take the same two numbers in opposite orders:
+ *
+ *     db.selectFrom(t).paginate(perPage, page)
+ *     Model.query().paginate(page, perPage)
+ *
+ * Both parameters are `number`, so getting it backwards is not a type error —
+ * you simply receive a different page, with no warning. `forPage(page, perPage)`
+ * sits ~60 lines from the builder's `paginate(perPage, page)` and takes the
+ * opposite order again, which is presumably where this came from.
+ *
+ * Resolved additively, deliberately: realigning either side would silently
+ * change which rows every existing caller gets. So both APIs now also accept
+ * `{ page, perPage }`, both keep their positional forms unchanged, and the
+ * ORM's result gains a `meta` object mirroring the builder's while keeping its
+ * flat fields. Nobody's call moves; there is now a way to write one that
+ * cannot be got wrong, and a shape that reads the same from either API.
+ *
+ * The positional divergence itself is left for a deliberate major.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { buildDatabaseSchema, buildSchemaMeta, createQueryBuilder } from '../src'
+import { clearModelRegistry, configureOrm, createModel, createTableFromModel } from '../src'
+import { config, setConfig } from '../src/config'
+import { resetConnection } from '../src/db'
+
+const MODELS = {
+  t: { columns: { id: { type: 'integer', isPrimaryKey: true }, name: { type: 'string' } } },
+} as any
+
+let dir: string
+let dbPath: string
+let snapshot: { dialect: string, database: Record<string, unknown> }
+
+function qb(): any {
+  return createQueryBuilder({
+    schema: buildDatabaseSchema(MODELS),
+    meta: buildSchemaMeta(MODELS),
+    autoMigration: { enabled: false } as any,
+  })
+}
+
+beforeEach(() => {
+  snapshot = { dialect: config.dialect, database: { ...config.database } }
+  dir = mkdtempSync(join(tmpdir(), 'qb-1092-'))
+  dbPath = join(dir, 'page.sqlite')
+  const seed = new Database(dbPath, { create: true })
+  seed.run('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+  for (let i = 1; i <= 20; i++) seed.run(`INSERT INTO t (id,name) VALUES (${i},'n${i}')`)
+  seed.close()
+  setConfig({ dialect: 'sqlite', database: { database: dbPath } } as any)
+  resetConnection()
+})
+
+afterEach(() => {
+  config.dialect = snapshot.dialect as any
+  for (const k of Object.keys(config.database)) delete (config.database as any)[k]
+  Object.assign(config.database, snapshot.database)
+  resetConnection()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('the builder accepts the options form (#1092)', () => {
+  it('{ perPage, page } means the same as the positional call', async () => {
+    const byOptions = await qb().selectFrom('t').selectAll().paginate({ perPage: 5, page: 2 })
+    const byPosition = await qb().selectFrom('t').selectAll().paginate(5, 2)
+
+    expect(byOptions.data.map((r: any) => r.id)).toEqual([6, 7, 8, 9, 10])
+    expect(byOptions.data).toEqual(byPosition.data)
+    expect(byOptions.meta).toEqual({ perPage: 5, page: 2, total: 20, lastPage: 4 })
+  })
+
+  it('the positional form is untouched', async () => {
+    const res = await qb().selectFrom('t').selectAll().paginate(5, 2)
+    expect(res.data.map((r: any) => r.id)).toEqual([6, 7, 8, 9, 10])
+  })
+
+  it('page defaults to 1', async () => {
+    const res = await qb().selectFrom('t').selectAll().paginate({ perPage: 3 })
+    expect(res.data.map((r: any) => r.id)).toEqual([1, 2, 3])
+    expect(res.meta.page).toBe(1)
+  })
+
+  it('the existing validation still applies through the options form', async () => {
+    await expect(qb().selectFrom('t').selectAll().paginate({ perPage: 0 }))
+      .rejects.toThrow(/expected positive integer/)
+    await expect(qb().selectFrom('t').selectAll().paginate({ perPage: 5, page: 0 }))
+      .rejects.toThrow(/expected integer >= 1/)
+  })
+})
+
+describe('the ORM accepts the options form and reports meta (#1092)', () => {
+  let Post: any
+
+  beforeEach(async () => {
+    clearModelRegistry()
+    const db = new Database(join(dir, 'orm.sqlite'), { create: true })
+    configureOrm({ database: db })
+    Post = createModel({
+      name: 'Pgpost',
+      table: 'pg_posts',
+      primaryKey: 'id',
+      autoIncrement: true,
+      attributes: { title: { type: 'string', fillable: true } },
+    } as any)
+    await createTableFromModel(Post.getDefinition())
+    for (let i = 1; i <= 20; i++) await Post.create({ title: `t${i}` })
+  })
+
+  afterEach(() => clearModelRegistry())
+
+  it('{ perPage, page } selects the same page the builder would', async () => {
+    const res = await Post.query().paginate({ perPage: 5, page: 2 })
+
+    // The positional ORM call for this page is paginate(2, 5) — the transposed
+    // order that made this worth fixing.
+    expect(res.data.map((r: any) => r.id)).toEqual([6, 7, 8, 9, 10])
+    expect(res.page).toBe(2)
+    expect(res.perPage).toBe(5)
+  })
+
+  it('the positional form keeps its own order', async () => {
+    const res = await Post.query().paginate(2, 5)
+    expect(res.data.map((r: any) => r.id)).toEqual([6, 7, 8, 9, 10])
+  })
+
+  it('the flat fields are unchanged', async () => {
+    const res = await Post.query().paginate({ perPage: 5, page: 2 })
+
+    expect(res.total).toBe(20)
+    expect(res.lastPage).toBe(4)
+    expect(res.hasMorePages).toBe(true)
+    expect(res.isEmpty).toBe(false)
+    expect(res.from).toBe(6)
+    expect(res.to).toBe(10)
+  })
+
+  it('and meta now reads the same as the builder\'s', async () => {
+    const orm = await Post.query().paginate({ perPage: 5, page: 2 })
+    const builder = await qb().selectFrom('t').selectAll().paginate({ perPage: 5, page: 2 })
+
+    // The point of the addition: one accessor works against either API.
+    expect(orm.meta).toEqual(builder.meta)
+  })
+})


### PR DESCRIPTION
Closes #1092.

The two paginate APIs take the same two numbers in **opposite orders**:

```ts
db.selectFrom(t).paginate(perPage, page)
Model.query().paginate(page, perPage)
```

Both parameters are `number`, so transposing them is not a type error — you just receive a different page, with nothing to tell you. `forPage(page, perPage)` sits ~60 lines from the builder's `paginate(perPage, page)` and takes the opposite order again, which is presumably where this came from.

## Why additive

Realigning either side is a one-line change and a silent break for every existing caller of whichever side moves — same call, same types, different rows. There is no deprecation path for that, because there is no way to detect the old intent at runtime.

So instead:

- **both APIs also accept `{ page, perPage }`**, where naming the arguments makes the order irrelevant
- **both keep their positional forms**, behaviour unchanged
- **the ORM result gains a `meta` object** mirroring the builder's, keeping every flat field it already returned

```ts
// means the same thing on both, and cannot be got wrong
await db.selectFrom('t').paginate({ perPage: 5, page: 2 })
await Model.query().paginate({ perPage: 5, page: 2 })

// ORM result: flat fields untouched, meta added
{ data, total, page, perPage, lastPage, hasMorePages, isEmpty, from, to,
  meta: { perPage, page, total, lastPage } }
```

A helper that reads `result.meta.total` now works against either API — which was the other half of the issue, and the half that at least failed loudly.

The positional divergence itself is left for a deliberate major. This adds the safe path; it does not pretend the trap is gone.

## Verification

8 new tests: the options form matches the positional result on the builder, the ORM's positional order is untouched, `page` defaults to 1, the existing `perPage`/`page` validation still fires through the options form, the ORM's flat fields are unchanged, and `orm.meta` deep-equals `builder.meta` for the same page — which is the property the addition exists to provide.

Full suite **2124 pass / 0 fail**, typecheck clean, pickier 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)