### PR TITLE
fix(browser)!: refuse orWhere rather than sending it as an AND

### DIFF
--- a/packages/bun-query-builder/src/browser.ts
+++ b/packages/bun-query-builder/src/browser.ts
@@ -401,23 +401,19 @@ export class BrowserQueryBuilder<T = any> {
    */
   orWhere(column: string, value: unknown): this
   orWhere(column: string, operator: WhereOperator, value: unknown): this
-  orWhere(column: string, operatorOrValue: unknown, value?: unknown): this {
-    if (value === undefined) {
-      this.state.wheres.push({
-        column,
-        operator: '=',
-        value: operatorOrValue,
-        boolean: 'or',
-      })
-    }
-    else {
-      this.state.wheres.push({
-        column,
-        operator: operatorOrValue as WhereOperator,
-        value,
-        boolean: 'or',
-      })
-    }
+  orWhere(_column: string, _operatorOrValue: unknown, _value?: unknown): this {
+    // Refused rather than recorded. `boolean: 'or'` was pushed onto the where
+    // list and buildQueryParams never read it, so the term went out as a plain
+    // filter and any receiving API read the whole set as a conjunction:
+    //
+    //     .where('role', 'admin').orWhere('role', 'moderator')
+    //     -> role=admin&role=moderator          (AND, not OR)
+    //
+    // That is a superset of the intended rows, returned without complaint. A
+    // wire spelling for OR would have to be agreed with whatever serves these
+    // requests, and inventing one here would ship a format nothing reads —
+    // the same silent failure, one layer further away. See #1096.
+    throw new TypeError('[browser] orWhere() is not supported by this client. The query-param format it builds has no spelling for a disjunction, so the term would be sent as a plain filter and the server would read it as AND \u2014 silently returning a superset of the rows you asked for. Express the alternatives as a single filter (whereIn), or issue one request per branch and merge the results.')
     return this
   }
 
@@ -536,8 +532,8 @@ export class BrowserQueryBuilder<T = any> {
   private buildQueryParams(): URLSearchParams {
     const params = new URLSearchParams()
 
-    // As in BrowserModelQueryBuilder: `boolean` is not read, so an `orWhere`
-    // serialises as an AND. Left alone deliberately — see #1096.
+    // Every recorded where is a conjunct: orWhere() now throws rather than
+    // recording a disjunction this format cannot express. See #1096.
     // Add where clauses as query params
     for (const where of this.state.wheres) {
       if (where.operator === '=') {
@@ -887,17 +883,13 @@ else {
   }
 
   orWhere<K extends BrowserColumnName<TDef>>(
-    column: K,
-    operatorOrValue: WhereOperator | (K extends keyof BrowserModelAttributes<TDef> ? BrowserModelAttributes<TDef>[K] : unknown),
-    value?: K extends keyof BrowserModelAttributes<TDef> ? BrowserModelAttributes<TDef>[K] : unknown
+    _column: K,
+    _operatorOrValue: WhereOperator | (K extends keyof BrowserModelAttributes<TDef> ? BrowserModelAttributes<TDef>[K] : unknown),
+    _value?: K extends keyof BrowserModelAttributes<TDef> ? BrowserModelAttributes<TDef>[K] : unknown
   ): BrowserModelQueryBuilder<TDef, TSelected> {
-    if (value === undefined) {
-      this._wheres.push({ column: column as string, operator: '=', value: operatorOrValue, boolean: 'or' })
-    }
-else {
-      this._wheres.push({ column: column as string, operator: operatorOrValue as WhereOperator, value, boolean: 'or' })
-    }
-    return this
+    // See BrowserQueryBuilder.orWhere: the recorded `boolean` was never read,
+    // so a disjunction was transmitted as a conjunction. #1096.
+    throw new TypeError('[browser] orWhere() is not supported by this client. The query-param format it builds has no spelling for a disjunction, so the term would be sent as a plain filter and the server would read it as AND \u2014 silently returning a superset of the rows you asked for. Express the alternatives as a single filter (whereIn), or issue one request per branch and merge the results.')
   }
 
   whereIn<K extends BrowserColumnName<TDef>>(
@@ -985,11 +977,9 @@ else {
   private buildQueryParams(): URLSearchParams {
     const params = new URLSearchParams()
 
-    // `where.boolean` is not read here, so an `orWhere` serialises exactly like
-    // a `where` and the server reads it as AND. Representing OR needs a wire
-    // format that this file has no precedent for, so it is left alone rather
-    // than invented — see #1096. BrowserQueryBuilder.buildQueryParams has the
-    // same gap.
+    // Every recorded where is a conjunct, which is what this format can say.
+    // orWhere() throws rather than recording a disjunction that would be
+    // transmitted — and read by the server — as one more AND term. See #1096.
     for (const where of this._wheres) {
       if (where.operator === '=') {
         params.append(where.column, String(where.value))

--- a/packages/bun-query-builder/test/browser.or-where-refused.test.ts
+++ b/packages/bun-query-builder/test/browser.or-where-refused.test.ts
@@ -1,0 +1,112 @@
+/**
+ * `orWhere` refuses rather than transmitting a disjunction as a conjunction.
+ * stacksjs/bun-query-builder#1096 — the half left open by #1108.
+ *
+ * Both browser builders recorded `boolean: 'or'` on the where list, and
+ * `buildQueryParams` never read it. Every recorded where was appended as one
+ * more parameter, which any receiving API reads as AND:
+ *
+ *     .where('role', 'admin').orWhere('role', 'moderator')
+ *     -> role=admin&role=moderator
+ *
+ * So the query returned a superset of the intended rows, with no error and a
+ * request that looks correct in a network panel.
+ *
+ * Throwing is the honest option here. The alternative — inventing a wire
+ * spelling like `filter[col][or][]` — would have to be agreed with whatever
+ * serves these requests; shipping one unilaterally produces the same silent
+ * failure, one layer further away, when the server ignores what it does not
+ * recognise.
+ *
+ * This IS a behaviour break for anyone calling orWhere today. What they have
+ * today is already wrong, just quietly, so the break replaces bad rows with a
+ * message naming the constraint and the two ways around it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { BrowserQueryBuilder, configureBrowser, createBrowserModel } from '../src/browser'
+
+const realFetch = globalThis.fetch
+let captured: string[] = []
+
+beforeEach(() => {
+  captured = []
+  globalThis.fetch = (async (input: any) => {
+    captured.push(typeof input === 'string' ? input : String(input?.url ?? input))
+    return new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as any
+  configureBrowser({ baseUrl: 'http://x.test/api' } as any)
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+const User = createBrowserModel({
+  name: 'User',
+  table: 'users',
+  traits: { useApi: { uri: 'users' } },
+  attributes: { role: { fillable: true }, status: { fillable: true } },
+} as any)
+
+describe('BrowserModelQueryBuilder.orWhere is refused (#1096)', () => {
+  it('throws instead of recording a term that would be sent as AND', () => {
+    expect(() => (User as any).query().where('role', 'admin').orWhere('role', 'moderator'))
+      .toThrow(/orWhere\(\) is not supported by this client/)
+  })
+
+  it('the message says why, not just no', () => {
+    let message = ''
+    try {
+      (User as any).query().orWhere('role', 'moderator')
+    }
+    catch (error: any) {
+      message = error.message
+    }
+
+    // Naming the mechanism is the point: the caller has to know the term would
+    // have been read as AND, or the refusal looks arbitrary.
+    expect(message).toContain('no spelling for a disjunction')
+    expect(message).toContain('AND')
+    // And it has to leave them somewhere to go.
+    expect(message).toContain('whereIn')
+  })
+
+  it('it is a TypeError, matching the other refusals in this codebase', () => {
+    expect(() => (User as any).query().orWhere('role', 'moderator')).toThrow(TypeError)
+  })
+
+  it('nothing is sent — the throw happens at the call, not at the request', async () => {
+    expect(() => (User as any).query().where('role', 'admin').orWhere('role', 'x')).toThrow()
+    expect(captured).toEqual([])
+  })
+})
+
+describe('BrowserQueryBuilder.orWhere is refused too (#1096)', () => {
+  it('both builders agree', () => {
+    const qb = new BrowserQueryBuilder('users' as any)
+    expect(() => (qb as any).where('role', 'admin').orWhere('role', 'moderator'))
+      .toThrow(/orWhere\(\) is not supported by this client/)
+  })
+})
+
+describe('the conjunctive paths are untouched (#1096)', () => {
+  it('chained where() still serialises as before', async () => {
+    await (User as any).query().where('role', 'admin').where('status', 'active').get()
+
+    expect(captured).toHaveLength(1)
+    expect(captured[0]).toContain('role=admin')
+    expect(captured[0]).toContain('status=active')
+  })
+
+  it('whereIn — the suggested replacement — still works', async () => {
+    await (User as any).query().whereIn('role', ['admin', 'moderator']).get()
+
+    expect(captured).toHaveLength(1)
+    // The alternatives-as-one-filter form the error message points at.
+    expect(decodeURIComponent(captured[0])).toContain('role[]=admin,moderator')
+  })
+})


### PR DESCRIPTION
Closes #1096 — the half left open by #1108, which fixed `not in`.

Both browser builders recorded `boolean: 'or'` on the where list, and `buildQueryParams` never read it. Every recorded where was appended as one more parameter, which any receiving API reads as a conjunction:

```ts
Model.query().where('role', 'admin').orWhere('role', 'moderator')
// role=admin&role=moderator        AND, not OR
```

The caller gets a **superset** of the rows they asked for — no error, and a request that looks correct in a network panel.

## Why throw rather than invent a spelling

The other option was serialising as `filter[col][or][]=…`, matching how `is` / `is not` already get distinct spellings. But that has to be agreed with whatever serves these requests, and I don't know that contract. Shipping a format unilaterally reproduces exactly the same silent failure one layer further away: the server ignores what it doesn't recognise, and the OR term vanishes just as quietly as it does today.

Throwing puts the failure at the call site, where the person who can fix it is standing.

The message names the mechanism and leaves somewhere to go:

> `[browser] orWhere() is not supported by this client. The query-param format it builds has no spelling for a disjunction, so the term would be sent as a plain filter and the server would read it as AND — silently returning a superset of the rows you asked for. Express the alternatives as a single filter (whereIn), or issue one request per branch and merge the results.`

A refusal that doesn't say why reads as arbitrary, and the caller can't tell whether it's a bug.

## This is a break — deliberately

Marked `!`. Anyone calling `orWhere` on these builders today starts getting a `TypeError`.

What they have today is already wrong, just quietly, so the trade is bad rows for a message. Nothing in the test suite covered it, and the **server-side** query builder's `orWhere` is entirely unaffected — that one composes real SQL and got its own grouping fix in #1083.

## Verification

7 new tests: both builders throw, it's a `TypeError` (matching the other refusals in this codebase), the message contains the mechanism and the suggested alternative, and **nothing is sent** — the throw happens at the call, not at the request, verified against a captured `fetch`.

Two guard tests pin the conjunctive paths as untouched: chained `where()` still serialises as before, and `whereIn` — the replacement the message points at — still emits `role[]=admin,moderator`.

5 of the 7 fail without the change. Full suite **2123 pass / 0 fail**, typecheck clean, pickier 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)