### PR TITLE
fix(client): keep client.d.ts free of `any`, and make the guard that says so run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
           echo "Waiting for PostgreSQL to be ready..."
           timeout 60 bash -c 'until pg_isready -h localhost -p 5432 -U postgres; do sleep 1; done'
           echo "PostgreSQL is ready!"
+      # public-surface-types.test.ts reads dist/*.d.ts. Without this it found no
+      # dist/, returned early, and checked nothing on every CI run — which is
+      # how an `any` reached client.d.ts after #1117 took that file to zero.
+      - name: Build
+        run: bun run build
+
       - name: Unit Tests
         run: bun run test
 

--- a/packages/bun-query-builder/src/client.ts
+++ b/packages/bun-query-builder/src/client.ts
@@ -640,8 +640,14 @@ export interface PaginateOptions {
   perPage?: number
   /** 1-based page number. Defaults to 1. */
   page?: number
-  /** Run the count and the page query inside this transaction — see #1051. */
-  tx?: { unsafe: (sql: string, params?: any[]) => any }
+  /**
+   * Run the count and the page query inside this transaction — see #1051.
+   *
+   * `unknown` rather than `any`, matching the positional overload's declared
+   * `opts.tx`. An `any` here is published in `client.d.ts`, which is the type
+   * an app touches on every query — #1117 took that file to zero and pinned it.
+   */
+  tx?: { unsafe: (sql: string, params?: unknown[]) => unknown }
 }
 
 export type QueryResult = unknown
@@ -5854,7 +5860,7 @@ export function createQueryBuilder<DB extends AnyDatabaseSchema>(state?: Partial
         if (typeof perPage === 'object' && perPage !== null) {
           const options = perPage
           page = options.page ?? 1
-          opts = options.tx ? { tx: options.tx } : {}
+          opts = options.tx ? { tx: options.tx as { unsafe: (sql: string, params?: any[]) => any } } : {}
           perPage = options.perPage ?? 10
         }
         if (!Number.isFinite(perPage) || perPage <= 0 || !Number.isInteger(perPage))

--- a/packages/bun-query-builder/test/public-surface-types.test.ts
+++ b/packages/bun-query-builder/test/public-surface-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 /**
@@ -29,18 +29,60 @@ import { join } from 'node:path'
  */
 
 const DIST = join(import.meta.dir, '..', 'dist')
+const SRC = join(import.meta.dir, '..', 'src')
 const BASELINE = 18
 
 function anyCount(source: string): number {
   return (source.match(/:\s*any\b|<any>|any\[\]/g) ?? []).length
 }
 
+/**
+ * Whether `dist/` reflects the `src/` in this working tree.
+ *
+ * This guard reads a build output, so it has two failure modes that are not
+ * regressions and must not be reported as ones:
+ *
+ *  - `dist/` missing entirely — nobody has built yet
+ *  - `dist/` older than `src/` — built before the change under test, so the
+ *    counts describe code that is no longer here. That produced a red suite
+ *    twice for people whose checkout predated #1117, on a defect he had
+ *    already fixed.
+ *
+ * In CI the same conditions mean the opposite: the workflow builds before
+ * testing, so a missing or stale `dist/` means the build step did not run, and
+ * skipping would be how a real leak ships unnoticed. That is exactly what
+ * happened — the CI `test` job never built, so this returned early on every
+ * run and never checked anything until the build step was added alongside
+ * this comment.
+ */
+function distState(): 'fresh' | 'missing' | 'stale' {
+  if (!existsSync(DIST))
+    return 'missing'
+  const declarations = readdirSync(DIST).filter(file => file.endsWith('.d.ts'))
+  if (declarations.length === 0)
+    return 'missing'
+  const builtAt = Math.min(...declarations.map(f => statSync(join(DIST, f)).mtimeMs))
+  const changedAt = Math.max(...readdirSync(SRC).map(f => statSync(join(SRC, f)).mtimeMs))
+  return changedAt > builtAt ? 'stale' : 'fresh'
+}
+
+const STATE = distState()
+const CI = Boolean(process.env.CI)
+
+function assertUsable(): boolean {
+  if (STATE === 'fresh')
+    return true
+  if (CI)
+    throw new Error(`[public-surface] dist/ is ${STATE} in CI — the build step must run before these tests, or this guard silently checks nothing.`)
+  // Locally: say why it did not run, rather than asserting against stale output.
+  console.warn(`[public-surface] skipped: dist/ is ${STATE}. Run \`bun run build\` to check the published types.`)
+  return false
+}
+
 describe('the published type surface', () => {
   it('does not leak more `any` than the documented survivors', () => {
-    if (!existsSync(DIST)) {
-      // Types are a build output; nothing to check before `bun run build`.
+    if (!assertUsable())
       return
-    }
 
     const declarations = readdirSync(DIST).filter(file => file.endsWith('.d.ts'))
     expect(declarations.length).toBeGreaterThan(0)
@@ -54,7 +96,7 @@ describe('the published type surface', () => {
   })
 
   it('keeps the query builder itself free of them', () => {
-    if (!existsSync(join(DIST, 'client.d.ts')))
+    if (!assertUsable())
       return
 
     // client.d.ts is the type an app touches on every single query. It went


### PR DESCRIPTION
**main is currently red** on `public-surface-types.test.ts`. This is my regression from #1130 plus the reason it got through.

## The leak

`PaginateOptions`, added in #1130, declared:

```ts
tx?: { unsafe: (sql: string, params?: any[]) => any }
```

I copied that from the implementation rather than from the positional overload sitting next to it, which says `unknown`. It published one `any` into `client.d.ts` — the file an app touches on every query, which #1117 took to **zero** and pinned there.

Narrowed to `unknown`. The implementation casts at the single point where it hands the handle to the existing `opts` bag.

## Why CI didn't catch it

The more useful half. That guard reads `dist/*.d.ts` and opened with:

```ts
if (!existsSync(DIST)) return
```

The CI `test` job never ran `bun run build`. So `dist/` was never there, and **the guard has never checked anything in CI** — it has passed by doing nothing on every run since it was written. A test that cannot fail is worse than no test, because it reads as coverage.

Locally it had the opposite failure: a `dist/` built before the change under test asserts against code that is no longer there. That produced a red suite twice this week for a checkout predating #1117 — on a defect Chris had already fixed.

## The fix

`dist/` is now classified rather than merely tested for existence:

| state | condition | CI | local |
|---|---|---|---|
| `fresh` | declarations newer than every `src/` file | check | check |
| `missing` | no `dist/`, or no `.d.ts` in it | **fail** | skip + reason |
| `stale` | any `src/` file newer than the oldest declaration | **fail** | skip + reason |

Under CI, missing or stale can only mean the build step didn't run, so silently skipping is precisely how a real leak ships. Everywhere else it's a skip that says why, instead of asserting against output that describes different code.

And the CI `test` job now builds first, so the guard has something to read.

## Verification

Both directions, with `dist/` deliberately staled:

```
$ bun test public-surface-types.test.ts
[public-surface] skipped: dist/ is stale. Run `bun run build` to check the published types.
 2 pass, 0 fail

$ CI=1 bun test public-surface-types.test.ts
error: [public-surface] dist/ is stale in CI — the build step must run before these tests…
 (fail)
```

And the original symptom is gone: `client.d.ts` back to 0, total back to 18.

Full suite **2131 pass / 0 fail**, typecheck clean, pickier 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)