### PR TITLE
fix(migrate)!: run the directories executeMigration was given

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -231,12 +231,22 @@ const migration = await generateMigration('./models', {
 
 ### executeMigration
 
-Execute a migration.
+Run every pending migration file in the corpus and record each one.
 
 ```typescript
 import { executeMigration } from 'bun-query-builder'
 
-await executeMigration(migration)
+// The configured `migrationDir`.
+await executeMigration()
+
+// A corpus assembled from several directories — the application's own
+// migrations plus the ones each installed package ships. Files from every
+// directory are ordered together by file name, so names must be unique
+// across the whole run.
+await executeMigration([
+  './database/migrations',
+  './node_modules/loghq/database/migrations',
+])
 ```
 
 ## Seeders

--- a/docs/features/migrations.md
+++ b/docs/features/migrations.md
@@ -22,16 +22,38 @@ The migration system automatically generates SQL DDL statements from your model 
 ```ts
 import { generateMigration, executeMigration } from 'bun-query-builder'
 
-// Generate migration from models directory
-const migration = await generateMigration('./models', {
+// Generate migration files from the models directory
+await generateMigration('./models', {
   dialect: 'postgres',
-  apply: true,
   full: true
 })
 
-// Execute the migration
-await executeMigration(migration)
+// Run every pending file in the configured `migrationDir`
+await executeMigration()
 ```
+
+### Run a Corpus Spread Across Directories
+
+`executeMigration` takes the directory, or the list of directories, to run.
+Omit it and it uses the configured `migrationDir`.
+
+```ts
+// The application's own migrations, plus the ones each installed package ships
+await executeMigration([
+  './database/migrations',
+  './node_modules/loghq/database/migrations',
+])
+```
+
+Files from every directory are ordered together by file name, not one directory
+at a time — the file name is the ordinal, and a package's tables routinely carry
+foreign keys into the application's. So a package migration can be placed before
+or after an application one deliberately.
+
+Because migrations are recorded in the ledger by their bare file name, a name
+cannot repeat across directories; a repeat is refused rather than recorded once
+and silently skipped. A directory that does not exist is refused too, rather
+than read as an empty corpus.
 
 ### Migration Options
 
@@ -200,12 +222,11 @@ const models = defineModels({
 
 ```ts
 try {
-  const migration = await generateMigration('./models', {
-    dialect: 'postgres',
-    apply: true
+  await generateMigration('./models', {
+    dialect: 'postgres'
   })
 
-  await executeMigration(migration)
+  await executeMigration()
 } catch (err) {
   console.error('Migration failed:', err)
   // Handle rollback or retry logic
@@ -270,7 +291,7 @@ beforeAll(async () => {
   })
 
   if (result.sqlStatements.length > 0) {
-    await executeMigration(result)
+    await executeMigration()
   }
 })
 ```
@@ -302,13 +323,15 @@ function generateMigration(
 
 ```ts
 function executeMigration(
-  migration: GenerateMigrationResult
+  dirs?: string | string[]
 ): Promise<boolean>
 ```
 
 **Parameters:**
 
-- `migration`: Result from generateMigration
+- `dirs`: Directory, or list of directories, holding the `.sql` corpus to run.
+  Defaults to the configured `migrationDir`. Relative paths resolve against the
+  workspace root. File names must be unique across every directory in a run.
 
 **Returns:**
 

--- a/packages/bun-query-builder/src/actions/migrate.ts
+++ b/packages/bun-query-builder/src/actions/migrate.ts
@@ -2,7 +2,7 @@ import type { MigrationPlan } from '@/migrations'
 import type { GenerateMigrationResult, MigrateOptions, SupportedDialect } from '@/types'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import process from 'node:process'
 import { config, getConfig } from '@/config'
 import { withFreshConnection } from '@/db'
@@ -51,9 +51,9 @@ async function settleAppliedFiles(qb: any, dialect: SupportedDialect, files: str
  * guessing from the name is how the runner used to delete their file. An
  * unreadable file counts as authored, which is the cautious reading.
  */
-function isGeneratedMigration(sqlDir: string, file: string): boolean {
+function isGeneratedMigration(filePath: string): boolean {
   try {
-    return isGeneratedMigrationSql(readFileSync(join(sqlDir, file), 'utf8'))
+    return isGeneratedMigrationSql(readFileSync(filePath, 'utf8'))
   }
   catch {
     return false
@@ -387,8 +387,71 @@ export async function generateMigration(dir?: string, opts: MigrateOptions = {})
   return { sql, sqlStatements, hasChanges, plan, operations }
 }
 
-// `dir` is the models directory. This function runs the SQL corpus, which it
-// finds from the workspace root, so it has no use for it — the parameter stays
+/**
+ * The directories `executeMigration` should enumerate, in the order given.
+ *
+ * Omitting the argument means the configured corpus, and creates it when it is
+ * missing — a fresh project has no `database/migrations` until something writes
+ * one. Naming directories means exactly those: they are not created, and one
+ * that does not exist is a caller error rather than an empty corpus, because
+ * the alternative is a run that silently applies nothing and reports success.
+ *
+ * Relative paths resolve against the workspace root, the same root
+ * `config.migrationDir` resolves against, so a caller does not have to know
+ * which directory the process happens to have been started from.
+ */
+function resolveMigrationDirs(dirs: string | string[] | undefined, workspaceRoot: string): string[] {
+  if (dirs === undefined)
+    return [ensureSqlDirectory(workspaceRoot)]
+
+  const named = Array.isArray(dirs) ? dirs : [dirs]
+
+  // An empty list is refused rather than read as "the configured corpus" or as
+  // "no corpus". Both readings are silent: the first ignores what the caller
+  // asked for, the second skips every migration and exits zero. A caller that
+  // means the configured default omits the argument.
+  if (named.length === 0)
+    throw new Error('executeMigration was given an empty list of directories. Pass at least one directory, or omit the argument to use the configured migrationDir.')
+
+  return named.map(dir => (isAbsolute(dir) ? dir : join(workspaceRoot, dir)))
+}
+
+/**
+ * The `.sql` corpus across every directory, in run order.
+ *
+ * Sorted globally by basename rather than per directory, because the basename
+ * IS the ordinal: a package's tables carry foreign keys into the application's
+ * and never the reverse, so sorting each directory separately and running them
+ * back to back puts `REFERENCES "users"` before `users` exists. Postgres and
+ * MySQL reject that; SQLite does not, so per-directory ordering fails on deploy
+ * having passed locally.
+ *
+ * The ledger keys on the bare basename, so a basename cannot repeat across
+ * directories. Left alone, the second file would look already-executed and be
+ * skipped — a migration that never ran, on a run that reported success. It is
+ * refused here instead, naming both paths.
+ */
+function collectMigrationFiles(dirs: string[]): Array<{ name: string, path: string }> {
+  const byName = new Map<string, string>()
+
+  for (const dir of dirs) {
+    if (!existsSync(dir))
+      throw new Error(`Migration directory not found: ${dir}`)
+
+    for (const name of readdirSync(dir).filter(file => file.endsWith('.sql'))) {
+      const claimed = byName.get(name)
+      if (claimed !== undefined)
+        throw new Error(`Duplicate migration file name across directories: "${name}" appears in both ${claimed} and ${join(dir, name)}. Migrations are recorded by file name, so names must be unique across every directory in a run.`)
+
+      byName.set(name, join(dir, name))
+    }
+  }
+
+  return [...byName]
+    .map(([name, path]) => ({ name, path }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+}
+
 /**
  * The advisory-lock name every migrate run contends on.
  *
@@ -479,9 +542,25 @@ async function withMigrationLock<T>(dialect: SupportedDialect, fn: () => Promise
   }
 }
 
-// because it is public API and every caller passes it.
-// eslint-disable-next-line pickier/no-unused-vars
-export async function executeMigration(dir?: string): Promise<boolean> {
+/**
+ * Run every pending migration file, in order, and record each one.
+ *
+ * `dirs` is the corpus to run. Omit it for the configured `migrationDir`,
+ * which is what the CLI and every caller inside this package do. Pass a
+ * directory, or a list of them, to run a corpus assembled from more than one
+ * place — an application's own migrations plus those shipped by each installed
+ * package, say. Files from every directory are ordered together by file name,
+ * so a package's migration can be placed before or after the application's
+ * deliberately; see {@link collectMigrationFiles} for why that has to be one
+ * global ordering and why file names must be unique across the whole run.
+ *
+ * The argument used to be declared and then ignored, so a caller passing the
+ * wrong directory got the configured one anyway and never found out. It is
+ * honoured now, which means a caller that was passing something other than a
+ * migrations directory — the models directory was the common one — will see
+ * that directory enumerated instead.
+ */
+export async function executeMigration(dirs?: string | string[]): Promise<boolean> {
   // Load the config file before anything reads `snapshotDir`.
   //
   // `config` is a synchronous singleton of defaults plus whatever `setConfig`
@@ -494,11 +573,9 @@ export async function executeMigration(dir?: string): Promise<boolean> {
   await getConfig()
 
   const workspaceRoot = getWorkspaceRoot()
-  const sqlDir = ensureSqlDirectory(workspaceRoot)
   const dialect = config.dialect || 'postgres'
 
-  const files = readdirSync(sqlDir)
-  const scriptFiles = files.filter(file => file.endsWith('.sql')).sort()
+  const scriptFiles = collectMigrationFiles(resolveMigrationDirs(dirs, workspaceRoot))
 
   if (scriptFiles.length === 0) {
     info('-- No migration files found to execute')
@@ -542,7 +619,7 @@ export async function executeMigration(dir?: string): Promise<boolean> {
        * corpus already contains), so there is nothing left for replay to fix,
        * and everything to lose by deleting the evidence.
        */
-      const pending = scriptFiles.filter(file => !executedMigrations.includes(file))
+      const pending = scriptFiles.filter(file => !executedMigrations.includes(file.name))
 
       if (pending.length === 0) {
         info('-- No pending migrations to execute')
@@ -551,8 +628,7 @@ export async function executeMigration(dir?: string): Promise<boolean> {
 
       info(`-- Executing ${pending.length} migration${pending.length === 1 ? '' : 's'}`)
 
-      for (const file of pending) {
-        const filePath = join(sqlDir, file)
+      for (const { name: file, path: filePath } of pending) {
         info(`-- Executing: ${file}`)
 
         try {
@@ -589,7 +665,7 @@ export async function executeMigration(dir?: string): Promise<boolean> {
           // never recorded it at all. Record it and carry on — the schema is
           // where the file says it should be. Anything else, including every
           // authored migration, fails loudly.
-          if (isGeneratedMigration(sqlDir, file) && isAlreadyAppliedError(err)) {
+          if (isGeneratedMigration(filePath) && isAlreadyAppliedError(err)) {
             await recordMigration(qb, file, dialect)
             info(`-- ✓ Migration ${file} was already applied; recorded it (${err instanceof Error ? err.message : String(err)})`)
             continue
@@ -833,7 +909,7 @@ function removeGeneratedMigrationFiles(sqlDir: string): void {
   const kept: string[] = []
 
   for (const file of readdirSync(sqlDir).filter(f => f.endsWith('.sql'))) {
-    if (!isGeneratedMigration(sqlDir, file)) {
+    if (!isGeneratedMigration(join(sqlDir, file))) {
       kept.push(file)
       continue
     }

--- a/packages/bun-query-builder/test/migrate-atomicity.test.ts
+++ b/packages/bun-query-builder/test/migrate-atomicity.test.ts
@@ -78,7 +78,7 @@ import { Database } from 'bun:sqlite'
 import { setConfig, executeMigration } from ${JSON.stringify(SRC)}
 
 setConfig({ dialect: 'sqlite', database: { database: './t.sqlite' }, verbose: false })
-try { await executeMigration(process.cwd()) } catch {}
+try { await executeMigration() } catch {}
 
 const db = new Database('./t.sqlite')
 // Explicit names, not a LIKE: 'mig_%' also matches the 'migrations' ledger.
@@ -121,7 +121,7 @@ import { setConfig, executeMigration } from ${JSON.stringify(SRC)}
 
 setConfig({ dialect: 'sqlite', database: { database: './t.sqlite' }, verbose: false })
 let error = ''
-try { await executeMigration(process.cwd()) } catch (e) { error = e instanceof Error ? e.message : String(e) }
+try { await executeMigration() } catch (e) { error = e instanceof Error ? e.message : String(e) }
 
 const db = new Database('./t.sqlite')
 const type = db.query("SELECT type FROM pragma_table_info('rebuilt') WHERE name = 'qty'").get()
@@ -165,7 +165,7 @@ describe.skipIf(!pgAvailable)('migration locking (#1067)', () => {
     writeFileSync(join(dir, 'worker.ts'), `
 import { setConfig, executeMigration } from ${JSON.stringify(SRC)}
 setConfig({ dialect: 'postgres', database: { url: ${JSON.stringify(PG_URL)} }, verbose: false })
-await executeMigration(process.cwd())
+await executeMigration()
 `)
 
     const result = run(dir, 'probe.ts', `

--- a/packages/bun-query-builder/test/migrate-multiple-dirs.test.ts
+++ b/packages/bun-query-builder/test/migrate-multiple-dirs.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Running one migration corpus that lives in more than one directory.
+ *
+ * `executeMigration` declared a `dir` argument and then threw it away, always
+ * enumerating `config.migrationDir` — so a caller could not point it anywhere
+ * else, and a caller pointing it at the wrong place never found out. Honouring
+ * the argument is the small half. The half that matters is a list: an
+ * application's own migrations plus the ones each installed package ships,
+ * where a package's tables carry foreign keys into the application's and never
+ * the reverse.
+ *
+ * Running each directory in turn does not work, because the file name is the
+ * ordinal and per-directory sorting loses the cross-directory order. These
+ * tests pin the global ordering, and the two ways a multi-directory run can go
+ * quietly wrong: a name that repeats across directories (the ledger keys on the
+ * bare name, so one file would be recorded and the other silently skipped) and
+ * a directory that is not there.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { executeMigration } from '../src/actions/migrate'
+import { config, setConfig } from '../src/config'
+
+let workspace: string
+let appDir: string
+let packageDir: string
+let dbFile: string
+let originalCwd: string
+let prevDatabase: any
+let prevDialect: any
+let dbCounter = 0
+
+/** The application's own corpus, at the configured `database/migrations`. */
+const USERS = '0000000001-create-users.sql'
+const USERS_SQL = 'CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "email" TEXT);\n'
+
+/**
+ * The application's, again — but ordered AFTER the package's file, and
+ * depending on it. A run that sorts each directory separately reaches this one
+ * while "posts" does not yet exist, and `ALTER TABLE` on a missing table fails
+ * on every dialect including SQLite, which tolerates a dangling REFERENCES.
+ */
+const AUTHORS = '0000000003-add-author-to-posts.sql'
+const AUTHORS_SQL = 'ALTER TABLE "posts" ADD COLUMN "author_id" INTEGER;\n'
+
+/** The package's, ordered between the two application files. */
+const POSTS = '0000000002-create-posts.sql'
+const POSTS_SQL = 'CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY, "user_id" INTEGER REFERENCES "users"("id"));\n'
+
+/** Point the builder at a database file no migration has ever run against. */
+function useFreshDatabase(): string {
+  dbCounter += 1
+  dbFile = join(workspace, 'database', `app-${dbCounter}.sqlite`)
+  setConfig({ dialect: 'sqlite', database: { ...prevDatabase, database: dbFile } })
+  return dbFile
+}
+
+/** Reads the database as it stands, treating "never created" as "nothing there". */
+function read<T>(query: string): T[] {
+  if (!existsSync(dbFile))
+    return []
+
+  const db = new Database(dbFile, { readonly: true })
+  try { return db.query(query).all() as T[] }
+  finally { db.close() }
+}
+
+function recorded(): string[] {
+  return read<{ migration: string }>('SELECT migration FROM migrations ORDER BY id').map(row => row.migration)
+}
+
+function columnsOf(table: string): string[] {
+  return read<{ name: string }>(`PRAGMA table_info("${table}")`).map(column => column.name)
+}
+
+beforeAll(() => {
+  originalCwd = process.cwd()
+  workspace = realpathSync(mkdtempSync(join(tmpdir(), 'qb-multi-dir-')))
+  appDir = join(workspace, 'database', 'migrations')
+  packageDir = join(workspace, 'node_modules', 'loghq', 'database', 'migrations')
+  mkdirSync(appDir, { recursive: true })
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(workspace, 'package.json'), '{"name":"multi-dir-fixture"}')
+  process.chdir(workspace)
+
+  prevDatabase = config.database
+  prevDialect = config.dialect
+})
+
+afterAll(() => {
+  setConfig({ dialect: prevDialect, database: prevDatabase })
+  process.chdir(originalCwd)
+  rmSync(workspace, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  rmSync(appDir, { recursive: true, force: true })
+  rmSync(packageDir, { recursive: true, force: true })
+  mkdirSync(appDir, { recursive: true })
+  mkdirSync(packageDir, { recursive: true })
+  useFreshDatabase()
+})
+
+describe('executeMigration across several directories', () => {
+  beforeEach(() => {
+    writeFileSync(join(appDir, USERS), USERS_SQL)
+    writeFileSync(join(appDir, AUTHORS), AUTHORS_SQL)
+    writeFileSync(join(packageDir, POSTS), POSTS_SQL)
+  })
+
+  it('orders every file by name across all of them, not one directory at a time', async () => {
+    await executeMigration([appDir, packageDir])
+
+    expect(recorded()).toEqual([USERS, POSTS, AUTHORS])
+    expect(columnsOf('posts')).toContain('author_id')
+  })
+
+  it('orders the same way whichever order the directories are given in', async () => {
+    await executeMigration([packageDir, appDir])
+
+    expect(recorded()).toEqual([USERS, POSTS, AUTHORS])
+  })
+
+  it('records the bare file name, whichever directory the file came from', async () => {
+    await executeMigration([appDir, packageDir])
+
+    expect(recorded()).not.toContain(join(packageDir, POSTS))
+  })
+
+  it('runs nothing on a second pass', async () => {
+    await executeMigration([appDir, packageDir])
+    await executeMigration([appDir, packageDir])
+
+    expect(recorded()).toEqual([USERS, POSTS, AUTHORS])
+  })
+
+  it('refuses a directory that is not there rather than reporting an empty corpus', async () => {
+    const missing = join(workspace, 'node_modules', 'not-installed', 'database', 'migrations')
+
+    await expect(executeMigration([appDir, missing])).rejects.toThrow(/not found/i)
+    expect(recorded()).toEqual([])
+  })
+
+  it('refuses a file name that repeats across directories', async () => {
+    // The ledger keys on the bare name, so the second file would look already
+    // executed and be skipped — a migration that never ran, on a run that
+    // reported success.
+    writeFileSync(join(packageDir, USERS), 'CREATE TABLE "loghq_users" ("id" INTEGER PRIMARY KEY);\n')
+
+    await expect(executeMigration([appDir, packageDir])).rejects.toThrow(new RegExp(USERS))
+    expect(recorded()).toEqual([])
+  })
+
+  it('refuses an empty list rather than guessing what it meant', async () => {
+    await expect(executeMigration([])).rejects.toThrow(/empty list/i)
+  })
+})
+
+describe('executeMigration with a single directory', () => {
+  it('runs the directory it was given', async () => {
+    writeFileSync(join(packageDir, POSTS), 'CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY);\n')
+
+    await executeMigration(packageDir)
+
+    expect(recorded()).toEqual([POSTS])
+  })
+
+  it('resolves a relative directory against the workspace root', async () => {
+    writeFileSync(join(packageDir, POSTS), 'CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY);\n')
+
+    await executeMigration('node_modules/loghq/database/migrations')
+
+    expect(recorded()).toEqual([POSTS])
+  })
+})
+
+describe('executeMigration with no argument', () => {
+  it('still runs the configured migrationDir, so existing callers are unchanged', async () => {
+    writeFileSync(join(appDir, USERS), USERS_SQL)
+    writeFileSync(join(packageDir, POSTS), POSTS_SQL)
+
+    await executeMigration()
+
+    expect(recorded()).toEqual([USERS])
+  })
+})

--- a/packages/bun-query-builder/test/migrations.attribute-change.test.ts
+++ b/packages/bun-query-builder/test/migrations.attribute-change.test.ts
@@ -97,7 +97,7 @@ describe('an attribute added after the table was migrated', () => {
     useOriginalDatabase()
     writeModel(`name: { validation: { rule: {} } }`)
     await generateMigration(modelsDir, { dialect: 'sqlite' })
-    await executeMigration(modelsDir)
+    await executeMigration()
   })
 
   it('writes a migration for the change', async () => {
@@ -111,7 +111,7 @@ describe('an attribute added after the table was migrated', () => {
   })
 
   it('applies it to the database it was generated on', async () => {
-    await executeMigration(modelsDir)
+    await executeMigration()
     expect(columnsOf(dbFile, 'widgets')).toContain('colour')
   })
 
@@ -126,7 +126,7 @@ describe('an attribute added after the table was migrated', () => {
     // The point of the whole corpus: a teammate clones, migrates, and gets the
     // same table. If the ALTER is not in the files, they get yesterday's table.
     const fresh = useFreshDatabase()
-    await executeMigration(modelsDir)
+    await executeMigration()
     useOriginalDatabase()
 
     expect(columnsOf(fresh, 'widgets')).toContain('name')
@@ -135,7 +135,7 @@ describe('an attribute added after the table was migrated', () => {
 
   it('does not re-run on the machine that already applied it', async () => {
     const before = migrationFiles()
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     // Recorded, so it is not replayed — replaying an ADD COLUMN is the
     // `duplicate column name` failure that takes the whole run down.
@@ -157,16 +157,16 @@ describe('a series of changes, each landing its own migration', () => {
 
     writeModel(`name: { validation: { rule: {} } }, colour: { validation: { rule: {} } }, size: { validation: { rule: {} } }`)
     await generateMigration(modelsDir, { dialect: 'sqlite' })
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     writeModel(`name: { validation: { rule: {} } }, colour: { validation: { rule: {} } }, size: { validation: { rule: {} } }, weight: { validation: { rule: {} } }`)
     await generateMigration(modelsDir, { dialect: 'sqlite' })
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     expect(migrationFiles().length).toBe(start + 2)
 
     const fresh = useFreshDatabase()
-    await executeMigration(modelsDir)
+    await executeMigration()
     useOriginalDatabase()
 
     const columns = columnsOf(fresh, 'widgets')
@@ -196,12 +196,12 @@ describe('two changes migrated inside the same second', () => {
   })
 
   it('runs both, on this machine and on a fresh one', async () => {
-    await executeMigration(modelsDir)
+    await executeMigration()
     expect(columnsOf(dbFile, 'widgets')).toContain('finish')
     expect(columnsOf(dbFile, 'widgets')).toContain('grade')
 
     const fresh = useFreshDatabase()
-    await executeMigration(modelsDir)
+    await executeMigration()
     useOriginalDatabase()
 
     const columns = columnsOf(fresh, 'widgets')
@@ -230,7 +230,7 @@ describe('a migration applied but never recorded', () => {
     writeFileSync(orphan, `-- qb:generated\nALTER TABLE widgets ADD COLUMN colour TEXT;\n`)
 
     // `colour` is already on the table, so this SQL cannot succeed.
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     expect(existsSync(orphan)).toBe(true)
     expect(columnsOf(dbFile, 'widgets')).toContain('colour')
@@ -244,7 +244,7 @@ describe('a migration applied but never recorded', () => {
     // recorded away. Only an unambiguous "already exists" is forgiven, and
     // only for a migration the generator wrote.
     let threw = false
-    try { await executeMigration(modelsDir) }
+    try { await executeMigration() }
     catch { threw = true }
     finally { rmSync(broken, { force: true }) }
 
@@ -267,11 +267,11 @@ describe('the snapshot going missing does not duplicate work', () => {
   })
 
   it('leaves the database untouched and still replayable afterwards', async () => {
-    await executeMigration(modelsDir)
+    await executeMigration()
     expect(columnsOf(dbFile, 'widgets')).toContain('weight')
 
     const fresh = useFreshDatabase()
-    await executeMigration(modelsDir)
+    await executeMigration()
     useOriginalDatabase()
     expect(columnsOf(fresh, 'widgets')).toContain('weight')
   })

--- a/packages/bun-query-builder/test/migrations.handwritten-lifecycle.test.ts
+++ b/packages/bun-query-builder/test/migrations.handwritten-lifecycle.test.ts
@@ -211,7 +211,7 @@ describe('the runner tells authored migrations from generated ones', () => {
     const authored = join(migrationsDir(), '9000000001-alter-farms-table.sql')
     writeFileSync(authored, 'ALTER TABLE farms ADD COLUMN steward TEXT;\n')
 
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     expect(existsSync(authored)).toBe(true)
     expect(columnsOf('farms')).toContain('steward')
@@ -221,7 +221,7 @@ describe('the runner tells authored migrations from generated ones', () => {
   it('does not replay it on the next run, so it cannot fail as a duplicate', async () => {
     // Recorded means run-once. Replaying an ADD COLUMN is the `duplicate
     // column name` failure that takes a whole migrate run down with it.
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     expect(existsSync(join(migrationsDir(), '9000000001-alter-farms-table.sql'))).toBe(true)
     expect(columnsOf('farms')).toContain('steward')
@@ -234,7 +234,7 @@ describe('the runner tells authored migrations from generated ones', () => {
     const generated = join(migrationsDir(), '9000000002-alter-farms-table.sql')
     writeFileSync(generated, `${GENERATED_MARKER}\nALTER TABLE farms ADD COLUMN drainage TEXT;\n`)
 
-    await executeMigration(modelsDir)
+    await executeMigration()
 
     expect(existsSync(generated)).toBe(true)
     expect(columnsOf('farms')).toContain('drainage')


### PR DESCRIPTION
Closes stacksjs/bun-query-builder#1137.

## The argument was declared and discarded

`executeMigration(dir?: string)` declared the parameter, carried a comment explaining why it was retained, and never read it — it resolved the corpus from `config.migrationDir` on every call. So `executeMigration('/somewhere/else')` ran the configured directory and reported success, and a caller pointing it at the wrong place never found out.

## One corpus, several directories

The reason it came up: with package auto-discovery, the corpus for a run is the application's `database/migrations` **plus** each installed package's. Calling once per directory does not work. The file name is the ordinal, and a package's tables carry foreign keys into the application's and never the reverse — so sorting each directory separately and running them back to back puts `REFERENCES "users"` before `users` exists. Postgres and MySQL reject that; SQLite does not, so the failure mode is green locally and red on deploy.

```ts
executeMigration()                        // config.migrationDir — unchanged
executeMigration(dir)
executeMigration([appDir, ...packageDirs])
```

Files from every directory are sorted **together** by name, so a package migration can be placed before or after an application one deliberately. Relative paths resolve against the workspace root, the same root `config.migrationDir` resolves against.

## Refused rather than absorbed

Three things a multi-directory run could do quietly, each of which ends in a migration that never ran on a run that exited zero:

- **A file name repeated across directories.** The ledger keys on the bare name, so the second file would look already-executed and be skipped. Refused, naming both paths.
- **A directory that is not there.** Would otherwise read as an empty corpus and report success.
- **An empty list.** Reading it as "the configured corpus" ignores what the caller asked for; reading it as "no corpus" skips everything. A caller that means the default omits the argument.

An omitted argument still creates `database/migrations` when missing, as before; named directories are never created.

## Breaking

A caller that was passing something other than a migrations directory now gets that directory enumerated. The models directory was the common one — `generateMigration(modelsDir)` sits directly above it — and this repo's own tests were doing exactly that; they pass no argument now. **Callers that pass nothing, including `bin/cli.ts` and `seed`, are unaffected.**

Worth checking downstream before this lands: `stacksjs/stacks` passes `modelsDir` at `storage/framework/core/database/src/migrations.ts:1597`, which has always been wrong and has never mattered.

## Also

The docs described `executeMigration(migration: GenerateMigrationResult)` — a signature it has not had. That would now be a type error rather than a silently ignored argument, so `docs/features/migrations.md` and `docs/api/reference.md` are corrected and document the multi-directory shape.

## Tests

New `test/migrate-multiple-dirs.test.ts`, 10 cases: global ordering across directories (with a third file that fails outright unless the cross-directory order held), order independent of the order the directories are given in, bare names in the ledger, second-pass no-op, and each of the three refusals. Verified the ordering cases fail when the global sort is removed.

Full suite: 2141 pass, 0 fail. `tsc --noEmit` clean; pickier clean apart from one pre-existing `no-console` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)